### PR TITLE
Add Coroutines Extension Documentation

### DIFF
--- a/docs/coroutines.md
+++ b/docs/coroutines.md
@@ -1,0 +1,18 @@
+# Coroutines Flow
+
+To consume a query as a Flow, depend on the Coroutines extensions artifact and use the extension method it provides:
+
+```groovy
+dependencies {
+  implementation "com.squareup.sqldelight:coroutines-extensions:1.2.1"
+}
+```
+
+```kotlin
+val players: Flow<List<HockeyPlayer>> = 
+  playerQueries.selectAll()
+    .asFlow()
+    .mapToList()
+```
+
+This flow emits the query result, and emits a new result every time the database changes for that query.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
   - 'Custom Column Types': custom_column_types.md
   - 'Migrations': migrations.md
   - 'RxJava': rxjava.md
+  - 'Coroutines': coroutines.md
   - 'Multiplatform': multiplatform.md
   - 'Android Paging': android_paging.md
   - 'Supported Dialects': supported_dialects.md


### PR DESCRIPTION

There is documentation for RxJava [here](https://cashapp.github.io/sqldelight/rxjava/), so it made sense to add coroutines documentation in the same style.
