### PR TITLE
CI: validate Gradle wrapper on pushes and PRs

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,8 +1,5 @@
 name: "Validate Gradle Wrapper"
-on:
-  push:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
   validation:


### PR DESCRIPTION
To align with KotlinPoet (see https://github.com/square/kotlinpoet/pull/894)