### PR TITLE
Actually include the kotlin code in the fatjar

### DIFF
--- a/sqlite-android-gradle-plugin/build.gradle
+++ b/sqlite-android-gradle-plugin/build.gradle
@@ -40,11 +40,7 @@ dependencies {
       fatJarExclude = true
     }
   }
-  compile "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version", {
-    ext {
-      fatJarExclude = true
-    }
-  }
+  compile "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
   testCompile gradleTestKit()
   testCompile 'junit:junit:4.12'


### PR DESCRIPTION
So that things dont explode if the kotlin gradle plugin hasnt been applied
