### PR TITLE
Move dialect ownership to the parser definition

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightEnvironment.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightEnvironment.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.sqldelight.core
 
+import com.alecstrong.sqlite.psi.core.DialectPreset
 import com.alecstrong.sqlite.psi.core.SqliteAnnotationHolder
 import com.alecstrong.sqlite.psi.core.SqliteCoreEnvironment
 import com.alecstrong.sqlite.psi.core.psi.SqliteCreateTableStmt
@@ -44,6 +45,7 @@ import com.squareup.sqldelight.core.psi.SqlDelightImportStmt
 import java.io.File
 import java.util.ArrayList
 import java.util.StringTokenizer
+import java.lang.UnsupportedOperationException
 import kotlin.system.measureTimeMillis
 
 /**
@@ -62,7 +64,7 @@ class SqlDelightEnvironment(
     /**
      * The package name to be used for the generated SqlDelightDatabase class.
      */
-    private val properties: SqlDelightDatabaseProperties? = null,
+    private val properties: SqlDelightDatabaseProperties,
     /**
      * An output directory to place the generated class files.
      */
@@ -84,6 +86,10 @@ class SqlDelightEnvironment(
   }
 
   override fun module(vFile: VirtualFile) = module
+
+  override var dialectPreset: DialectPreset
+    get() = properties!!.dialectPreset
+    set(value) { throw UnsupportedOperationException() }
 
   /**
    * Run the SQLDelight compiler and return the error or success status.

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightProjectService.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightProjectService.kt
@@ -15,12 +15,15 @@
  */
 package com.squareup.sqldelight.core
 
+import com.alecstrong.sqlite.psi.core.DialectPreset
 import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 
 interface SqlDelightProjectService {
+  var dialectPreset: DialectPreset
+
   fun module(vFile: VirtualFile): Module?
 
   companion object {

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightPropertiesFile.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightPropertiesFile.kt
@@ -50,7 +50,21 @@ data class SqlDelightDatabaseProperties(
   val className: String,
   val dependencies: List<SqlDelightDatabaseName>,
   val dialectPreset: DialectPreset = DialectPreset.SQLITE
-)
+) {
+  fun toJson(): String {
+    return adapter.toJson(this)
+  }
+
+  companion object {
+    private val adapter by lazy {
+      val moshi = Moshi.Builder().build()
+
+      return@lazy moshi.adapter(SqlDelightDatabaseProperties::class.java)
+    }
+
+    fun fromText(text: String) = adapter.fromJson(text)
+  }
+}
 
 /**
  * A compilation unit represents the group of .sq files which will be compiled all at once. A

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/SqlDelightParserDefinition.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/SqlDelightParserDefinition.kt
@@ -15,23 +15,31 @@
  */
 package com.squareup.sqldelight.core.lang
 
+import com.alecstrong.sqlite.psi.core.DialectPreset
+import com.alecstrong.sqlite.psi.core.SqliteParser
 import com.alecstrong.sqlite.psi.core.SqliteParserDefinition
-import com.intellij.lang.ASTNode
-import com.intellij.lang.PsiBuilder
-import com.intellij.lang.parser.GeneratedParserUtilBase.Parser
+import com.intellij.openapi.project.Project
 import com.intellij.psi.FileViewProvider
-import com.intellij.psi.PsiElement
 import com.intellij.psi.tree.IFileElementType
+import com.squareup.sqldelight.core.SqlDelightProjectService
 import com.squareup.sqldelight.core.SqldelightParserUtil
 
 class SqlDelightParserDefinition: SqliteParserDefinition() {
-  init {
-    SqldelightParserUtil.overrideSqliteParser()
-  }
+  private var dialect: DialectPreset? = null
 
   override fun createFile(viewProvider: FileViewProvider) = SqlDelightFile(viewProvider)
   override fun getFileNodeType() = FILE
   override fun getLanguage() = SqlDelightLanguage
+
+  override fun createParser(project: Project): SqliteParser {
+    val newDialect = SqlDelightProjectService.getInstance(project).dialectPreset
+    if (newDialect != dialect) {
+      newDialect.setup()
+      SqldelightParserUtil.overrideSqliteParser()
+      dialect = newDialect
+    }
+    return super.createParser(project)
+  }
 
   companion object {
     private val FILE = IFileElementType(SqlDelightLanguage)

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/GenerateSchemaTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/GenerateSchemaTask.kt
@@ -1,6 +1,7 @@
 package com.squareup.sqldelight.gradle
 
 import com.squareup.sqldelight.VERSION
+import com.squareup.sqldelight.core.SqlDelightDatabaseProperties
 import com.squareup.sqldelight.core.SqlDelightEnvironment
 import com.squareup.sqldelight.core.lang.SqlDelightFile
 import com.squareup.sqldelight.core.lang.util.forInitializationStatements
@@ -37,6 +38,7 @@ abstract class GenerateSchemaTask : SourceTask() {
   var outputDirectory: File? = null
 
   @Internal lateinit var sourceFolders: Iterable<File>
+  @Internal @Input lateinit var properties: SqlDelightDatabaseProperties
 
   @TaskAction
   fun generateSchemaFile() {
@@ -44,6 +46,7 @@ abstract class GenerateSchemaTask : SourceTask() {
       it.sourceFolders.set(sourceFolders.filter(File::exists))
       it.outputDirectory.set(outputDirectory)
       it.moduleName.set(project.name)
+      it.propertiesJson.set(properties.toJson())
     }
   }
 
@@ -58,6 +61,7 @@ abstract class GenerateSchemaTask : SourceTask() {
     val sourceFolders: ListProperty<File>
     val outputDirectory: DirectoryProperty
     val moduleName: Property<String>
+    val propertiesJson: Property<String>
   }
 
   abstract class GenerateSchema : WorkAction<GenerateSchemaWorkParameters> {
@@ -65,7 +69,8 @@ abstract class GenerateSchemaTask : SourceTask() {
       val environment = SqlDelightEnvironment(
           sourceFolders = parameters.sourceFolders.get(),
           dependencyFolders = emptyList(),
-          moduleName = parameters.moduleName.get()
+          moduleName = parameters.moduleName.get(),
+          properties = SqlDelightDatabaseProperties.fromText(parameters.propertiesJson.get())!!
       )
 
       var maxVersion = 1

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightDatabase.kt
@@ -152,6 +152,7 @@ class SqlDelightDatabase(
           it.workingDirectory = File(project.buildDir, "sqldelight/migration_verification/${source.name.capitalize()}$name")
           it.group = "sqldelight"
           it.description = "Verify ${source.name} $name migrations and CREATE statements match."
+          it.properties = getProperties()
         }
 
     if (schemaOutputDirectory != null) {
@@ -163,6 +164,7 @@ class SqlDelightDatabase(
         it.include("**${File.separatorChar}*.${MigrationFileType.defaultExtension}")
         it.group = "sqldelight"
         it.description = "Generate a .db file containing the current $name schema for ${source.name}."
+        it.properties = getProperties()
       }
     }
     project.tasks.named("check").configure {

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightTask.kt
@@ -61,9 +61,6 @@ open class SqlDelightTask : SourceTask() {
       )
     }
 
-    properties.dialectPreset.setup()
-    SqldelightParserUtil.overrideSqliteParser()
-
     val generationStatus = environment.generateSqlDelightFiles { info ->
       logger.log(INFO, info)
     }

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/VerifyMigrationTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/VerifyMigrationTask.kt
@@ -1,6 +1,7 @@
 package com.squareup.sqldelight.gradle
 
 import com.squareup.sqldelight.VERSION
+import com.squareup.sqldelight.core.SqlDelightDatabaseProperties
 import com.squareup.sqldelight.core.SqlDelightEnvironment
 import com.squareup.sqldelight.core.lang.SqlDelightFile
 import com.squareup.sqldelight.core.lang.util.forInitializationStatements
@@ -27,12 +28,14 @@ open class VerifyMigrationTask : SourceTask() {
   @Internal lateinit var workingDirectory: File
 
   @Internal lateinit var sourceFolders: Iterable<File>
+  @Internal @Input lateinit var properties: SqlDelightDatabaseProperties
 
   private val environment by lazy {
     SqlDelightEnvironment(
         sourceFolders = sourceFolders.filter { it.exists() },
         dependencyFolders = emptyList(),
-        moduleName = project.name
+        moduleName = project.name,
+        properties = properties
     )
   }
 


### PR DESCRIPTION
This means the IDE plugin also picks up dialect changes on gradle sync, however the parser is project specific so you cant mix dialects in a single project. Which I think is fine in practice? I guess we'll roll with it for now and see when it breaks