### PR TITLE
Restore missing section for migrations to mkdocs

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,0 +1,18 @@
+# Migrations
+
+The `.sq` file always describes how to create the latest schema in an empty database. If your database is currently on an earlier version, migration files bring those databases up-to-date. 
+
+The first version of the schema is 1. Migration files are named `<version to upgrade from>.sqm`. To migrate to version 2, put migration statements in `1.sqm`:
+
+```sql
+ALTER TABLE hockeyPlayer ADD COLUMN draft_year INTEGER;
+ALTER TABLE hockeyPlayer ADD COLUMN draft_order INTEGER;
+```
+
+Migration files go in the `src/main/sqldelight` folder. 
+
+These SQL statements are run by `Database.Schema.migrate()`. This is automatic for the Android and iOS drivers. 
+
+You can also place a `.db` file in the `src/main/sqldelight` folder of the same `<version number>.db` format. If there is a `.db` file present, a new `verifySqlDelightMigration` task will be added to the gradle project, and it will run as part of the `test` task, meaning your migrations will be verified against that `.db` file. It confirms that the migrations yield a database with the latest schema.
+
+To generate a `.db` file from your latest schema, run the `generateSqlDelightSchema` task. You should probably do this before you create your first migration.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
   - 'Types': types.md
   - 'Transactions': transactions.md
   - 'Custom Column Types': custom_column_types.md
+  - 'Migrations': migrations.md
   - 'RxJava': rxjava.md
   - 'Multiplatform': multiplatform.md
   - 'Android Paging': android_paging.md


### PR DESCRIPTION
Migrations section got missed when copying over the readme to mkdocs.