### PR TITLE
Switch to a single runtime marshal/mapper type.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,8 @@ ext {
 
   butterKnife = 'com.jakewharton:butterknife:7.0.1'
   autoValue = 'com.google.auto.value:auto-value:1.1'
+
+  isCi = "true".equals(System.getenv('CI'))
 }
 
 subprojects {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,7 @@
 rootProject.name = 'sqldelight'
-include 'sqldelight-studio-plugin'
+
 include 'sqldelight-compiler'
 include 'sqldelight-gradle-plugin'
+include 'sqldelight-runtime'
 include 'sqldelight-sample'
+include 'sqldelight-studio-plugin'

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/SqliteCompiler.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/SqliteCompiler.kt
@@ -113,6 +113,7 @@ class SqliteCompiler<T> {
     const val OUTPUT_DIRECTORY = "generated/source/sqldelight"
     const val FILE_EXTENSION = "sq"
     val NULLABLE = ClassName.get("android.support.annotation", "Nullable")
+    val COLUMN_ADAPTER_TYPE = ClassName.get("com.squareup.sqldelight", "ColumnAdapter")
 
     fun interfaceName(sqliteFileName: String) = sqliteFileName + "Model"
   }

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/model/Column.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/model/Column.kt
@@ -20,7 +20,9 @@ import com.google.common.base.CaseFormat.LOWER_UNDERSCORE
 import com.squareup.javapoet.ArrayTypeName
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.ClassName.bestGuess
+import com.squareup.javapoet.ParameterizedTypeName
 import com.squareup.javapoet.TypeName
+import com.squareup.sqldelight.SqliteCompiler
 import com.squareup.sqldelight.SqlitePluginException
 import com.squareup.sqldelight.model.Column.Type.BLOB
 import com.squareup.sqldelight.model.Column.Type.BOOLEAN
@@ -37,7 +39,8 @@ import java.util.ArrayList
 
 class Column<T>(internal val name: String, val type: Type, fullyQualifiedClass: String? = null,
     originatingElement: T) : SqlElement<T>(originatingElement) {
-  fun mapperName() = Column.mapperName(name)
+  fun adapterType() = ParameterizedTypeName.get(SqliteCompiler.COLUMN_ADAPTER_TYPE, javaType)
+
   fun mapperField() = Column.mapperField(name)
   fun defaultValue() =
       if (isNullable) "null"
@@ -48,7 +51,6 @@ class Column<T>(internal val name: String, val type: Type, fullyQualifiedClass: 
         else -> throw SqlitePluginException(originatingElement as Any, "Unknown type " + type)
       }
 
-  fun marshalName() = Column.marshalName(name)
   fun marshalField() = Column.marshalField(name)
   fun marshaledValue() =
       when (type) {
@@ -108,9 +110,7 @@ class Column<T>(internal val name: String, val type: Type, fullyQualifiedClass: 
   companion object {
     fun fieldName(name: String) = name.toUpperCase()
     fun methodName(name: String) = name
-    fun mapperName(name: String) = LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, name) + "Mapper"
     fun mapperField(name: String) = LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, name) + "Mapper"
-    fun marshalName(name: String) = LOWER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, name) + "Marshal"
     fun marshalField(name: String) = LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, name) + "Marshal"
   }
 }

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/model/Table.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/model/Table.kt
@@ -33,7 +33,4 @@ class Table<T>(
   val marshalClassName = interfaceClassName.nestedClass("${name}Marshal")
   val mapperClassName = interfaceClassName.nestedClass("Mapper")
   val creatorClassName = mapperClassName.nestedClass("Creator")
-
-  fun mapperClassName(column: Column<*>) = mapperClassName.nestedClass(column.mapperName())
-  fun marshalClassName(column: Column<*>) = marshalClassName.nestedClass(column.marshalName())
 }

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightPlugin.kt
@@ -47,8 +47,12 @@ class SqlDelightPlugin : Plugin<Project> {
     val compileDeps = project.configurations.getByName("compile").dependencies
     project.gradle.addListener(object : DependencyResolutionListener {
       override fun beforeResolve(dependencies: ResolvableDependencies?) {
+        if (System.getProperty("sqldelight.skip.runtime") != "true") {
+          compileDeps.add(project.dependencies.create("com.squareup.sqldelight:runtime:0.1"))
+        }
         compileDeps.add(
             project.dependencies.create("com.android.support:support-annotations:23.1.1"))
+
         project.gradle.removeListener(this)
       }
 

--- a/sqldelight-gradle-plugin/src/test/fixtures/custom-class-works-fine/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/fixtures/custom-class-works-fine/build.gradle
@@ -6,4 +6,8 @@ plugins {
 android {
   compileSdkVersion 23
   buildToolsVersion '23.0.2'
+
+  sourceSets {
+    main.java.srcDirs += '../../../../../sqldelight-runtime/src/main/java'
+  }
 }

--- a/sqldelight-gradle-plugin/src/test/fixtures/custom-class-works-fine/expected/com/test/UserModel.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/custom-class-works-fine/expected/com/test/UserModel.java
@@ -2,6 +2,7 @@ package com.test;
 
 import android.content.ContentValues;
 import android.database.Cursor;
+import com.squareup.sqldelight.ColumnAdapter;
 import java.lang.String;
 
 public interface UserModel {
@@ -19,9 +20,9 @@ public interface UserModel {
   final class Mapper<T extends UserModel> {
     private final Creator<T> creator;
 
-    private final BalanceMapper balanceMapper;
+    private final ColumnAdapter<User.Money> balanceMapper;
 
-    protected Mapper(Creator<T> creator, BalanceMapper balanceMapper) {
+    protected Mapper(Creator<T> creator, ColumnAdapter<User.Money> balanceMapper) {
       this.creator = creator;
       this.balanceMapper = balanceMapper;
     }
@@ -35,18 +36,14 @@ public interface UserModel {
     public interface Creator<R extends UserModel> {
       R create(User.Money balance);
     }
-
-    public interface BalanceMapper {
-      User.Money map(Cursor cursor, int columnIndex);
-    }
   }
 
   class UserMarshal<T extends UserMarshal<T>> {
     protected ContentValues contentValues = new ContentValues();
 
-    private final BalanceMarshal balanceMarshal;
+    private final ColumnAdapter<User.Money> balanceMarshal;
 
-    public UserMarshal(BalanceMarshal balanceMarshal) {
+    public UserMarshal(ColumnAdapter<User.Money> balanceMarshal) {
       this.balanceMarshal = balanceMarshal;
     }
 
@@ -57,10 +54,6 @@ public interface UserModel {
     public T balance(User.Money balance) {
       balanceMarshal.marshal(contentValues, BALANCE, balance);
       return (T) this;
-    }
-
-    public interface BalanceMarshal {
-      void marshal(ContentValues contentValues, String columnName, User.Money balance);
     }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/fixtures/custom-class-works-fine/src/main/java/com/test/User.java
+++ b/sqldelight-gradle-plugin/src/test/fixtures/custom-class-works-fine/src/main/java/com/test/User.java
@@ -3,6 +3,7 @@ package com.test;
 import android.content.ContentValues;
 import android.database.Cursor;
 import java.lang.Override;
+import com.squareup.sqldelight.ColumnAdapter;
 
 public class User implements UserModel {
   public static class Money {
@@ -15,26 +16,28 @@ public class User implements UserModel {
     }
   }
 
-  public static Mapper<User> MAPPER = new Mapper<>(new Mapper.Creator() {
-    @Override
-    public User create(Money balance) {
-      return new User(balance);
-    }
-  }, new Mapper.BalanceMapper() {
+  public static ColumnAdapter<Money> MONEY_ADAPTER = new ColumnAdapter<Money>() {
     @Override
     public Money map(Cursor cursor, int columnIndex) {
       String[] money = cursor.getString(columnIndex).split(".");
       return new Money(Integer.parseInt(money[0]), Integer.parseInt(money[1]));
     }
-  });
+
+    @Override
+    public void marshal(ContentValues contentValues, String columnName, Money balance) {
+      contentValues.put(columnName, balance.dollars + "." + balance.cents);
+    }
+  };
+
+  public static Mapper<User> MAPPER = new Mapper<>(new Mapper.Creator() {
+    @Override
+    public User create(Money balance) {
+      return new User(balance);
+    }
+  }, MONEY_ADAPTER);
 
   public static UserMarshal marshal() {
-    return new UserMarshal(new UserMarshal.BalanceMarshal() {
-      @Override
-      public void marshal(ContentValues contentValues, String columnName, Money balance) {
-        contentValues.put(columnName, balance.dollars + "." + balance.cents);
-      }
-    });
+    return new UserMarshal(MONEY_ADAPTER);
   }
 
   private final Money balance;

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/SqlDelightPluginTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/SqlDelightPluginTest.kt
@@ -14,7 +14,7 @@ import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
 
 class SqlDelightPluginTest {
-  @get:Rule val fixture = FixtureRunner()
+  @get:Rule val fixture = FixtureRunner("-Dsqldelight.skip.runtime=true")
 
   @FixtureName("works-fine")
   @Test

--- a/sqldelight-runtime/build.gradle
+++ b/sqldelight-runtime/build.gradle
@@ -1,0 +1,48 @@
+buildscript {
+  dependencies {
+    classpath rootProject.ext.androidPlugin
+  }
+}
+
+apply plugin: 'com.android.library'
+
+android {
+  compileSdkVersion rootProject.ext.compileSdkVersion
+  buildToolsVersion rootProject.ext.buildToolsVersion
+
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_7
+    targetCompatibility JavaVersion.VERSION_1_7
+  }
+
+  lintOptions {
+    textOutput 'stdout'
+  }
+
+  dexOptions {
+    preDexLibraries = !rootProject.ext.isCi
+  }
+
+  defaultConfig {
+    targetSdkVersion 23
+  }
+}
+
+dependencies {
+  compile 'com.android.support:support-annotations:23.1.1'
+}
+
+configurations {
+  jar
+}
+android.libraryVariants.all { variant ->
+  if (variant.name != 'release') return
+
+  def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
+  task.description = "Create jar artifact for ${variant.name}"
+  task.dependsOn variant.javaCompile
+  task.from variant.javaCompile.destinationDir
+  task.destinationDir = project.file("${project.buildDir}/outputs/jar")
+  task.archiveName = "${project.name}-${variant.baseName}.jar"
+  artifacts.add('jar', task);
+}

--- a/sqldelight-runtime/src/main/AndroidManifest.xml
+++ b/sqldelight-runtime/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.squareup.sqldelight"/>

--- a/sqldelight-runtime/src/main/java/com/squareup/sqldelight/ColumnAdapter.java
+++ b/sqldelight-runtime/src/main/java/com/squareup/sqldelight/ColumnAdapter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sqldelight;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+
+/** Marshal and map the type {@code T} to and from a representation in the database. */
+public interface ColumnAdapter<T> {
+  /**
+   * Return an instance of {@code T} corresponding to the value at {@code columnIndex} in
+   * {@code cursor}.
+   */
+  T map(Cursor cursor, int columnIndex);
+
+  /** Store a database representation of {@code value} in {@code values} for {@code key}. */
+  void marshal(ContentValues values, String key, T value);
+}

--- a/sqldelight-sample/build.gradle
+++ b/sqldelight-sample/build.gradle
@@ -19,10 +19,6 @@ dependencies {
   apt rootProject.ext.autoValue
 }
 
-def isCi() {
-  return "true".equals(System.getenv('CI'))
-}
-
 android {
   compileSdkVersion rootProject.ext.compileSdkVersion
   buildToolsVersion rootProject.ext.buildToolsVersion
@@ -37,7 +33,7 @@ android {
   }
 
   dexOptions {
-    preDexLibraries = !isCi()
+    preDexLibraries = !rootProject.ext.isCi
   }
 
   defaultConfig {


### PR DESCRIPTION
This reduces the need for column-specific instances or implementing a ton of interfaces on a single implementation. An instance is still given for each column so different implementations can still be chosen when needed.
