### PR TITLE
Fix broken links to gradle and upgrading docs

### DIFF
--- a/docs/gradle.md
+++ b/docs/gradle.md
@@ -68,4 +68,4 @@ Snapshots of the development version (including the IDE plugin zip) are availabl
 
 ## Upgrading From Previous Versions
 
-There's a separate guide for upgrading from 0.7 and other pre-1.0 versions [here](/upgrading)
+There's a separate guide for upgrading from 0.7 and other pre-1.0 versions [here](upgrading.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ SQLDelight generates typesafe APIs from your SQL statements. It compile-time ver
 
 ## Example
 
-To use SQLDelight, apply the [gradle plugin](/gradle) and put your SQL statements in a `.sq` file in `src/main/sqldelight`.  Typically the first statement in the SQL file creates a table.
+To use SQLDelight, apply the [gradle plugin](gradle.md) and put your SQL statements in a `.sq` file in `src/main/sqldelight`.  Typically the first statement in the SQL file creates a table.
 
 ```sql
 -- src/main/sqldelight/com/example/sqldelight/hockey/data/Player.sq


### PR DESCRIPTION
Turns out MkDocs expects internal links to use the exact file format instead of pointing to the page's generated URL ([source](https://www.mkdocs.org/user-guide/writing-your-docs/)). Fixes [this issue](https://github.com/cashapp/sqldelight/issues/1534#issuecomment-568208956) in #1534. This fix can be tested on my fork [here](https://saket.github.io/sqldelight/) and [here](https://saket.github.io/sqldelight/gradle/).