### PR TITLE
Use kotlinOptions.freeCompilerArgs instead of extraOpts.

### DIFF
--- a/drivers/native-driver/build.gradle
+++ b/drivers/native-driver/build.gradle
@@ -33,7 +33,7 @@ kotlin {
     targetFromPreset(presets.iosArm64, 'iosArm64')
     targetFromPreset(presets.mingwX64, 'mingw') {
       compilations.each {
-        it.extraOpts("-linker-options", "-Lc:\\msys64\\mingw64\\lib")
+        it.kotlinOptions.freeCompilerArgs += ["-linker-options", "-Lc:\\msys64\\mingw64\\lib"]
       }
     }
   }
@@ -42,7 +42,7 @@ kotlin {
     compilations.main.source(sourceSets.nativeMain)
     compilations.test.source(sourceSets.nativeTest)
     compilations.test {
-      extraOpts("-linker-options", "-lsqlite3")
+      kotlinOptions.freeCompilerArgs += ["-linker-options", "-lsqlite3"]
     }
   }
 }

--- a/sample/android/src/main/java/com/example/sqldelight/hockey/data/Extensions.kt
+++ b/sample/android/src/main/java/com/example/sqldelight/hockey/data/Extensions.kt
@@ -4,9 +4,9 @@ import android.content.Context
 import com.example.sqldelight.hockey.HockeyDb
 import com.squareup.sqldelight.android.AndroidSqliteDriver
 
-fun Db.getInstance(contex: Context): HockeyDb {
+fun Db.getInstance(context: Context): HockeyDb {
   if (!Db.ready) {
-    Db.dbSetup(AndroidSqliteDriver(Schema, contex))
+    Db.dbSetup(AndroidSqliteDriver(Schema, context))
   }
   return Db.instance
 }

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/BindableQuery.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/BindableQuery.kt
@@ -190,7 +190,7 @@ abstract class BindableQuery(
     private val JAVADOC_TEXT_REGEX = Regex("/\\*\\*|\n \\*[ /]?| \\*/")
 
     /**
-     * The query id map use to avoid string hashcord collision. Ideally this map should be per module.
+     * The query id map use to avoid string hashcode collision. Ideally this map should be per module.
      */
     val queryIdMap = ConcurrentHashMap<String, Int>()
 

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
@@ -52,7 +52,7 @@ internal data class IntermediateType(
    */
   val bindArg: SqliteBindExpr? = null,
   /**
-   * Wether or not this argument is extracted from a different type
+   * Whether or not this argument is extracted from a different type
    */
   val extracted: Boolean = false
 ) {

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/kotlin/Multiplatform.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/kotlin/Multiplatform.kt
@@ -5,11 +5,11 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation
 
 fun Project.linkSqlite() {
-  val extension = project.extensions.findByType(KotlinMultiplatformExtension ::class.java) ?: return
-  extension.targets
-      .flatMap { it.compilations }
-      .filterIsInstance<KotlinNativeCompilation>()
-      .forEach { compilationUnit ->
-        compilationUnit.extraOpts("-linker-options", "-lsqlite3")
-      }
+    val extension = project.extensions.findByType(KotlinMultiplatformExtension::class.java) ?: return
+    extension.targets
+        .flatMap { it.compilations }
+        .filterIsInstance<KotlinNativeCompilation>()
+        .forEach { compilationUnit ->
+            compilationUnit.kotlinOptions.freeCompilerArgs += arrayOf("-linker-options", "-lsqlite3")
+        }
 }

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/kotlin/Multiplatform.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/kotlin/Multiplatform.kt
@@ -5,11 +5,11 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation
 
 fun Project.linkSqlite() {
-    val extension = project.extensions.findByType(KotlinMultiplatformExtension::class.java) ?: return
-    extension.targets
-        .flatMap { it.compilations }
-        .filterIsInstance<KotlinNativeCompilation>()
-        .forEach { compilationUnit ->
-            compilationUnit.kotlinOptions.freeCompilerArgs += arrayOf("-linker-options", "-lsqlite3")
-        }
+  val extension = project.extensions.findByType(KotlinMultiplatformExtension ::class.java) ?: return
+  extension.targets
+      .flatMap { it.compilations }
+      .filterIsInstance<KotlinNativeCompilation>()
+      .forEach { compilationUnit ->
+        compilationUnit.kotlinOptions.freeCompilerArgs += arrayOf("-linker-options", "-lsqlite3")
+      }
 }

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/GradlePluginCombinationTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/GradlePluginCombinationTests.kt
@@ -37,7 +37,7 @@ class GradlePluginCombinationTests {
   }
 
   @Test
-  fun `sqldelight fails when linkSqlite=false on native without additiona linker settings`() {
+  fun `sqldelight fails when linkSqlite=false on native without additional linker settings`() {
     withTemporaryFixture {
       gradleFile("""
     |plugins {


### PR DESCRIPTION
When the project is built, a warning message appears: "The compilation.extraOpts method used in this build is deprecated. Use compilation.kotlinOptions.freeCompilerArgs instead."

This pull request uses kotlinOptions,freeCompilerArgs instead of extraOpts. In addition, it corrects some mispellings.