### PR TITLE
Fix string highlighting in IDE plugin

### DIFF
--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/lang/SqlDelightHighlighter.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/lang/SqlDelightHighlighter.kt
@@ -218,7 +218,7 @@ class SqlDelightHighlighter : SyntaxHighlighterBase() {
         SqliteTypes.BITWISE_OR.index to SQLITE_OPERATOR,
         SqliteTypes.CONCAT.index to SQLITE_OPERATOR,
 
-        SqliteTypes.STRING_LITERAL.index to SQLITE_STRING,
+        SqliteTypes.STRING.index to SQLITE_STRING,
 
         // Comments
 


### PR DESCRIPTION
Fixes #829 

As discussed offline, we don't want to highlight column types, since they're not considered keywords in SQLite, and highlighting "import" keywords isn't achievable with the way the plugin framework is designed.