### PR TITLE
Explicitly specify site-url for fixing broken 404 pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: SQLDelight
+site_url: https://cashapp.github.io/sqldelight/
 repo_name: sqldelight
 repo_url: https://github.com/cashapp/sqldelight
 site_description: "SQLDelight - Generates typesafe Kotlin APIs from SQL"


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/2387680/71122575-ecdaa680-21ae-11ea-8158-b3af285bfe3b.png) | ![image](https://user-images.githubusercontent.com/2387680/71122659-1eec0880-21af-11ea-876e-3a20c4b88102.png) |

MkDocs' 404 page uses relative links to the organization's github page by default resulting in broken resources (stylesheets, images et al). What's worse is that the links in the navigation sidebar also get affected so manually changing the url in the address bar is the only way to exit. 

The fix is to specify the site URL explicitly ([source](https://github.com/mkdocs/mkdocs/issues/77)). A preview of this fix can be seen on my fork: https://saket.github.io/sqldelight/page-that-does-not-exist/

Once this is deployed and confirmed to work, I'll send the same PRs to other cashapp and square repositories.