### PR TITLE
Fix the return type of avg() to be nullable

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/util/ExprUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/util/ExprUtil.kt
@@ -179,7 +179,8 @@ private fun SqlFunctionExpr.functionType() = result@when (functionName.text.toLo
   }
 
   "randomblob", "zeroblob" -> IntermediateType(BLOB)
-  "total", "avg" -> IntermediateType(REAL)
+  "total" -> IntermediateType(REAL)
+  "avg" -> IntermediateType(REAL).asNullable()
   "abs", "likelihood", "likely", "unlikely" -> exprList[0].type()
   "coalesce", "ifnull" -> encapsulatingType(exprList, INTEGER, REAL, TEXT, BLOB)
   "nullif" -> exprList[0].type().asNullable()

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/ExpressionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/ExpressionTest.kt
@@ -211,20 +211,44 @@ class ExpressionTest {
     ).inOrder()
   }
 
-  @Test fun `aggregate real functions return non null reals`() {
+  @Test fun `total function returns non null real`() {
     val file = FixtureCompiler.parseSql("""
       |CREATE TABLE test (
       |  value INTEGER
       |);
       |
       |someSelect:
-      |SELECT total(value), avg(value)
+      |SELECT total(value)
       |FROM test;
       """.trimMargin(), tempFolder)
 
     val query = file.namedQueries.first()
     assertThat(query.resultColumns.map { it.javaType }).containsExactly(
-        DOUBLE, DOUBLE
+        DOUBLE
+    ).inOrder()
+  }
+
+  /**
+   * avg's output is nullable because it returns NULL for an input that's empty
+   * or only contains NULLs.
+   *
+   * https://www.sqlite.org/lang_aggfunc.html#avg:
+   * >> The result of avg() is NULL if and only if there are no non-NULL inputs.
+   */
+  @Test fun `avg function returns nullable real`() {
+    val file = FixtureCompiler.parseSql("""
+    |CREATE TABLE test (
+    |  value INTEGER
+    |);
+    |
+    |someSelect:
+    |SELECT avg(value)
+    |FROM test;
+    """.trimMargin(), tempFolder)
+
+    val query = file.namedQueries.first()
+    assertThat(query.resultColumns.map { it.javaType }).containsExactly(
+        DOUBLE.copy(nullable = true)
     ).inOrder()
   }
 


### PR DESCRIPTION
Fixes [#1596: Return type of avg() should be nullable](https://github.com/cashapp/sqldelight/issues/1596)