### PR TITLE
move the generated files under "generated"

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightDatabase.kt
@@ -1,5 +1,6 @@
 package com.squareup.sqldelight.gradle
 
+import com.android.builder.model.AndroidProject.FD_GENERATED
 import com.squareup.sqldelight.core.SqlDelightCompilationUnit
 import com.squareup.sqldelight.core.SqlDelightDatabaseName
 import com.squareup.sqldelight.core.SqlDelightDatabaseProperties
@@ -21,7 +22,7 @@ class SqlDelightDatabase(
   var sourceFolders: Collection<String>? = null
 ) {
   private val generatedSourcesDirectory
-    get() = File(project.buildDir, "sqldelight/code/$name")
+    get() = File(project.buildDir, "$FD_GENERATED/sqldelight/code/$name")
 
   private val sources by lazy { sources() }
   private val dependencies = mutableListOf<SqlDelightDatabase>()

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/CompilationUnitTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/CompilationUnitTests.kt
@@ -29,7 +29,7 @@ class CompilationUnitTests {
         val database = properties.databases[0]
         assertThat(database.className).isEqualTo("CommonDb")
         assertThat(database.packageName).isEqualTo("com.sample")
-        assertThat(database.outputDirectory).isEqualTo("build/sqldelight/code/CommonDb")
+        assertThat(database.outputDirectory).isEqualTo("build/generated/sqldelight/code/CommonDb")
         assertThat(database.compilationUnits).containsExactly(
             SqlDelightCompilationUnit(
                 name = "main",
@@ -66,7 +66,7 @@ class CompilationUnitTests {
             SqlDelightDatabaseProperties(
                 className = "CommonDb",
                 packageName = "com.sample",
-                outputDirectory = "build/sqldelight/code/CommonDb",
+                outputDirectory = "build/generated/sqldelight/code/CommonDb",
                 compilationUnits = listOf(
                     SqlDelightCompilationUnit(
                         name = "main",
@@ -78,7 +78,7 @@ class CompilationUnitTests {
             SqlDelightDatabaseProperties(
                 className = "OtherDb",
                 packageName = "com.sample.otherdb",
-                outputDirectory = "build/sqldelight/code/OtherDb",
+                outputDirectory = "build/generated/sqldelight/code/OtherDb",
                 compilationUnits = listOf(
                     SqlDelightCompilationUnit(
                         name = "main",
@@ -125,7 +125,7 @@ class CompilationUnitTests {
         val database = properties.databases[0]
         assertThat(database.className).isEqualTo("CommonDb")
         assertThat(database.packageName).isEqualTo("com.sample")
-        assertThat(database.outputDirectory).isEqualTo("build/sqldelight/code/CommonDb")
+        assertThat(database.outputDirectory).isEqualTo("build/generated/sqldelight/code/CommonDb")
         assertThat(database.compilationUnits).containsExactly(
             SqlDelightCompilationUnit(
                 name = "jvmMain",
@@ -229,7 +229,7 @@ class CompilationUnitTests {
         val database = properties.databases[0]
         assertThat(database.className).isEqualTo("CommonDb")
         assertThat(database.packageName).isEqualTo("com.sample")
-        assertThat(database.outputDirectory).isEqualTo("build/sqldelight/code/CommonDb")
+        assertThat(database.outputDirectory).isEqualTo("build/generated/sqldelight/code/CommonDb")
         assertThat(database.compilationUnits).containsExactly(
             SqlDelightCompilationUnit(
                 name = "androidLibMinApi21DemoDebug",
@@ -435,7 +435,7 @@ class CompilationUnitTests {
         val database = properties.databases[0]
         assertThat(database.className).isEqualTo("CommonDb")
         assertThat(database.packageName).isEqualTo("com.sample")
-        assertThat(database.outputDirectory).isEqualTo("build/sqldelight/code/CommonDb")
+        assertThat(database.outputDirectory).isEqualTo("build/generated/sqldelight/code/CommonDb")
         assertThat(database.compilationUnits).containsExactly(
             SqlDelightCompilationUnit(
                 name = "minApi23DemoDebug",

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/MultiModuleTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/MultiModuleTests.kt
@@ -28,7 +28,7 @@ class MultiModuleTests {
 
     val properties = SqlDelightPropertiesFile.fromFile(propertiesFile).databases.single().withInvariantPathSeparators()
     assertThat(properties.packageName).isEqualTo("com.example")
-    assertThat(properties.outputDirectory).isEqualTo("build/sqldelight/code/Database")
+    assertThat(properties.outputDirectory).isEqualTo("build/generated/sqldelight/code/Database")
     assertThat(properties.compilationUnits).hasSize(1)
 
     with(properties.compilationUnits[0]) {
@@ -100,7 +100,7 @@ class MultiModuleTests {
         .withInvariantPathSeparators()
         .withSortedCompilationUnits()
     assertThat(properties.packageName).isEqualTo("com.sample.android")
-    assertThat(properties.outputDirectory).isEqualTo("build/sqldelight/code/CommonDb")
+    assertThat(properties.outputDirectory).isEqualTo("build/generated/sqldelight/code/CommonDb")
     assertThat(properties.compilationUnits).containsExactly(
         SqlDelightCompilationUnit(
             name = "minApi23Debug",

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/PluginTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/PluginTest.kt
@@ -79,7 +79,7 @@ class PluginTest {
         .withProjectDir(fixtureRoot)
         .withPluginClasspath()
 
-    val buildDir = File(fixtureRoot, sqldelightDir)
+    val buildDir = File(fixtureRoot, "build/generated/sqldelight")
 
     buildDir.delete()
     val result = runner
@@ -96,7 +96,7 @@ class PluginTest {
         .withProjectDir(fixtureRoot)
         .withPluginClasspath()
 
-    val buildDir = File(fixtureRoot, sqldelightDir)
+    val buildDir = File(fixtureRoot, "build/generated/sqldelight")
 
     buildDir.delete()
     val result = runner
@@ -114,7 +114,7 @@ class PluginTest {
         .withPluginClasspath()
         .forwardOutput()
 
-    val buildDir = File(fixtureRoot, sqldelightDir)
+    val buildDir = File(fixtureRoot, "build/generated/sqldelight")
 
     buildDir.delete()
     val result = runner
@@ -132,7 +132,7 @@ class PluginTest {
         .withProjectDir(fixtureRoot)
         .withPluginClasspath()
 
-    val buildDir = File(fixtureRoot, sqldelightDir)
+    val buildDir = File(fixtureRoot, "build/generated/sqldelight")
 
     buildDir.delete()
     var result = runner
@@ -158,7 +158,7 @@ class PluginTest {
         .withProjectDir(fixtureRoot)
         .withPluginClasspath()
 
-    val buildDir = File(fixtureRoot, sqldelightDir)
+    val buildDir = File(fixtureRoot, "build/generated/sqldelight")
 
     buildDir.delete()
     val result = runner
@@ -177,7 +177,7 @@ class PluginTest {
         .withProjectDir(fixtureRoot)
         .withPluginClasspath()
 
-    val buildDir = File(fixtureRoot, sqldelightDir)
+    val buildDir = File(fixtureRoot, "build/generated/sqldelight")
 
     buildDir.delete()
     var result = runner
@@ -205,7 +205,7 @@ class PluginTest {
         .withProjectDir(fixtureRoot)
         .withPluginClasspath()
 
-    val outputFolder = File(fixtureRoot, sqldelightDir).apply { mkdirs() }
+    val outputFolder = File(fixtureRoot, "build/generated/sqldelight").apply { mkdirs() }
     val garbage = File(outputFolder, "sup.txt").apply { createNewFile() }
 
     assertThat(garbage.exists()).isTrue()

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/PluginTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/PluginTest.kt
@@ -79,7 +79,7 @@ class PluginTest {
         .withProjectDir(fixtureRoot)
         .withPluginClasspath()
 
-    val buildDir = File(fixtureRoot, "build/sqldelight")
+    val buildDir = File(fixtureRoot, sqldelightDir)
 
     buildDir.delete()
     val result = runner
@@ -96,7 +96,7 @@ class PluginTest {
         .withProjectDir(fixtureRoot)
         .withPluginClasspath()
 
-    val buildDir = File(fixtureRoot, "build/sqldelight")
+    val buildDir = File(fixtureRoot, sqldelightDir)
 
     buildDir.delete()
     val result = runner
@@ -114,7 +114,7 @@ class PluginTest {
         .withPluginClasspath()
         .forwardOutput()
 
-    val buildDir = File(fixtureRoot, "build/sqldelight")
+    val buildDir = File(fixtureRoot, sqldelightDir)
 
     buildDir.delete()
     val result = runner
@@ -132,7 +132,7 @@ class PluginTest {
         .withProjectDir(fixtureRoot)
         .withPluginClasspath()
 
-    val buildDir = File(fixtureRoot, "build/sqldelight")
+    val buildDir = File(fixtureRoot, sqldelightDir)
 
     buildDir.delete()
     var result = runner
@@ -158,7 +158,7 @@ class PluginTest {
         .withProjectDir(fixtureRoot)
         .withPluginClasspath()
 
-    val buildDir = File(fixtureRoot, "build/sqldelight")
+    val buildDir = File(fixtureRoot, sqldelightDir)
 
     buildDir.delete()
     val result = runner
@@ -177,7 +177,7 @@ class PluginTest {
         .withProjectDir(fixtureRoot)
         .withPluginClasspath()
 
-    val buildDir = File(fixtureRoot, "build/sqldelight")
+    val buildDir = File(fixtureRoot, sqldelightDir)
 
     buildDir.delete()
     var result = runner
@@ -205,7 +205,7 @@ class PluginTest {
         .withProjectDir(fixtureRoot)
         .withPluginClasspath()
 
-    val outputFolder = File(fixtureRoot, "build/sqldelight").apply { mkdirs() }
+    val outputFolder = File(fixtureRoot, sqldelightDir).apply { mkdirs() }
     val garbage = File(outputFolder, "sup.txt").apply { createNewFile() }
 
     assertThat(garbage.exists()).isTrue()

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/PropertiesFileTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/PropertiesFileTest.kt
@@ -25,7 +25,7 @@ class PropertiesFileTest {
 
     val properties = SqlDelightPropertiesFile.fromFile(propertiesFile).databases.single().withInvariantPathSeparators()
     assertThat(properties.packageName).isEqualTo("com.example")
-    assertThat(properties.outputDirectory).isEqualTo("build/sqldelight/code/Database")
+    assertThat(properties.outputDirectory).isEqualTo("build/generated/sqldelight/code/Database")
     assertThat(properties.compilationUnits).hasSize(1)
 
     with(properties.compilationUnits[0]) {

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/TestUtil.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/TestUtil.kt
@@ -35,3 +35,5 @@ private fun SqlDelightCompilationUnit.withSortedSourceFolders(): SqlDelightCompi
 }
 
 private fun SqlDelightSourceFolder.withInvariantPathSeparators() = copy(path = path.withInvariantPathSeparators())
+
+val sqldelightDir = "build/generated/sqldelight"

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/TestUtil.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/TestUtil.kt
@@ -35,5 +35,3 @@ private fun SqlDelightCompilationUnit.withSortedSourceFolders(): SqlDelightCompi
 }
 
 private fun SqlDelightSourceFolder.withInvariantPathSeparators() = copy(path = path.withInvariantPathSeparators())
-
-val sqldelightDir = "build/generated/sqldelight"

--- a/sqldelight-idea-plugin/src/test/kotlin/com/squareup/sqldelight/intellij/folding/FoldingTests.kt
+++ b/sqldelight-idea-plugin/src/test/kotlin/com/squareup/sqldelight/intellij/folding/FoldingTests.kt
@@ -22,38 +22,38 @@ class FoldingTests : SqlDelightFixtureTestCase() {
   override val fixtureDirectory = "folding"
 
   fun testSingleImport() {
-    myFixture.testFolding("$testDataPath/$sqldelightDir/SingleImport.sq")
+    myFixture.testFolding("$testDataPath/build/generated/sqldelight/SingleImport.sq")
   }
 
   fun testMultipleImports() {
-    myFixture.testFolding("$testDataPath/$sqldelightDir/MultipleImports.sq")
+    myFixture.testFolding("$testDataPath/build/generated/sqldelight/MultipleImports.sq")
   }
 
   fun testIncompleteImport() {
-    myFixture.testFolding("$testDataPath/$sqldelightDir/IncompleteImport.sq")
+    myFixture.testFolding("$testDataPath/build/generated/sqldelight/IncompleteImport.sq")
   }
 
   fun testCreateTable() {
-    myFixture.testFolding("$testDataPath/$sqldelightDir/CreateTable.sq")
+    myFixture.testFolding("$testDataPath/build/generated/sqldelight/CreateTable.sq")
   }
 
   fun testCreateView() {
-    myFixture.testFolding("$testDataPath/$sqldelightDir/CreateView.sq")
+    myFixture.testFolding("$testDataPath/build/generated/sqldelight/CreateView.sq")
   }
 
   fun testCreateTrigger() {
-    myFixture.testFolding("$testDataPath/$sqldelightDir/CreateTrigger.sq")
+    myFixture.testFolding("$testDataPath/build/generated/sqldelight/CreateTrigger.sq")
   }
 
   fun testCreateIndex() {
-    myFixture.testFolding("$testDataPath/$sqldelightDir/CreateIndex.sq")
+    myFixture.testFolding("$testDataPath/build/generated/sqldelight/CreateIndex.sq")
   }
 
   fun testStatements() {
-    myFixture.testFolding("$testDataPath/$sqldelightDir/Statements.sq")
+    myFixture.testFolding("$testDataPath/build/generated/sqldelight/Statements.sq")
   }
 
   fun testAll() {
-    myFixture.testFolding("$testDataPath/$sqldelightDir/Player.sq")
+    myFixture.testFolding("$testDataPath/build/generated/sqldelight/Player.sq")
   }
 }

--- a/sqldelight-idea-plugin/src/test/kotlin/com/squareup/sqldelight/intellij/folding/FoldingTests.kt
+++ b/sqldelight-idea-plugin/src/test/kotlin/com/squareup/sqldelight/intellij/folding/FoldingTests.kt
@@ -22,38 +22,38 @@ class FoldingTests : SqlDelightFixtureTestCase() {
   override val fixtureDirectory = "folding"
 
   fun testSingleImport() {
-    myFixture.testFolding("$testDataPath/build/generated/sqldelight/SingleImport.sq")
+    myFixture.testFolding("$testDataPath/$sqldelightDir/SingleImport.sq")
   }
 
   fun testMultipleImports() {
-    myFixture.testFolding("$testDataPath/build/generated/sqldelight/MultipleImports.sq")
+    myFixture.testFolding("$testDataPath/$sqldelightDir/MultipleImports.sq")
   }
 
   fun testIncompleteImport() {
-    myFixture.testFolding("$testDataPath/build/generated/sqldelight/IncompleteImport.sq")
+    myFixture.testFolding("$testDataPath/$sqldelightDir/IncompleteImport.sq")
   }
 
   fun testCreateTable() {
-    myFixture.testFolding("$testDataPath/build/generated/sqldelight/CreateTable.sq")
+    myFixture.testFolding("$testDataPath/$sqldelightDir/CreateTable.sq")
   }
 
   fun testCreateView() {
-    myFixture.testFolding("$testDataPath/build/generated/sqldelight/CreateView.sq")
+    myFixture.testFolding("$testDataPath/$sqldelightDir/CreateView.sq")
   }
 
   fun testCreateTrigger() {
-    myFixture.testFolding("$testDataPath/build/generated/sqldelight/CreateTrigger.sq")
+    myFixture.testFolding("$testDataPath/$sqldelightDir/CreateTrigger.sq")
   }
 
   fun testCreateIndex() {
-    myFixture.testFolding("$testDataPath/build/generated/sqldelight/CreateIndex.sq")
+    myFixture.testFolding("$testDataPath/$sqldelightDir/CreateIndex.sq")
   }
 
   fun testStatements() {
-    myFixture.testFolding("$testDataPath/build/generated/sqldelight/Statements.sq")
+    myFixture.testFolding("$testDataPath/$sqldelightDir/Statements.sq")
   }
 
   fun testAll() {
-    myFixture.testFolding("$testDataPath/build/generated/sqldelight/Player.sq")
+    myFixture.testFolding("$testDataPath/$sqldelightDir/Player.sq")
   }
 }


### PR DESCRIPTION
This fixes an android warning during sync (https://github.com/cashapp/sqldelight/issues/1287). The warning comes from the intellij android plugin there: https://github.com/JetBrains/android/blob/40ee31fa0b3d6733aa364c6f1561354433f523e1/android/src/com/android/tools/idea/gradle/util/GeneratedSourceFolders.java#L27

This PR adds an android constraint to what is otherwise a multiplatform project but I guess this is ok ?