### PR TITLE
Declare test task inputs.

### DIFF
--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -46,6 +46,11 @@ dependencies {
 }
 
 test {
+  inputs.files("../gradle/dependencies.gradle").withPathSensitivity(PathSensitivity.RELATIVE)
+  inputs.property("ANDROID_HOME", System.getenv("ANDROID_HOME"))
+  inputs.property("TRAVIS_OS_NAME", System.getenv("TRAVIS_OS_NAME"))
+  inputs.dir("../gradle/wrapper").withPathSensitivity(PathSensitivity.RELATIVE)
+
   // The integration tests require local installations of some of the runtimes.
   if (System.getenv("TRAVIS_OS_NAME") == "linux") {
     dependsOn(


### PR DESCRIPTION
The gradle build cache is disabled for this project, but if it were enabled,
the integration tests would be cached even when files and properties
they depend on would be used.

See: https://github.com/gradle/gradle/issues/9151 for more info.