### PR TITLE
Fix inconsistency in directory name sanitizing

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightEnvironment.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightEnvironment.kt
@@ -69,11 +69,12 @@ class SqlDelightEnvironment(
      * An output directory to place the generated class files.
      */
     private val outputDirectory: File? = null,
-    private val moduleName: String
+    moduleName: String
 ) : SqlCoreEnvironment(SqlDelightParserDefinition(), SqlDelightFileType, sourceFolders),
     SqlDelightProjectService {
   val project: Project = projectEnvironment.project
   val module = MockModule(project, project)
+  private val moduleName = SqlDelightFileIndex.sanitizeDirectoryName(moduleName)
 
   init {
     SqlDelightFileIndex.setInstance(module, FileIndex())
@@ -270,7 +271,7 @@ class SqlDelightEnvironment(
 
       for (sourceFolder in sourceFolders(file)) {
         val path = file.parent!!.relativePathUnder(sourceFolder)
-        if (path != null) return path.joinToString(separator = ".")
+        if (path != null) return path.joinToString(separator = ".") { SqlDelightFileIndex.sanitizeDirectoryName(it) }
       }
 
       throw IllegalStateException("Tried to find package name of file ${file.virtualFile!!.path} when" +

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightFileIndex.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightFileIndex.kt
@@ -106,5 +106,9 @@ interface SqlDelightFileIndex {
         })
       }
     }
+
+    fun sanitizeDirectoryName(name: String): String {
+      return name.filter(Char::isLetter)
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightTask.kt
@@ -20,7 +20,6 @@ import com.squareup.sqldelight.core.SqlDelightDatabaseProperties
 import com.squareup.sqldelight.core.SqlDelightEnvironment
 import com.squareup.sqldelight.core.SqlDelightEnvironment.CompilationStatus.Failure
 import com.squareup.sqldelight.core.SqlDelightException
-import com.squareup.sqldelight.core.SqldelightParserUtil
 import org.gradle.api.file.FileTree
 import org.gradle.api.logging.LogLevel.ERROR
 import org.gradle.api.logging.LogLevel.INFO
@@ -57,7 +56,7 @@ open class SqlDelightTask : SourceTask() {
           dependencyFolders = dependencySourceFolders.filter { it.exists() },
           properties = properties,
           outputDirectory = outputDirectory,
-          moduleName = project.name.filter { it.isLetter() }
+          moduleName = project.name
       )
     }
 

--- a/test-util/src/main/kotlin/com/squareup/sqldelight/test/util/TestEnvironment.kt
+++ b/test-util/src/main/kotlin/com/squareup/sqldelight/test/util/TestEnvironment.kt
@@ -31,7 +31,8 @@ internal class TestEnvironment(private val outputDirectory: File = File("output"
             dialectPreset = DialectPreset.SQLITE_3_18
         ),
         outputDirectory = outputDirectory,
-        moduleName = "testmodule"
+        // hyphen in the name tests that our module name sanitizing works correctly
+        moduleName = "test-module"
     )
     environment.annotate(annotationHolder)
     return environment


### PR DESCRIPTION
Before, if a project was named `taco-db`, the implementation package would correctly sanitize it to `tacodb` for the package name. The `FileIndex` used to generate later references to the generated implementation didn't do this same directory name sanitizing though, so it would try to generate a a package name with ``taco-db`` in it, which wasn't right and would fail to compile.

This tries to unify their behavior with a shared function.