### PR TITLE
Revert gradle to 5.6

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,7 +12,7 @@ ext.versions = [
     moshi: '1.9.2',
     stately: '0.9.5',
     sqliter: '0.6.6',
-    testhelp: '0.2.8',
+    testhelp: '0.2.9',
     paging: '2.0.0',
 ]
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,3 +16,5 @@ include ':sqldelight-gradle-plugin'
 include ':sqldelight-idea-plugin'
 include ':sqlite-migrations'
 include ':test-util'
+
+enableFeaturePreview("GRADLE_METADATA")

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/GenerateSchemaTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/GenerateSchemaTask.kt
@@ -6,6 +6,7 @@ import com.squareup.sqldelight.core.lang.SqlDelightFile
 import com.squareup.sqldelight.core.lang.util.forInitializationStatements
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileTree
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
@@ -25,13 +26,14 @@ import java.sql.DriverManager
 import javax.inject.Inject
 
 @CacheableTask
-open class GenerateSchemaTask
-@Inject constructor(val workerExecutor: WorkerExecutor) : SourceTask() {
+abstract class GenerateSchemaTask : SourceTask() {
   @Suppress("unused") // Required to invalidate the task on version updates.
-  @Input fun pluginVersion() = VERSION
+  @Input val pluginVersion = VERSION
+
+  @get:Inject
+  abstract val workerExecutor: WorkerExecutor
 
   @get:OutputDirectory
-  @get:PathSensitive(PathSensitivity.RELATIVE)
   var outputDirectory: File? = null
 
   @Internal lateinit var sourceFolders: Iterable<File>
@@ -53,7 +55,7 @@ open class GenerateSchemaTask
   }
 
   interface GenerateSchemaWorkParameters : WorkParameters {
-    val sourceFolders: Property<List<File>>
+    val sourceFolders: ListProperty<File>
     val outputDirectory: DirectoryProperty
     val moduleName: Property<String>
   }

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightTask.kt
@@ -38,10 +38,9 @@ import java.io.File
 @CacheableTask
 open class SqlDelightTask : SourceTask() {
   @Suppress("unused") // Required to invalidate the task on version updates.
-  @Input fun pluginVersion() = VERSION
+  @Input val pluginVersion = VERSION
 
   @get:OutputDirectory
-  @get:PathSensitive(PathSensitivity.RELATIVE)
   var outputDirectory: File? = null
 
   @Internal lateinit var sourceFolders: Iterable<File>

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/VerifyMigrationTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/VerifyMigrationTask.kt
@@ -21,7 +21,7 @@ import java.io.File
 
 open class VerifyMigrationTask : SourceTask() {
   @Suppress("unused") // Required to invalidate the task on version updates.
-  @Input fun pluginVersion() = VERSION
+  @Input val pluginVersion = VERSION
 
   /** Directory where the database files are copied for the migration scripts to run against. */
   @Internal lateinit var workingDirectory: File


### PR DESCRIPTION
Gradle 6.1 has issues resolving `co.touchlab.testhelp` (and maybe all mpp deps) so just going to stay on 5.6 for now so we can get a healthy release out

this does fix some of the other annotation-related issues that 6.1 was having so hopefully the future upgrade will be easier