### PR TITLE
Add plugin id file

### DIFF
--- a/sqldelight-gradle-plugin/src/main/resources/META-INF/gradle-plugins/com.squareup.sqldelight.properties
+++ b/sqldelight-gradle-plugin/src/main/resources/META-INF/gradle-plugins/com.squareup.sqldelight.properties
@@ -1,0 +1,1 @@
+implementation-class=com.squareup.sqldelight.gradle.SqlDelightPlugin


### PR DESCRIPTION
According to https://docs.gradle.org/current/userguide/custom_plugins.html#sec:custom_plugins_standalone_project:

> you need to provide a properties file in the jar’s META-INF/gradle-plugins directory that matches the id of your plugin.

This is how gradle can find the plugin by id. This should fix #1496.