### PR TITLE
Fix gradle-plugin to work with buildDir from different root(RAMDisk)

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightPropertiesFile.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightPropertiesFile.kt
@@ -46,11 +46,9 @@ data class SqlDelightDatabaseProperties(
   val packageName: String,
   val compilationUnits: List<SqlDelightCompilationUnit>,
   /**
-   * Absolute path for generated sources directory.
-   * It may have different system roots with the project
-   * in case of custom build directory(RAMDisk for example).
+   * NOTE: May have different root from project directory
    */
-  val outputDirectory: String,
+  val outputDirectory: File,
   val className: String,
   val dependencies: List<SqlDelightDatabaseName>
 )

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightPropertiesFile.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightPropertiesFile.kt
@@ -45,6 +45,11 @@ class SqlDelightPropertiesFile(
 data class SqlDelightDatabaseProperties(
   val packageName: String,
   val compilationUnits: List<SqlDelightCompilationUnit>,
+  /**
+   * Absolute path for generated sources directory.
+   * It may have different system roots with the project
+   * in case of custom build directory(RAMDisk for example).
+   */
   val outputDirectory: String,
   val className: String,
   val dependencies: List<SqlDelightDatabaseName>

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightDatabase.kt
@@ -22,7 +22,7 @@ class SqlDelightDatabase(
   var sourceFolders: Collection<String>? = null
 ) {
   private val generatedSourcesDirectory
-    get() = File(project.buildDir, "$FD_GENERATED/sqldelight/code/$name")
+    get() = project.buildDir.resolve("$FD_GENERATED/sqldelight/code/$name")
 
   private val sources by lazy { sources() }
   private val dependencies = mutableListOf<SqlDelightDatabase>()
@@ -63,7 +63,7 @@ class SqlDelightDatabase(
                 sourceFolders = sourceFolders(source).sortedBy { it.path }
             )
           },
-          outputDirectory = generatedSourcesDirectory.toRelativeString(project.projectDir),
+          outputDirectory = generatedSourcesDirectory.invariantSeparatorsPath,
           className = name,
           dependencies = dependencies.map { SqlDelightDatabaseName(it.packageName!!, it.name) }
       )
@@ -97,12 +97,12 @@ class SqlDelightDatabase(
     // place right now. Can revisit later but prioritise common for now:
 
     val common = sources.singleOrNull { it.type == KotlinPlatformType.common }
-    common?.sourceDirectorySet?.srcDir(generatedSourcesDirectory.toRelativeString(project.projectDir))
+    common?.sourceDirectorySet?.srcDir(generatedSourcesDirectory)
 
     sources.forEach { source ->
       // Add the source dependency on the generated code.
       if (common == null) {
-        source.sourceDirectorySet.srcDir(generatedSourcesDirectory.toRelativeString(project.projectDir))
+        source.sourceDirectorySet.srcDir(generatedSourcesDirectory)
       }
 
       val allFiles = sourceFolders(source)

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightDatabase.kt
@@ -63,7 +63,7 @@ class SqlDelightDatabase(
                 sourceFolders = sourceFolders(source).sortedBy { it.path }
             )
           },
-          outputDirectory = generatedSourcesDirectory.invariantSeparatorsPath,
+          outputDirectory = generatedSourcesDirectory,
           className = name,
           dependencies = dependencies.map { SqlDelightDatabaseName(it.packageName!!, it.name) }
       )

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/CompilationUnitTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/CompilationUnitTests.kt
@@ -29,7 +29,7 @@ class CompilationUnitTests {
         val database = properties.databases[0]
         assertThat(database.className).isEqualTo("CommonDb")
         assertThat(database.packageName).isEqualTo("com.sample")
-        assertThat(database.outputDirectory).endsWith("build/generated/sqldelight/code/CommonDb")
+        assertThat(database.outputDirectory).isEqualTo(file("build/generated/sqldelight/code/CommonDb"))
         assertThat(database.compilationUnits).containsExactly(
             SqlDelightCompilationUnit(
                 name = "main",
@@ -62,12 +62,11 @@ class CompilationUnitTests {
       """.trimMargin())
 
       properties().let { properties ->
-        val databases = properties.databases
-        val expect = listOf(
+        assertThat(properties.databases).containsExactly(
             SqlDelightDatabaseProperties(
                 className = "CommonDb",
                 packageName = "com.sample",
-                outputDirectory = "build/generated/sqldelight/code/CommonDb",
+                outputDirectory = file("build/generated/sqldelight/code/CommonDb"),
                 compilationUnits = listOf(
                     SqlDelightCompilationUnit(
                         name = "main",
@@ -79,7 +78,7 @@ class CompilationUnitTests {
             SqlDelightDatabaseProperties(
                 className = "OtherDb",
                 packageName = "com.sample.otherdb",
-                outputDirectory = "build/generated/sqldelight/code/OtherDb",
+                outputDirectory = file("build/generated/sqldelight/code/OtherDb"),
                 compilationUnits = listOf(
                     SqlDelightCompilationUnit(
                         name = "main",
@@ -92,18 +91,6 @@ class CompilationUnitTests {
                 dependencies = emptyList()
             )
         )
-
-        //check outputDirectory separately because it's absolute
-        for ((expected, actual) in expect.zip(databases)) {
-          assertThat(actual.outputDirectory)
-            .endsWith(expected.outputDirectory)
-        }
-
-        val databasesWithCheckedOutputDirectories = expect
-          .zip(databases)
-          .map { (expected, actual)-> actual.copy(outputDirectory = expected.outputDirectory) }
-
-        assertThat(databasesWithCheckedOutputDirectories).containsExactlyElementsIn(expect)
       }
     }
   }
@@ -138,7 +125,7 @@ class CompilationUnitTests {
         val database = properties.databases[0]
         assertThat(database.className).isEqualTo("CommonDb")
         assertThat(database.packageName).isEqualTo("com.sample")
-        assertThat(database.outputDirectory).endsWith("build/generated/sqldelight/code/CommonDb")
+        assertThat(database.outputDirectory).isEqualTo(file("build/generated/sqldelight/code/CommonDb"))
         assertThat(database.compilationUnits).containsExactly(
             SqlDelightCompilationUnit(
                 name = "jvmMain",
@@ -242,7 +229,7 @@ class CompilationUnitTests {
         val database = properties.databases[0]
         assertThat(database.className).isEqualTo("CommonDb")
         assertThat(database.packageName).isEqualTo("com.sample")
-        assertThat(database.outputDirectory).endsWith("build/generated/sqldelight/code/CommonDb")
+        assertThat(database.outputDirectory).isEqualTo(file("build/generated/sqldelight/code/CommonDb"))
         assertThat(database.compilationUnits).containsExactly(
             SqlDelightCompilationUnit(
                 name = "androidLibMinApi21DemoDebug",
@@ -448,7 +435,7 @@ class CompilationUnitTests {
         val database = properties.databases[0]
         assertThat(database.className).isEqualTo("CommonDb")
         assertThat(database.packageName).isEqualTo("com.sample")
-        assertThat(database.outputDirectory).endsWith("build/generated/sqldelight/code/CommonDb")
+        assertThat(database.outputDirectory).isEqualTo(file("build/generated/sqldelight/code/CommonDb"))
         assertThat(database.compilationUnits).containsExactly(
             SqlDelightCompilationUnit(
                 name = "minApi23DemoDebug",

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/CompilationUnitTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/CompilationUnitTests.kt
@@ -29,7 +29,7 @@ class CompilationUnitTests {
         val database = properties.databases[0]
         assertThat(database.className).isEqualTo("CommonDb")
         assertThat(database.packageName).isEqualTo("com.sample")
-        assertThat(database.outputDirectory).isEqualTo("build/generated/sqldelight/code/CommonDb")
+        assertThat(database.outputDirectory).endsWith("build/generated/sqldelight/code/CommonDb")
         assertThat(database.compilationUnits).containsExactly(
             SqlDelightCompilationUnit(
                 name = "main",
@@ -62,7 +62,8 @@ class CompilationUnitTests {
       """.trimMargin())
 
       properties().let { properties ->
-        assertThat(properties.databases).containsExactly(
+        val databases = properties.databases
+        val expect = listOf(
             SqlDelightDatabaseProperties(
                 className = "CommonDb",
                 packageName = "com.sample",
@@ -91,6 +92,18 @@ class CompilationUnitTests {
                 dependencies = emptyList()
             )
         )
+
+        //check outputDirectory separately because it's absolute
+        for ((expected, actual) in expect.zip(databases)) {
+          assertThat(actual.outputDirectory)
+            .endsWith(expected.outputDirectory)
+        }
+
+        val databasesWithCheckedOutputDirectories = expect
+          .zip(databases)
+          .map { (expected, actual)-> actual.copy(outputDirectory = expected.outputDirectory) }
+
+        assertThat(databasesWithCheckedOutputDirectories).containsExactlyElementsIn(expect)
       }
     }
   }
@@ -125,7 +138,7 @@ class CompilationUnitTests {
         val database = properties.databases[0]
         assertThat(database.className).isEqualTo("CommonDb")
         assertThat(database.packageName).isEqualTo("com.sample")
-        assertThat(database.outputDirectory).isEqualTo("build/generated/sqldelight/code/CommonDb")
+        assertThat(database.outputDirectory).endsWith("build/generated/sqldelight/code/CommonDb")
         assertThat(database.compilationUnits).containsExactly(
             SqlDelightCompilationUnit(
                 name = "jvmMain",
@@ -229,7 +242,7 @@ class CompilationUnitTests {
         val database = properties.databases[0]
         assertThat(database.className).isEqualTo("CommonDb")
         assertThat(database.packageName).isEqualTo("com.sample")
-        assertThat(database.outputDirectory).isEqualTo("build/generated/sqldelight/code/CommonDb")
+        assertThat(database.outputDirectory).endsWith("build/generated/sqldelight/code/CommonDb")
         assertThat(database.compilationUnits).containsExactly(
             SqlDelightCompilationUnit(
                 name = "androidLibMinApi21DemoDebug",
@@ -435,7 +448,7 @@ class CompilationUnitTests {
         val database = properties.databases[0]
         assertThat(database.className).isEqualTo("CommonDb")
         assertThat(database.packageName).isEqualTo("com.sample")
-        assertThat(database.outputDirectory).isEqualTo("build/generated/sqldelight/code/CommonDb")
+        assertThat(database.outputDirectory).endsWith("build/generated/sqldelight/code/CommonDb")
         assertThat(database.compilationUnits).containsExactly(
             SqlDelightCompilationUnit(
                 name = "minApi23DemoDebug",

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/MultiModuleTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/MultiModuleTests.kt
@@ -28,7 +28,7 @@ class MultiModuleTests {
 
     val properties = SqlDelightPropertiesFile.fromFile(propertiesFile).databases.single().withInvariantPathSeparators()
     assertThat(properties.packageName).isEqualTo("com.example")
-    assertThat(properties.outputDirectory).isEqualTo("build/generated/sqldelight/code/Database")
+    assertThat(properties.outputDirectory).endsWith("build/generated/sqldelight/code/Database")
     assertThat(properties.compilationUnits).hasSize(1)
 
     with(properties.compilationUnits[0]) {
@@ -100,7 +100,7 @@ class MultiModuleTests {
         .withInvariantPathSeparators()
         .withSortedCompilationUnits()
     assertThat(properties.packageName).isEqualTo("com.sample.android")
-    assertThat(properties.outputDirectory).isEqualTo("build/generated/sqldelight/code/CommonDb")
+    assertThat(properties.outputDirectory).endsWith("build/generated/sqldelight/code/CommonDb")
     assertThat(properties.compilationUnits).containsExactly(
         SqlDelightCompilationUnit(
             name = "minApi23Debug",

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/MultiModuleTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/MultiModuleTests.kt
@@ -28,7 +28,7 @@ class MultiModuleTests {
 
     val properties = SqlDelightPropertiesFile.fromFile(propertiesFile).databases.single().withInvariantPathSeparators()
     assertThat(properties.packageName).isEqualTo("com.example")
-    assertThat(properties.outputDirectory).endsWith("build/generated/sqldelight/code/Database")
+    assertThat(properties.outputDirectory).isEqualTo(fixtureRoot.resolve("build/generated/sqldelight/code/Database"))
     assertThat(properties.compilationUnits).hasSize(1)
 
     with(properties.compilationUnits[0]) {
@@ -100,7 +100,7 @@ class MultiModuleTests {
         .withInvariantPathSeparators()
         .withSortedCompilationUnits()
     assertThat(properties.packageName).isEqualTo("com.sample.android")
-    assertThat(properties.outputDirectory).endsWith("build/generated/sqldelight/code/CommonDb")
+    assertThat(properties.outputDirectory).isEqualTo(fixtureRoot.resolve("build/generated/sqldelight/code/CommonDb"))
     assertThat(properties.compilationUnits).containsExactly(
         SqlDelightCompilationUnit(
             name = "minApi23Debug",

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/PropertiesFileTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/PropertiesFileTest.kt
@@ -25,7 +25,7 @@ class PropertiesFileTest {
 
     val properties = SqlDelightPropertiesFile.fromFile(propertiesFile).databases.single().withInvariantPathSeparators()
     assertThat(properties.packageName).isEqualTo("com.example")
-    assertThat(properties.outputDirectory).endsWith("build/generated/sqldelight/code/Database")
+    assertThat(properties.outputDirectory).isEqualTo(fixtureRoot.resolve("build/generated/sqldelight/code/Database"))
     assertThat(properties.compilationUnits).hasSize(1)
 
     with(properties.compilationUnits[0]) {

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/PropertiesFileTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/PropertiesFileTest.kt
@@ -25,7 +25,7 @@ class PropertiesFileTest {
 
     val properties = SqlDelightPropertiesFile.fromFile(propertiesFile).databases.single().withInvariantPathSeparators()
     assertThat(properties.packageName).isEqualTo("com.example")
-    assertThat(properties.outputDirectory).isEqualTo("build/generated/sqldelight/code/Database")
+    assertThat(properties.outputDirectory).endsWith("build/generated/sqldelight/code/Database")
     assertThat(properties.compilationUnits).hasSize(1)
 
     with(properties.compilationUnits[0]) {

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/TemporaryFixture.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/TemporaryFixture.kt
@@ -22,6 +22,10 @@ internal class TemporaryFixture : AutoCloseable {
     File(fixtureRoot, "build.gradle").apply { createNewFile() }.writeText(text)
   }
 
+  internal fun file(path: String): File {
+    return fixtureRoot.resolve(path)
+  }
+
   internal fun configure(runTask: String = "clean") {
     val result = GradleRunner.create()
         .withProjectDir(fixtureRoot)

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/TestUtil.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/TestUtil.kt
@@ -16,7 +16,7 @@ internal fun SqlDelightPropertiesFile.withInvariantPathSeparators(): SqlDelightP
 internal fun SqlDelightDatabaseProperties.withInvariantPathSeparators(): SqlDelightDatabaseProperties {
   return copy(
       compilationUnits = compilationUnits.map { it.withInvariantPathSeparators() },
-      outputDirectory = outputDirectory.withInvariantPathSeparators()
+      outputDirectory = outputDirectory
   )
 }
 

--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/FileIndex.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/FileIndex.kt
@@ -30,7 +30,7 @@ class FileIndex(
 ) : SqlDelightFileIndex {
   override val isConfigured = true
   override val packageName = properties.packageName
-  override val outputDirectory = properties.outputDirectory
+  override val outputDirectory = properties.outputDirectory.name
   override val className = properties.className
   override val dependencies = properties.dependencies
 

--- a/sqldelight-idea-plugin/src/test/kotlin/com/squareup/sqldelight/intellij/SqlDelightProjectTestCase.kt
+++ b/sqldelight-idea-plugin/src/test/kotlin/com/squareup/sqldelight/intellij/SqlDelightProjectTestCase.kt
@@ -49,7 +49,7 @@ abstract class SqlDelightProjectTestCase : LightCodeInsightFixtureTestCase() {
             SqlDelightCompilationUnit("productionDebug", listOf(SqlDelightSourceFolder("src/main/sqldelight", false), SqlDelightSourceFolder("src/production/sqldelight", false), SqlDelightSourceFolder("src/debug/sqldelight", false), SqlDelightSourceFolder("src/productionDebug/sqldelight", false))),
             SqlDelightCompilationUnit("productionRelease", listOf(SqlDelightSourceFolder("src/main/sqldelight", false), SqlDelightSourceFolder("src/production/sqldelight", false), SqlDelightSourceFolder("src/release/sqldelight", false), SqlDelightSourceFolder("src/productionRelease/sqldelight", false)))
         ),
-        outputDirectory = "build",
+        outputDirectory = File("build"),
         dependencies = emptyList()
     )
   }

--- a/test-util/src/main/kotlin/com/squareup/sqldelight/test/util/TestEnvironment.kt
+++ b/test-util/src/main/kotlin/com/squareup/sqldelight/test/util/TestEnvironment.kt
@@ -25,7 +25,7 @@ internal class TestEnvironment(private val outputDirectory: File = File("output"
             className = "TestDatabase",
             dependencies = emptyList(),
             compilationUnits = emptyList(),
-            outputDirectory = outputDirectory.absolutePath
+            outputDirectory = outputDirectory
         ),
         outputDirectory = outputDirectory,
         moduleName = "testmodule"


### PR DESCRIPTION
#1493, #1498

Use absolute paths for database generated source directory