### PR TITLE
Couple small actions updates

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v2
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
       - name: Cache gradle
         uses: actions/cache@v1
         with:

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Cache gradle
         uses: actions/cache@v1
         with:

--- a/.github/workflows/Publish-Website.yml
+++ b/.github/workflows/Publish-Website.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Prep mkdocs
         run: .github/workflows/prepare_mkdocs.sh

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout the repo
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Publish the macOS artifacts
       env:
         ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME }}
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Publish the windows artifact
         env:
           ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME }}
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Publish the plugin artifacts
         env:
           ORG_GRADLE_PROJECT_SQLDELIGHT_BUGSNAG_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SQLDELIGHT_BUGSNAG_KEY }}

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,5 +1,8 @@
 name: "Validate Gradle Wrapper"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   validation:


### PR DESCRIPTION
- Use checkout@v2 everywhere, which is substantially faster than v1
- Run gradle wrapper validation on PRs before any other gradle commands. This is good hygiene for first line of defense, as otherwise it just tries to race the other one. 