### PR TITLE
Ignore root reports folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
-.idea
+/.idea
 *.iml
 build
 local.properties
+/reports


### PR DESCRIPTION
This shows up when a build fails very early and you have --profile on.
