### PR TITLE
start MySQL on Ubuntu before running tests

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -37,6 +37,9 @@ jobs:
         with:
           path: lib/download
           key: intellij-${{ hashFiles('gradle/dependencies.gradle') }}
+      - name: Start MySQL
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo /etc/init.d/mysql start
 
       - name: Run ubuntu tests
         if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
This fixes CI which was broken by this change
https://github.blog/changelog/2020-02-21-github-actions-breaking-change-ubuntu-virtual-environments-will-no-longer-start-the-mysql-service-automatically/