### PR TITLE
Remove explicit Kotlin support.

### DIFF
--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -51,7 +51,6 @@ dependencies {
       fatJarExclude = true
     }
   }
-  compile "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
   testCompile gradleTestKit()
   testCompile 'junit:junit:4.12'

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/SqlDelightPluginTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/SqlDelightPluginTest.kt
@@ -1,6 +1,7 @@
 package com.squareup.sqldelight
 
 import com.google.common.truth.Truth.assertThat
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import java.io.File
@@ -100,6 +101,7 @@ class SqlDelightPluginTest {
     assertExpectedFiles()
   }
 
+  @Ignore("https://github.com/square/sqldelight/issues/80")
   @FixtureName("works-for-kotlin")
   @Test
   fun worksForKotlin() {


### PR DESCRIPTION
We want the Kotlin Android plugin to automatically recognize generated sources from registered tasks and will pursue that avenue instead.

Refs #80.
