### PR TITLE
Fix iOS timestamp multiplication to respect milliseconds.

### DIFF
--- a/sample/common/src/iosMain/kotlin/com/example/sqldelight/hockey/data/Date.kt
+++ b/sample/common/src/iosMain/kotlin/com/example/sqldelight/hockey/data/Date.kt
@@ -22,5 +22,5 @@ actual class DateAdapter actual constructor() : ColumnAdapter<Date, Long> {
       Date(NSDate.dateWithTimeIntervalSince1970(databaseValue.toDouble() / 1000))
 
   override fun encode(value: Date): Long =
-      floor(value.nsDate.timeIntervalSince1970).toLong() * 1000L
+      floor(value.nsDate.timeIntervalSince1970 * 1000L).toLong()
 }


### PR DESCRIPTION
Otherwise the last three digits will always be `000`