### PR TITLE
Avoid synthetic accessor in generated code

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/SelectQueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/SelectQueryGenerator.kt
@@ -223,8 +223,9 @@ class SelectQueryGenerator(private val query: NamedQuery) : QueryGenerator(query
     // For each bind argument the query has.
     query.arguments.sortedBy { it.index }.forEach { (_, parameter) ->
       // Add the argument as a constructor property. (Used later to figure out if query dirtied)
-      // private val id: Int
-      queryType.addProperty(PropertySpec.builder(parameter.name, parameter.argumentType(), PRIVATE)
+      // val id: Int
+      queryType.addProperty(PropertySpec.builder(parameter.name, parameter.argumentType())
+          .addAnnotation(JvmField::class)
           .initializer(parameter.name)
           .build())
       constructor.addParameter(parameter.name, parameter.argumentType())

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/QueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/QueriesTypeTest.kt
@@ -50,6 +50,7 @@ class QueriesTypeTest {
       |import kotlin.String
       |import kotlin.collections.List
       |import kotlin.collections.MutableList
+      |import kotlin.jvm.JvmField
       |import kotlin.reflect.KClass
       |
       |internal val KClass<TestDatabase>.schema: SqlDriver.Schema
@@ -114,7 +115,8 @@ class QueriesTypeTest {
       |  }
       |
       |  private inner class SelectForId<out T : Any>(
-      |    private val id: Long,
+      |    @JvmField
+      |    val id: Long,
       |    mapper: (SqlCursor) -> T
       |  ) : Query<T>(selectForId, mapper) {
       |    override fun execute(): SqlCursor = driver.executeQuery(${select.id}, ""${'"'}

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryFunctionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryFunctionTest.kt
@@ -185,8 +185,10 @@ class SelectQueryFunctionTest {
     val generator = SelectQueryGenerator(file.namedQueries.first())
     assertThat(generator.querySubtype().toString()).isEqualTo("""
       |private inner class SelectForId<out T : kotlin.Any>(
-      |  private val good: kotlin.collections.Collection<kotlin.Long>,
-      |  private val bad: kotlin.collections.Collection<kotlin.Long>,
+      |  @kotlin.jvm.JvmField
+      |  val good: kotlin.collections.Collection<kotlin.Long>,
+      |  @kotlin.jvm.JvmField
+      |  val bad: kotlin.collections.Collection<kotlin.Long>,
       |  mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(selectForId, mapper) {
       |  override fun execute(): com.squareup.sqldelight.db.SqlCursor {
@@ -282,7 +284,8 @@ class SelectQueryFunctionTest {
 
     assertThat(generator.querySubtype().toString()).isEqualTo("""
       |private inner class EquivalentNamesNamed<out T : kotlin.Any>(
-      |  private val name: kotlin.String,
+      |  @kotlin.jvm.JvmField
+      |  val name: kotlin.String,
       |  mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(equivalentNamesNamed, mapper) {
       |  override fun execute(): com.squareup.sqldelight.db.SqlCursor = driver.executeQuery(${query.id}, ""${'"'}

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryTypeTest.kt
@@ -27,7 +27,8 @@ class SelectQueryTypeTest {
 
     assertThat(generator.querySubtype().toString()).isEqualTo("""
       |private inner class SelectForId<out T : kotlin.Any>(
-      |  private val id: kotlin.Long,
+      |  @kotlin.jvm.JvmField
+      |  val id: kotlin.Long,
       |  mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(selectForId, mapper) {
       |  override fun execute(): com.squareup.sqldelight.db.SqlCursor = driver.executeQuery(${query.id}, ""${'"'}
@@ -62,8 +63,10 @@ class SelectQueryTypeTest {
 
     assertThat(generator.querySubtype().toString()).isEqualTo("""
       |private inner class Select<out T : kotlin.Any>(
-      |  private val value: kotlin.String,
-      |  private val id: kotlin.Long,
+      |  @kotlin.jvm.JvmField
+      |  val value: kotlin.String,
+      |  @kotlin.jvm.JvmField
+      |  val id: kotlin.Long,
       |  mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(select, mapper) {
       |  override fun execute(): com.squareup.sqldelight.db.SqlCursor = driver.executeQuery(${query.id}, ""${'"'}
@@ -97,7 +100,8 @@ class SelectQueryTypeTest {
 
     assertThat(generator.querySubtype().toString()).isEqualTo("""
       |private inner class SelectForId<out T : kotlin.Any>(
-      |  private val id: kotlin.collections.Collection<kotlin.Long>,
+      |  @kotlin.jvm.JvmField
+      |  val id: kotlin.collections.Collection<kotlin.Long>,
       |  mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(selectForId, mapper) {
       |  override fun execute(): com.squareup.sqldelight.db.SqlCursor {
@@ -135,7 +139,8 @@ class SelectQueryTypeTest {
 
     assertThat(generator.querySubtype().toString()).isEqualTo("""
        |private inner class Select_news_list<out T : kotlin.Any>(
-       |  private val userId: kotlin.String?,
+       |  @kotlin.jvm.JvmField
+       |  val userId: kotlin.String?,
        |  mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
        |) : com.squareup.sqldelight.Query<T>(select_news_list, mapper) {
        |  override fun execute(): com.squareup.sqldelight.db.SqlCursor = driver.executeQuery(null, ""${'"'}SELECT * FROM socialFeedItem WHERE message IS NOT NULL AND userId ${"$"}{ if (userId == null) "IS" else "=" } ?1 ORDER BY datetime(creation_time) DESC""${'"'}, 1) {
@@ -166,8 +171,10 @@ class SelectQueryTypeTest {
 
     assertThat(generator.querySubtype().toString()).isEqualTo("""
        |private inner class SelectData<out T : kotlin.Any>(
-       |  private val userId: kotlin.String?,
-       |  private val username: kotlin.String,
+       |  @kotlin.jvm.JvmField
+       |  val userId: kotlin.String?,
+       |  @kotlin.jvm.JvmField
+       |  val username: kotlin.String,
        |  mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
        |) : com.squareup.sqldelight.Query<T>(selectData, mapper) {
        |  override fun execute(): com.squareup.sqldelight.db.SqlCursor = driver.executeQuery(null, ""${'"'}
@@ -205,10 +212,14 @@ class SelectQueryTypeTest {
 
     assertThat(generator.querySubtype().toString()).isEqualTo("""
       |private inner class SelectForId<out T : kotlin.Any>(
-      |  private val val_: kotlin.String?,
-      |  private val val__: kotlin.String?,
-      |  private val val___: kotlin.String?,
-      |  private val val____: kotlin.String?,
+      |  @kotlin.jvm.JvmField
+      |  val val_: kotlin.String?,
+      |  @kotlin.jvm.JvmField
+      |  val val__: kotlin.String?,
+      |  @kotlin.jvm.JvmField
+      |  val val___: kotlin.String?,
+      |  @kotlin.jvm.JvmField
+      |  val val____: kotlin.String?,
       |  mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(selectForId, mapper) {
       |  override fun execute(): com.squareup.sqldelight.db.SqlCursor = driver.executeQuery(null, ""${'"'}
@@ -247,8 +258,10 @@ class SelectQueryTypeTest {
 
     assertThat(generator.querySubtype().toString()).isEqualTo("""
       |private inner class SelectMatching<out T : kotlin.Any>(
-      |  private val data: kotlin.String,
-      |  private val rowid: kotlin.Long,
+      |  @kotlin.jvm.JvmField
+      |  val data: kotlin.String,
+      |  @kotlin.jvm.JvmField
+      |  val rowid: kotlin.Long,
       |  mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(selectMatching, mapper) {
       |  override fun execute(): com.squareup.sqldelight.db.SqlCursor = driver.executeQuery(${query.id}, ""${'"'}


### PR DESCRIPTION
The nested mapper lambda accesses these properties from the enclosing query which required a bridge method. Since the enclosing type is private, the properties can be public. Also, for an easy performance win, mark the properties as being backed directly by a field.

Closes #1469.