### PR TITLE
Expose query data class instead of its interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ val database = Database(driver)
 val playerQueries: PlayerQueries = database.playerQueries
 
 println(playerQueries.selectAll().executeAsList())
-// Prints [HockeyPlayer.Impl(15, "Ryan Getzlaf")]
+// Prints [HockeyPlayer(15, "Ryan Getzlaf")]
 
 playerQueries.insert(player_number = 10, full_name = "Corey Perry")
 println(playerQueries.selectAll().executeAsList())
-// Prints [HockeyPlayer.Impl(15, "Ryan Getzlaf"), HockeyPlayer.Impl(10, "Corey Perry")]
+// Prints [HockeyPlayer(15, "Ryan Getzlaf"), HockeyPlayer(10, "Corey Perry")]
 
 val player = HockeyPlayer(10, "Ronald McDonald")
 playerQueries.insertFullPlayerObject(player)

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,11 +91,11 @@ val database = Database(driver)
 val playerQueries: PlayerQueries = database.playerQueries
 
 println(playerQueries.selectAll().executeAsList())
-// Prints [HockeyPlayer.Impl(15, "Ryan Getzlaf")]
+// Prints [HockeyPlayer(15, "Ryan Getzlaf")]
 
 playerQueries.insert(player_number = 10, full_name = "Corey Perry")
 println(playerQueries.selectAll().executeAsList())
-// Prints [HockeyPlayer.Impl(15, "Ryan Getzlaf"), HockeyPlayer.Impl(10, "Corey Perry")]
+// Prints [HockeyPlayer(15, "Ryan Getzlaf"), HockeyPlayer(10, "Corey Perry")]
 
 val player = HockeyPlayer(10, "Ronald McDonald")
 playerQueries.insertFullPlayerObject(player)

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/Group.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/Group.kt
@@ -3,16 +3,12 @@ package com.example
 import kotlin.Long
 import kotlin.String
 
-interface Group {
+data class Group(
   val index: Long
-
-  data class Impl(
-    override val index: Long
-  ) : Group {
-    override fun toString(): String = """
-    |Group.Impl [
-    |  index: $index
-    |]
-    """.trimMargin()
-  }
+) {
+  override fun toString(): String = """
+  |Group [
+  |  index: $index
+  |]
+  """.trimMargin()
 }

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/Player.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/Player.kt
@@ -5,32 +5,22 @@ import com.squareup.sqldelight.core.integration.Shoots
 import kotlin.Long
 import kotlin.String
 
-interface Player {
-  val name: String
-
-  val number: Long
-
-  val team: String?
-
+data class Player(
+  val name: String,
+  val number: Long,
+  val team: String?,
   val shoots: Shoots
+) {
+  override fun toString(): String = """
+  |Player [
+  |  name: $name
+  |  number: $number
+  |  team: $team
+  |  shoots: $shoots
+  |]
+  """.trimMargin()
 
   class Adapter(
     val shootsAdapter: ColumnAdapter<Shoots, String>
   )
-
-  data class Impl(
-    override val name: String,
-    override val number: Long,
-    override val team: String?,
-    override val shoots: Shoots
-  ) : Player {
-    override fun toString(): String = """
-    |Player.Impl [
-    |  name: $name
-    |  number: $number
-    |  team: $team
-    |  shoots: $shoots
-    |]
-    """.trimMargin()
-  }
 }

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/SelectNull.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/SelectNull.kt
@@ -3,16 +3,12 @@ package com.example
 import java.lang.Void
 import kotlin.String
 
-interface SelectNull {
+data class SelectNull(
   val expr: Void?
-
-  data class Impl(
-    override val expr: Void?
-  ) : SelectNull {
-    override fun toString(): String = """
-    |SelectNull.Impl [
-    |  expr: $expr
-    |]
-    """.trimMargin()
-  }
+) {
+  override fun toString(): String = """
+  |SelectNull [
+  |  expr: $expr
+  |]
+  """.trimMargin()
 }

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/Team.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/Team.kt
@@ -5,32 +5,22 @@ import com.squareup.sqldelight.core.integration.Shoots
 import kotlin.Long
 import kotlin.String
 
-interface Team {
-  val name: String
-
-  val captain: Long
-
-  val inner_type: Shoots.Type?
-
+data class Team(
+  val name: String,
+  val captain: Long,
+  val inner_type: Shoots.Type?,
   val coach: String
+) {
+  override fun toString(): String = """
+  |Team [
+  |  name: $name
+  |  captain: $captain
+  |  inner_type: $inner_type
+  |  coach: $coach
+  |]
+  """.trimMargin()
 
   class Adapter(
     val inner_typeAdapter: ColumnAdapter<Shoots.Type, String>
   )
-
-  data class Impl(
-    override val name: String,
-    override val captain: Long,
-    override val inner_type: Shoots.Type?,
-    override val coach: String
-  ) : Team {
-    override fun toString(): String = """
-    |Team.Impl [
-    |  name: $name
-    |  captain: $captain
-    |  inner_type: $inner_type
-    |  coach: $coach
-    |]
-    """.trimMargin()
-  }
 }

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/testmodule/TestDatabaseImpl.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/testmodule/TestDatabaseImpl.kt
@@ -110,7 +110,7 @@ private class TeamQueriesImpl(
     )
   }
 
-  override fun teamForCoach(coach: String): Query<Team> = teamForCoach(coach, Team::Impl)
+  override fun teamForCoach(coach: String): Query<Team> = teamForCoach(coach, ::Team)
 
   override fun <T : Any> forInnerType(inner_type: Shoots.Type?, mapper: (
     name: String,
@@ -127,7 +127,7 @@ private class TeamQueriesImpl(
   }
 
   override fun forInnerType(inner_type: Shoots.Type?): Query<Team> = forInnerType(inner_type,
-      Team::Impl)
+      ::Team)
 
   private inner class TeamForCoach<out T : Any>(
     @JvmField
@@ -192,7 +192,7 @@ private class PlayerQueriesImpl(
     )
   }
 
-  override fun allPlayers(): Query<Player> = allPlayers(Player::Impl)
+  override fun allPlayers(): Query<Player> = allPlayers(::Player)
 
   override fun <T : Any> playersForTeam(team: String?, mapper: (
     name: String,
@@ -208,7 +208,7 @@ private class PlayerQueriesImpl(
     )
   }
 
-  override fun playersForTeam(team: String?): Query<Player> = playersForTeam(team, Player::Impl)
+  override fun playersForTeam(team: String?): Query<Player> = playersForTeam(team, ::Player)
 
   override fun <T : Any> playersForNumbers(number: Collection<Long>, mapper: (
     name: String,
@@ -225,7 +225,7 @@ private class PlayerQueriesImpl(
   }
 
   override fun playersForNumbers(number: Collection<Long>): Query<Player> =
-      playersForNumbers(number, Player::Impl)
+      playersForNumbers(number, ::Player)
 
   override fun <T : Any> selectNull(mapper: (expr: Void?) -> T): Query<T> = Query(106890351,
       selectNull, driver, "Player.sq", "selectNull", "SELECT NULL") { cursor ->
@@ -234,7 +234,7 @@ private class PlayerQueriesImpl(
     )
   }
 
-  override fun selectNull(): Query<SelectNull> = selectNull(SelectNull::Impl)
+  override fun selectNull(): Query<SelectNull> = selectNull(::SelectNull)
 
   override fun insertPlayer(
     name: String,

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/squareup/sqldelight/core/integration/IntegrationTest.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/squareup/sqldelight/core/integration/IntegrationTest.kt
@@ -155,8 +155,8 @@ class IntegrationTest {
     })
 
     assertThat(allPlayers.executeAsList()).containsExactly(
-        Player.Impl("Ryan Getzlaf", 15, "Anaheim Ducks", RIGHT),
-        Player.Impl("Erik Karlsson", 65, "Ottawa Senators", RIGHT)
+        Player("Ryan Getzlaf", 15, "Anaheim Ducks", RIGHT),
+        Player("Erik Karlsson", 65, "Ottawa Senators", RIGHT)
     )
 
     queryWrapper.playerQueries.insertPlayer("Sidney Crosby", 87, "Pittsburgh Penguins", LEFT)
@@ -164,9 +164,9 @@ class IntegrationTest {
     assertThat(resultSetChanged.get()).isEqualTo(1)
 
     assertThat(allPlayers.executeAsList()).containsExactly(
-        Player.Impl("Ryan Getzlaf", 15, "Anaheim Ducks", RIGHT),
-        Player.Impl("Erik Karlsson", 65, "Ottawa Senators", RIGHT),
-        Player.Impl("Sidney Crosby", 87, "Pittsburgh Penguins", LEFT)
+        Player("Ryan Getzlaf", 15, "Anaheim Ducks", RIGHT),
+        Player("Erik Karlsson", 65, "Ottawa Senators", RIGHT),
+        Player("Sidney Crosby", 87, "Pittsburgh Penguins", LEFT)
     )
   }
 
@@ -181,7 +181,7 @@ class IntegrationTest {
     })
 
     assertThat(teamForCoach.executeAsList()).containsExactly(
-        Team.Impl("Anaheim Ducks", 15, null, "Randy Carlyle")
+        Team("Anaheim Ducks", 15, null, "Randy Carlyle")
     )
 
     queryWrapper.playerQueries.insertPlayer("Sidney Crosby", 87, "Pittsburgh Penguins", LEFT)
@@ -200,7 +200,7 @@ class IntegrationTest {
     })
 
     assertThat(playersForNumbers.executeAsList()).containsExactly(
-        Player.Impl("Ryan Getzlaf", 15, "Anaheim Ducks", RIGHT)
+        Player("Ryan Getzlaf", 15, "Anaheim Ducks", RIGHT)
     )
 
     queryWrapper.playerQueries.insertPlayer("Sidney Crosby", 87, "Pittsburgh Penguins", LEFT)
@@ -208,8 +208,8 @@ class IntegrationTest {
     assertThat(resultSetChanged.get()).isEqualTo(1)
 
     assertThat(playersForNumbers.executeAsList()).containsExactly(
-        Player.Impl("Ryan Getzlaf", 15, "Anaheim Ducks", RIGHT),
-        Player.Impl("Sidney Crosby", 87, "Pittsburgh Penguins", LEFT)
+        Player("Ryan Getzlaf", 15, "Anaheim Ducks", RIGHT),
+        Player("Sidney Crosby", 87, "Pittsburgh Penguins", LEFT)
     )
   }
 
@@ -224,7 +224,7 @@ class IntegrationTest {
     })
 
     assertThat(playersForNumbers.executeAsList()).containsExactly(
-        Player.Impl("Ryan Getzlaf", 15, "Anaheim Ducks", RIGHT)
+        Player("Ryan Getzlaf", 15, "Anaheim Ducks", RIGHT)
     )
 
     queryWrapper.playerQueries.transaction {
@@ -235,9 +235,9 @@ class IntegrationTest {
     assertThat(resultSetChanged.get()).isEqualTo(1)
 
     assertThat(playersForNumbers.executeAsList()).containsExactly(
-        Player.Impl("Ryan Getzlaf", 15, "Anaheim Ducks", RIGHT),
-        Player.Impl("Sidney Crosby", 87, "Pittsburgh Penguins", LEFT),
-        Player.Impl("Corey Perry", 10, "Anaheim Ducks", RIGHT)
+        Player("Ryan Getzlaf", 15, "Anaheim Ducks", RIGHT),
+        Player("Sidney Crosby", 87, "Pittsburgh Penguins", LEFT),
+        Player("Corey Perry", 10, "Anaheim Ducks", RIGHT)
     )
   }
 
@@ -252,7 +252,7 @@ class IntegrationTest {
     })
 
     assertThat(playersForTeam.executeAsList()).containsExactly(
-        Player.Impl("Ryan Getzlaf", 15, "Anaheim Ducks", RIGHT)
+        Player("Ryan Getzlaf", 15, "Anaheim Ducks", RIGHT)
     )
 
     queryWrapper.playerQueries.transaction {
@@ -262,8 +262,8 @@ class IntegrationTest {
     assertThat(resultSetChanged.get()).isEqualTo(1)
 
     assertThat(playersForTeam.executeAsList()).containsExactly(
-        Player.Impl("Ryan Getzlaf", 15, "Anaheim Ducks", RIGHT),
-        Player.Impl("Erik Karlsson", 65, "Anaheim Ducks", RIGHT)
+        Player("Ryan Getzlaf", 15, "Anaheim Ducks", RIGHT),
+        Player("Erik Karlsson", 65, "Anaheim Ducks", RIGHT)
     )
   }
 
@@ -278,7 +278,7 @@ class IntegrationTest {
     })
 
     assertThat(playersForTeam.executeAsList()).containsExactly(
-        Player.Impl("Ryan Getzlaf", 15, "Anaheim Ducks", RIGHT)
+        Player("Ryan Getzlaf", 15, "Anaheim Ducks", RIGHT)
     )
 
     queryWrapper.playerQueries.transaction {
@@ -289,9 +289,9 @@ class IntegrationTest {
     assertThat(resultSetChanged.get()).isEqualTo(1)
 
     assertThat(playersForTeam.executeAsList()).containsExactly(
-        Player.Impl("Ryan Getzlaf", 15, "Anaheim Ducks", RIGHT),
-        Player.Impl("Erik Karlsson", 65, "Anaheim Ducks", RIGHT),
-        Player.Impl("Sidney Crosby", 87, "Anaheim Ducks", LEFT)
+        Player("Ryan Getzlaf", 15, "Anaheim Ducks", RIGHT),
+        Player("Erik Karlsson", 65, "Anaheim Ducks", RIGHT),
+        Player("Sidney Crosby", 87, "Anaheim Ducks", LEFT)
     )
   }
 
@@ -305,7 +305,7 @@ class IntegrationTest {
 
   @Test fun `inner type query`() {
     assertThat(queryWrapper.teamQueries.forInnerType(ONE).executeAsList()).containsExactly(
-        Team.Impl("Ottawa Senators", 65, ONE, "Guy Boucher")
+        Team("Ottawa Senators", 65, ONE, "Guy Boucher")
     )
   }
 }

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/QueryInterfaceGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/QueryInterfaceGenerator.kt
@@ -15,37 +15,33 @@
  */
 package com.squareup.sqldelight.core.compiler
 
-import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.DATA
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
-import com.squareup.kotlinpoet.KModifier.PUBLIC
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.joinToCode
 import com.squareup.sqldelight.core.compiler.model.NamedQuery
-import com.squareup.sqldelight.core.lang.IMPLEMENTATION_NAME
 import com.squareup.sqldelight.core.lang.psi.ColumnDefMixin.Companion.isArrayType
-import com.squareup.sqldelight.core.lang.util.sqFile
 
 class QueryInterfaceGenerator(val query: NamedQuery) {
-  private fun kotlinImplementationSpec(): TypeSpec {
-    val typeSpec = TypeSpec.classBuilder(IMPLEMENTATION_NAME)
+  fun kotlinImplementationSpec(): TypeSpec {
+    val typeSpec = TypeSpec.classBuilder(query.name.capitalize())
         .addModifiers(DATA)
-        .addSuperinterface(ClassName(query.select.sqFile().packageName, query.name.capitalize()))
 
     val propertyPrints = mutableListOf<CodeBlock>()
     val contentToString = MemberName("kotlin.collections", "contentToString")
+
     val constructor = FunSpec.constructorBuilder()
 
     query.resultColumns.forEach {
-      typeSpec.addProperty(PropertySpec.builder(it.name, it.javaType, OVERRIDE)
+      typeSpec.addProperty(PropertySpec.builder(it.name, it.javaType)
           .initializer(it.name)
           .build())
-      constructor.addParameter(it.name, it.javaType, OVERRIDE)
+      constructor.addParameter(it.name, it.javaType)
 
       propertyPrints += if (it.javaType.isArrayType) {
         CodeBlock.of("${it.name}: \${${it.name}.%M()}", contentToString)
@@ -59,24 +55,14 @@ class QueryInterfaceGenerator(val query: NamedQuery) {
         .addModifiers(OVERRIDE)
         .addStatement("return %L", propertyPrints.joinToCode(
             separator = "\n|  ",
-            prefix = "\"\"\"\n|${query.name.capitalize()}.$IMPLEMENTATION_NAME [\n|  ",
+            prefix = "\"\"\"\n|${query.name.capitalize()} [\n|  ",
             suffix = "\n|]\n\"\"\".trimMargin()")
         )
         .build()
     )
 
-    return typeSpec.primaryConstructor(constructor.build()).build()
-  }
-
-  fun kotlinInterfaceSpec(): TypeSpec {
-    val typeSpec = TypeSpec.interfaceBuilder(query.name.capitalize())
-
-    query.resultColumns.forEach {
-      typeSpec.addProperty(it.name, it.javaType, PUBLIC)
-    }
-
     return typeSpec
-        .addType(kotlinImplementationSpec())
+        .primaryConstructor(constructor.build())
         .build()
   }
 }

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/SelectQueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/SelectQueryGenerator.kt
@@ -36,7 +36,6 @@ import com.squareup.sqldelight.core.lang.CURSOR_NAME
 import com.squareup.sqldelight.core.lang.CURSOR_TYPE
 import com.squareup.sqldelight.core.lang.DRIVER_NAME
 import com.squareup.sqldelight.core.lang.EXECUTE_METHOD
-import com.squareup.sqldelight.core.lang.IMPLEMENTATION_NAME
 import com.squareup.sqldelight.core.lang.MAPPER_NAME
 import com.squareup.sqldelight.core.lang.QUERY_LIST_TYPE
 import com.squareup.sqldelight.core.lang.QUERY_TYPE
@@ -55,7 +54,7 @@ class SelectQueryGenerator(private val query: NamedQuery) : QueryGenerator(query
     query.arguments.sortedBy { it.index }.forEach { (_, argument) ->
       params.add(CodeBlock.of(argument.name))
     }
-    params.add(CodeBlock.of("%T::$IMPLEMENTATION_NAME", query.interfaceType))
+    params.add(CodeBlock.of("::%T", query.interfaceType))
     return function
         .addStatement("return %L", params.joinToCode(", ", "${query.name}(", ")"))
         .build()

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/SqlDelightCompiler.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/SqlDelightCompiler.kt
@@ -109,7 +109,7 @@ object SqlDelightCompiler {
               .apply {
                 tryWithElement(createTable) {
                   val generator = TableInterfaceGenerator(createTable)
-                  addType(generator.kotlinInterfaceSpec())
+                  addType(generator.kotlinImplementationSpec())
                 }
               }
               .build()
@@ -164,7 +164,7 @@ object SqlDelightCompiler {
               .apply {
                 tryWithElement(namedQuery.select) {
                   val generator = QueryInterfaceGenerator(namedQuery)
-                  addType(generator.kotlinInterfaceSpec())
+                  addType(generator.kotlinImplementationSpec())
                 }
               }
               .build()

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/Constants.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/Constants.kt
@@ -16,8 +16,6 @@ internal val DATABASE_SCHEMA_TYPE = DRIVER_TYPE.nestedClass("Schema")
 
 internal val CUSTOM_DATABASE_NAME = "database"
 
-internal val IMPLEMENTATION_NAME = "Impl"
-
 internal val ADAPTER_NAME = "Adapter"
 
 internal val SqlCreateTableStmt.adapterName

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/QueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/QueriesTypeTest.kt
@@ -101,7 +101,7 @@ class QueriesTypeTest {
       |    )
       |  }
       |
-      |  override fun selectForId(id: Long): Query<Data> = selectForId(id, Data::Impl)
+      |  override fun selectForId(id: Long): Query<Data> = selectForId(id, ::Data)
       |
       |  override fun insertData(id: Long?, value: List?) {
       |    driver.execute(${insert.id}, ""${'"'}

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/ExpressionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/ExpressionTest.kt
@@ -30,7 +30,7 @@ class ExpressionTest {
 
     val generator = SelectQueryGenerator(file.namedQueries.first())
     assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo("""
-      |override fun testQuery(SecondId: kotlin.Long, value: kotlin.String): com.squareup.sqldelight.Query<com.example.Test> = testQuery(SecondId, value, com.example.Test::Impl)
+      |override fun testQuery(SecondId: kotlin.Long, value: kotlin.String): com.squareup.sqldelight.Query<com.example.Test> = testQuery(SecondId, value, ::com.example.Test)
       |""".trimMargin())
   }
 

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/InterfaceGeneration.kt
@@ -37,23 +37,17 @@ class InterfaceGeneration {
     """.trimMargin(), temporaryFolder)
 
     val query = file.namedQueries.first()
-    assertThat(QueryInterfaceGenerator(query).kotlinInterfaceSpec().toString()).isEqualTo("""
-      |interface LeftJoin {
-      |  val val1: kotlin.String
-      |
+    assertThat(QueryInterfaceGenerator(query).kotlinImplementationSpec().toString()).isEqualTo("""
+      |data class LeftJoin(
+      |  val val1: kotlin.String,
       |  val val2: kotlin.String?
-      |
-      |  data class Impl(
-      |    override val val1: kotlin.String,
-      |    override val val2: kotlin.String?
-      |  ) : com.example.LeftJoin {
-      |    override fun toString(): kotlin.String = ""${'"'}
-      |    |LeftJoin.Impl [
-      |    |  val1: ${"$"}val1
-      |    |  val2: ${"$"}val2
-      |    |]
-      |    ""${'"'}.trimMargin()
-      |  }
+      |) {
+      |  override fun toString(): kotlin.String = ""${'"'}
+      |  |LeftJoin [
+      |  |  val1: ${"$"}val1
+      |  |  val2: ${"$"}val2
+      |  |]
+      |  ""${'"'}.trimMargin()
       |}
       |""".trimMargin())
   }
@@ -74,23 +68,17 @@ class InterfaceGeneration {
     """.trimMargin(), temporaryFolder)
 
     val query = file.namedQueries.first()
-    assertThat(QueryInterfaceGenerator(query).kotlinInterfaceSpec().toString()).isEqualTo("""
-      |interface LeftJoin {
-      |  val value: kotlin.String
-      |
+    assertThat(QueryInterfaceGenerator(query).kotlinImplementationSpec().toString()).isEqualTo("""
+      |data class LeftJoin(
+      |  val value: kotlin.String,
       |  val value_: kotlin.String
-      |
-      |  data class Impl(
-      |    override val value: kotlin.String,
-      |    override val value_: kotlin.String
-      |  ) : com.example.LeftJoin {
-      |    override fun toString(): kotlin.String = ""${'"'}
-      |    |LeftJoin.Impl [
-      |    |  value: ${"$"}value
-      |    |  value_: ${"$"}value_
-      |    |]
-      |    ""${'"'}.trimMargin()
-      |  }
+      |) {
+      |  override fun toString(): kotlin.String = ""${'"'}
+      |  |LeftJoin [
+      |  |  value: ${"$"}value
+      |  |  value_: ${"$"}value_
+      |  |]
+      |  ""${'"'}.trimMargin()
       |}
       |""".trimMargin())
   }
@@ -114,23 +102,17 @@ class InterfaceGeneration {
     """.trimMargin(), temporaryFolder)
 
     val query = file.namedQueries.first()
-    assertThat(QueryInterfaceGenerator(query).kotlinInterfaceSpec().toString()).isEqualTo("""
-      |interface UnionOfBoth {
-      |  val value: kotlin.String?
-      |
+    assertThat(QueryInterfaceGenerator(query).kotlinImplementationSpec().toString()).isEqualTo("""
+      |data class UnionOfBoth(
+      |  val value: kotlin.String?,
       |  val value_: kotlin.String?
-      |
-      |  data class Impl(
-      |    override val value: kotlin.String?,
-      |    override val value_: kotlin.String?
-      |  ) : com.example.UnionOfBoth {
-      |    override fun toString(): kotlin.String = ""${'"'}
-      |    |UnionOfBoth.Impl [
-      |    |  value: ${"$"}value
-      |    |  value_: ${"$"}value_
-      |    |]
-      |    ""${'"'}.trimMargin()
-      |  }
+      |) {
+      |  override fun toString(): kotlin.String = ""${'"'}
+      |  |UnionOfBoth [
+      |  |  value: ${"$"}value
+      |  |  value_: ${"$"}value_
+      |  |]
+      |  ""${'"'}.trimMargin()
       |}
       |""".trimMargin())
   }
@@ -150,23 +132,17 @@ class InterfaceGeneration {
     """.trimMargin(), temporaryFolder)
 
     val query = file.namedQueries.first()
-    assertThat(QueryInterfaceGenerator(query).kotlinInterfaceSpec().toString()).isEqualTo("""
-      |interface UnionOfBoth {
-      |  val value: kotlin.collections.List
-      |
+    assertThat(QueryInterfaceGenerator(query).kotlinImplementationSpec().toString()).isEqualTo("""
+      |data class UnionOfBoth(
+      |  val value: kotlin.collections.List,
       |  val value_: kotlin.collections.List?
-      |
-      |  data class Impl(
-      |    override val value: kotlin.collections.List,
-      |    override val value_: kotlin.collections.List?
-      |  ) : com.example.UnionOfBoth {
-      |    override fun toString(): kotlin.String = ""${'"'}
-      |    |UnionOfBoth.Impl [
-      |    |  value: ${"$"}value
-      |    |  value_: ${"$"}value_
-      |    |]
-      |    ""${'"'}.trimMargin()
-      |  }
+      |) {
+      |  override fun toString(): kotlin.String = ""${'"'}
+      |  |UnionOfBoth [
+      |  |  value: ${"$"}value
+      |  |  value_: ${"$"}value_
+      |  |]
+      |  ""${'"'}.trimMargin()
       |}
       |""".trimMargin())
   }
@@ -186,23 +162,17 @@ class InterfaceGeneration {
     """.trimMargin(), temporaryFolder)
 
     val query = file.namedQueries.first()
-    assertThat(QueryInterfaceGenerator(query).kotlinInterfaceSpec().toString()).isEqualTo("""
-      |interface UnionOfBoth {
-      |  val value: kotlin.collections.List?
-      |
+    assertThat(QueryInterfaceGenerator(query).kotlinImplementationSpec().toString()).isEqualTo("""
+      |data class UnionOfBoth(
+      |  val value: kotlin.collections.List?,
       |  val expr: kotlin.collections.List?
-      |
-      |  data class Impl(
-      |    override val value: kotlin.collections.List?,
-      |    override val expr: kotlin.collections.List?
-      |  ) : com.example.UnionOfBoth {
-      |    override fun toString(): kotlin.String = ""${'"'}
-      |    |UnionOfBoth.Impl [
-      |    |  value: ${"$"}value
-      |    |  expr: ${"$"}expr
-      |    |]
-      |    ""${'"'}.trimMargin()
-      |  }
+      |) {
+      |  override fun toString(): kotlin.String = ""${'"'}
+      |  |UnionOfBoth [
+      |  |  value: ${"$"}value
+      |  |  expr: ${"$"}expr
+      |  |]
+      |  ""${'"'}.trimMargin()
       |}
       |""".trimMargin())
   }
@@ -222,23 +192,17 @@ class InterfaceGeneration {
     """.trimMargin(), temporaryFolder)
 
     val query = file.namedQueries.first()
-    assertThat(QueryInterfaceGenerator(query).kotlinInterfaceSpec().toString()).isEqualTo("""
-      |interface UnionOfBoth {
-      |  val value: kotlin.collections.List
-      |
+    assertThat(QueryInterfaceGenerator(query).kotlinImplementationSpec().toString()).isEqualTo("""
+      |data class UnionOfBoth(
+      |  val value: kotlin.collections.List,
       |  val expr: kotlin.collections.List
-      |
-      |  data class Impl(
-      |    override val value: kotlin.collections.List,
-      |    override val expr: kotlin.collections.List
-      |  ) : com.example.UnionOfBoth {
-      |    override fun toString(): kotlin.String = ""${'"'}
-      |    |UnionOfBoth.Impl [
-      |    |  value: ${"$"}value
-      |    |  expr: ${"$"}expr
-      |    |]
-      |    ""${'"'}.trimMargin()
-      |  }
+      |) {
+      |  override fun toString(): kotlin.String = ""${'"'}
+      |  |UnionOfBoth [
+      |  |  value: ${"$"}value
+      |  |  expr: ${"$"}expr
+      |  |]
+      |  ""${'"'}.trimMargin()
       |}
       |""".trimMargin())
   }
@@ -270,43 +234,27 @@ class InterfaceGeneration {
     """.trimMargin(), temporaryFolder)
 
     val query = file.namedQueries.first()
-    assertThat(QueryInterfaceGenerator(query).kotlinInterfaceSpec().toString()).isEqualTo("""
-      |interface Select_all {
-      |  val _id: kotlin.Long
-      |
-      |  val name: kotlin.String
-      |
-      |  val address: kotlin.String
-      |
-      |  val status: TestADbModel.Status
-      |
-      |  val _id_: kotlin.Long
-      |
-      |  val name_: kotlin.String
-      |
+    assertThat(QueryInterfaceGenerator(query).kotlinImplementationSpec().toString()).isEqualTo("""
+      |data class Select_all(
+      |  val _id: kotlin.Long,
+      |  val name: kotlin.String,
+      |  val address: kotlin.String,
+      |  val status: TestADbModel.Status,
+      |  val _id_: kotlin.Long,
+      |  val name_: kotlin.String,
       |  val address_: kotlin.String
-      |
-      |  data class Impl(
-      |    override val _id: kotlin.Long,
-      |    override val name: kotlin.String,
-      |    override val address: kotlin.String,
-      |    override val status: TestADbModel.Status,
-      |    override val _id_: kotlin.Long,
-      |    override val name_: kotlin.String,
-      |    override val address_: kotlin.String
-      |  ) : com.example.Select_all {
-      |    override fun toString(): kotlin.String = ""${'"'}
-      |    |Select_all.Impl [
-      |    |  _id: ${"$"}_id
-      |    |  name: ${"$"}name
-      |    |  address: ${"$"}address
-      |    |  status: ${"$"}status
-      |    |  _id_: ${"$"}_id_
-      |    |  name_: ${"$"}name_
-      |    |  address_: ${"$"}address_
-      |    |]
-      |    ""${'"'}.trimMargin()
-      |  }
+      |) {
+      |  override fun toString(): kotlin.String = ""${'"'}
+      |  |Select_all [
+      |  |  _id: ${"$"}_id
+      |  |  name: ${"$"}name
+      |  |  address: ${"$"}address
+      |  |  status: ${"$"}status
+      |  |  _id_: ${"$"}_id_
+      |  |  name_: ${"$"}name_
+      |  |  address_: ${"$"}address_
+      |  |]
+      |  ""${'"'}.trimMargin()
       |}
       |""".trimMargin())
   }
@@ -337,23 +285,17 @@ class InterfaceGeneration {
     """.trimMargin(), temporaryFolder)
 
     val query = file.namedQueries.first()
-    assertThat(QueryInterfaceGenerator(query).kotlinInterfaceSpec().toString()).isEqualTo("""
-      |interface SelectFromView {
-      |  val name: kotlin.String?
-      |
+    assertThat(QueryInterfaceGenerator(query).kotlinImplementationSpec().toString()).isEqualTo("""
+      |data class SelectFromView(
+      |  val name: kotlin.String?,
       |  val nameB: kotlin.String?
-      |
-      |  data class Impl(
-      |    override val name: kotlin.String?,
-      |    override val nameB: kotlin.String?
-      |  ) : com.example.SelectFromView {
-      |    override fun toString(): kotlin.String = ""${'"'}
-      |    |SelectFromView.Impl [
-      |    |  name: ${"$"}name
-      |    |  nameB: ${"$"}nameB
-      |    |]
-      |    ""${'"'}.trimMargin()
-      |  }
+      |) {
+      |  override fun toString(): kotlin.String = ""${'"'}
+      |  |SelectFromView [
+      |  |  name: ${"$"}name
+      |  |  nameB: ${"$"}nameB
+      |  |]
+      |  ""${'"'}.trimMargin()
       |}
       |""".trimMargin())
   }
@@ -374,26 +316,18 @@ class InterfaceGeneration {
       |
       |import kotlin.String
       |
-      |interface SomeSelect {
-      |  val is_cool: String
-      |
-      |  val get_cheese: String
-      |
+      |data class SomeSelect(
+      |  val is_cool: String,
+      |  val get_cheese: String,
       |  val stuff: String
-      |
-      |  data class Impl(
-      |    override val is_cool: String,
-      |    override val get_cheese: String,
-      |    override val stuff: String
-      |  ) : SomeSelect {
-      |    override fun toString(): String = ""${'"'}
-      |    |SomeSelect.Impl [
-      |    |  is_cool: ${"$"}is_cool
-      |    |  get_cheese: ${"$"}get_cheese
-      |    |  stuff: ${"$"}stuff
-      |    |]
-      |    ""${'"'}.trimMargin()
-      |  }
+      |) {
+      |  override fun toString(): String = ""${'"'}
+      |  |SomeSelect [
+      |  |  is_cool: ${"$"}is_cool
+      |  |  get_cheese: ${"$"}get_cheese
+      |  |  stuff: ${"$"}stuff
+      |  |]
+      |  ""${'"'}.trimMargin()
       |}
       |""".trimMargin())
   }
@@ -434,30 +368,20 @@ class InterfaceGeneration {
       |import kotlin.Long
       |import kotlin.String
       |
-      |interface SomeSelect {
-      |  val id: String
-      |
-      |  val status: Test.Status?
-      |
-      |  val attr: String?
-      |
+      |data class SomeSelect(
+      |  val id: String,
+      |  val status: Test.Status?,
+      |  val attr: String?,
       |  val ordering: Long
-      |
-      |  data class Impl(
-      |    override val id: String,
-      |    override val status: Test.Status?,
-      |    override val attr: String?,
-      |    override val ordering: Long
-      |  ) : SomeSelect {
-      |    override fun toString(): String = ""${'"'}
-      |    |SomeSelect.Impl [
-      |    |  id: ${"$"}id
-      |    |  status: ${"$"}status
-      |    |  attr: ${"$"}attr
-      |    |  ordering: ${"$"}ordering
-      |    |]
-      |    ""${'"'}.trimMargin()
-      |  }
+      |) {
+      |  override fun toString(): String = ""${'"'}
+      |  |SomeSelect [
+      |  |  id: ${"$"}id
+      |  |  status: ${"$"}status
+      |  |  attr: ${"$"}attr
+      |  |  ordering: ${"$"}ordering
+      |  |]
+      |  ""${'"'}.trimMargin()
       |}
       |""".trimMargin())
   }
@@ -485,22 +409,16 @@ class InterfaceGeneration {
       |import kotlin.Long
       |import kotlin.String
       |
-      |interface SomeSelect {
-      |  val text_content: String?
-      |
+      |data class SomeSelect(
+      |  val text_content: String?,
       |  val expr: Long
-      |
-      |  data class Impl(
-      |    override val text_content: String?,
-      |    override val expr: Long
-      |  ) : SomeSelect {
-      |    override fun toString(): String = ""${'"'}
-      |    |SomeSelect.Impl [
-      |    |  text_content: ${"$"}text_content
-      |    |  expr: ${"$"}expr
-      |    |]
-      |    ""${'"'}.trimMargin()
-      |  }
+      |) {
+      |  override fun toString(): String = ""${'"'}
+      |  |SomeSelect [
+      |  |  text_content: ${"$"}text_content
+      |  |  expr: ${"$"}expr
+      |  |]
+      |  ""${'"'}.trimMargin()
       |}
       |""".trimMargin())
   }
@@ -542,58 +460,34 @@ class InterfaceGeneration {
       |import kotlin.Long
       |import kotlin.String
       |
-      |interface Exact_match {
-      |  val _id: Long
-      |
-      |  val parent_id: Long
-      |
-      |  val child_id: Long
-      |
-      |  val _id_: Long
-      |
-      |  val category: List
-      |
-      |  val type: List
-      |
-      |  val name: String
-      |
-      |  val _id__: Long
-      |
-      |  val category_: List
-      |
-      |  val type_: List
-      |
+      |data class Exact_match(
+      |  val _id: Long,
+      |  val parent_id: Long,
+      |  val child_id: Long,
+      |  val _id_: Long,
+      |  val category: List,
+      |  val type: List,
+      |  val name: String,
+      |  val _id__: Long,
+      |  val category_: List,
+      |  val type_: List,
       |  val name_: String
-      |
-      |  data class Impl(
-      |    override val _id: Long,
-      |    override val parent_id: Long,
-      |    override val child_id: Long,
-      |    override val _id_: Long,
-      |    override val category: List,
-      |    override val type: List,
-      |    override val name: String,
-      |    override val _id__: Long,
-      |    override val category_: List,
-      |    override val type_: List,
-      |    override val name_: String
-      |  ) : Exact_match {
-      |    override fun toString(): String = ""${'"'}
-      |    |Exact_match.Impl [
-      |    |  _id: ${"$"}_id
-      |    |  parent_id: ${"$"}parent_id
-      |    |  child_id: ${"$"}child_id
-      |    |  _id_: ${"$"}_id_
-      |    |  category: ${"$"}category
-      |    |  type: ${"$"}type
-      |    |  name: ${"$"}name
-      |    |  _id__: ${"$"}_id__
-      |    |  category_: ${"$"}category_
-      |    |  type_: ${"$"}type_
-      |    |  name_: ${"$"}name_
-      |    |]
-      |    ""${'"'}.trimMargin()
-      |  }
+      |) {
+      |  override fun toString(): String = ""${'"'}
+      |  |Exact_match [
+      |  |  _id: ${"$"}_id
+      |  |  parent_id: ${"$"}parent_id
+      |  |  child_id: ${"$"}child_id
+      |  |  _id_: ${"$"}_id_
+      |  |  category: ${"$"}category
+      |  |  type: ${"$"}type
+      |  |  name: ${"$"}name
+      |  |  _id__: ${"$"}_id__
+      |  |  category_: ${"$"}category_
+      |  |  type_: ${"$"}type_
+      |  |  name_: ${"$"}name_
+      |  |]
+      |  ""${'"'}.trimMargin()
       |}
       |""".trimMargin())
   }
@@ -639,54 +533,32 @@ class InterfaceGeneration {
       |import kotlin.String
       |import kotlin.collections.contentToString
       |
-      |interface SelectAll {
-      |  val arrayValue: Array<Int>
-      |
-      |  val booleanArrayValue: BooleanArray
-      |
-      |  val byteArrayValue: ByteArray
-      |
-      |  val charArrayValue: CharArray
-      |
-      |  val doubleArrayValue: DoubleArray
-      |
-      |  val floatArrayValue: FloatArray
-      |
-      |  val intArrayValue: IntArray
-      |
-      |  val longArrayValue: LongArray
-      |
-      |  val shortArrayValue: ShortArray
-      |
+      |data class SelectAll(
+      |  val arrayValue: Array<Int>,
+      |  val booleanArrayValue: BooleanArray,
+      |  val byteArrayValue: ByteArray,
+      |  val charArrayValue: CharArray,
+      |  val doubleArrayValue: DoubleArray,
+      |  val floatArrayValue: FloatArray,
+      |  val intArrayValue: IntArray,
+      |  val longArrayValue: LongArray,
+      |  val shortArrayValue: ShortArray,
       |  val expr: Long
-      |
-      |  data class Impl(
-      |    override val arrayValue: Array<Int>,
-      |    override val booleanArrayValue: BooleanArray,
-      |    override val byteArrayValue: ByteArray,
-      |    override val charArrayValue: CharArray,
-      |    override val doubleArrayValue: DoubleArray,
-      |    override val floatArrayValue: FloatArray,
-      |    override val intArrayValue: IntArray,
-      |    override val longArrayValue: LongArray,
-      |    override val shortArrayValue: ShortArray,
-      |    override val expr: Long
-      |  ) : SelectAll {
-      |    override fun toString(): String = ""${'"'}
-      |    |SelectAll.Impl [
-      |    |  arrayValue: ${'$'}{arrayValue.contentToString()}
-      |    |  booleanArrayValue: ${'$'}{booleanArrayValue.contentToString()}
-      |    |  byteArrayValue: ${'$'}{byteArrayValue.contentToString()}
-      |    |  charArrayValue: ${'$'}{charArrayValue.contentToString()}
-      |    |  doubleArrayValue: ${'$'}{doubleArrayValue.contentToString()}
-      |    |  floatArrayValue: ${'$'}{floatArrayValue.contentToString()}
-      |    |  intArrayValue: ${'$'}{intArrayValue.contentToString()}
-      |    |  longArrayValue: ${'$'}{longArrayValue.contentToString()}
-      |    |  shortArrayValue: ${'$'}{shortArrayValue.contentToString()}
-      |    |  expr: ${'$'}expr
-      |    |]
-      |    ""${'"'}.trimMargin()
-      |  }
+      |) {
+      |  override fun toString(): String = ""${'"'}
+      |  |SelectAll [
+      |  |  arrayValue: ${'$'}{arrayValue.contentToString()}
+      |  |  booleanArrayValue: ${'$'}{booleanArrayValue.contentToString()}
+      |  |  byteArrayValue: ${'$'}{byteArrayValue.contentToString()}
+      |  |  charArrayValue: ${'$'}{charArrayValue.contentToString()}
+      |  |  doubleArrayValue: ${'$'}{doubleArrayValue.contentToString()}
+      |  |  floatArrayValue: ${'$'}{floatArrayValue.contentToString()}
+      |  |  intArrayValue: ${'$'}{intArrayValue.contentToString()}
+      |  |  longArrayValue: ${'$'}{longArrayValue.contentToString()}
+      |  |  shortArrayValue: ${'$'}{shortArrayValue.contentToString()}
+      |  |  expr: ${'$'}expr
+      |  |]
+      |  ""${'"'}.trimMargin()
       |}
       |""".trimMargin())
   }
@@ -718,26 +590,18 @@ class InterfaceGeneration {
       |import kotlin.Double
       |import kotlin.String
       |
-      |interface Average {
-      |  val avg_integer_value: Double?
-      |
-      |  val avg_real_value: Double?
-      |
+      |data class Average(
+      |  val avg_integer_value: Double?,
+      |  val avg_real_value: Double?,
       |  val avg_nullable_real_value: Double?
-      |
-      |  data class Impl(
-      |    override val avg_integer_value: Double?,
-      |    override val avg_real_value: Double?,
-      |    override val avg_nullable_real_value: Double?
-      |  ) : Average {
-      |    override fun toString(): String = ""${'"'}
-      |    |Average.Impl [
-      |    |  avg_integer_value: ${'$'}avg_integer_value
-      |    |  avg_real_value: ${'$'}avg_real_value
-      |    |  avg_nullable_real_value: ${'$'}avg_nullable_real_value
-      |    |]
-      |    ""${'"'}.trimMargin()
-      |  }
+      |) {
+      |  override fun toString(): String = ""${'"'}
+      |  |Average [
+      |  |  avg_integer_value: ${'$'}avg_integer_value
+      |  |  avg_real_value: ${'$'}avg_real_value
+      |  |  avg_nullable_real_value: ${'$'}avg_nullable_real_value
+      |  |]
+      |  ""${'"'}.trimMargin()
       |}
       |""".trimMargin())
   }

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/JavadocTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/JavadocTest.kt
@@ -26,7 +26,7 @@ class JavadocTest {
       |/**
       | * Queries all values.
       | */
-      |override fun selectAll(): com.squareup.sqldelight.Query<com.example.Test> = selectAll(com.example.Test::Impl)
+      |override fun selectAll(): com.squareup.sqldelight.Query<com.example.Test> = selectAll(::com.example.Test)
       |""".trimMargin())
   }
 
@@ -51,7 +51,7 @@ class JavadocTest {
       | *
       | * @deprecated Don't use it!
       | */
-      |override fun selectAll(): com.squareup.sqldelight.Query<com.example.Test> = selectAll(com.example.Test::Impl)
+      |override fun selectAll(): com.squareup.sqldelight.Query<com.example.Test> = selectAll(::com.example.Test)
       |""".trimMargin())
   }
 
@@ -76,7 +76,7 @@ class JavadocTest {
       | *
       | * ** @deprecated Don't use it!
       | */
-      |override fun selectAll(): com.squareup.sqldelight.Query<com.example.Test> = selectAll(com.example.Test::Impl)
+      |override fun selectAll(): com.squareup.sqldelight.Query<com.example.Test> = selectAll(::com.example.Test)
       |""".trimMargin())
   }
 
@@ -93,7 +93,7 @@ class JavadocTest {
       |/**
       | * Queries all values.
       | */
-      |override fun selectAll(): com.squareup.sqldelight.Query<com.example.Test> = selectAll(com.example.Test::Impl)
+      |override fun selectAll(): com.squareup.sqldelight.Query<com.example.Test> = selectAll(::com.example.Test)
       |""".trimMargin())
   }
 
@@ -112,7 +112,7 @@ class JavadocTest {
       |/**
       | * Queries all values.
       | */
-      |override fun selectAll(): com.squareup.sqldelight.Query<com.example.Test> = selectAll(com.example.Test::Impl)
+      |override fun selectAll(): com.squareup.sqldelight.Query<com.example.Test> = selectAll(::com.example.Test)
       |""".trimMargin())
   }
 

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryFunctionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryFunctionTest.kt
@@ -25,7 +25,7 @@ class SelectQueryFunctionTest {
 
     val generator = SelectQueryGenerator(file.namedQueries.first())
     assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo("""
-      |override fun selectForId(id: kotlin.Long): com.squareup.sqldelight.Query<com.example.Data> = selectForId(id, com.example.Data::Impl)
+      |override fun selectForId(id: kotlin.Long): com.squareup.sqldelight.Query<com.example.Data> = selectForId(id, ::com.example.Data)
       |""".trimMargin())
   }
 
@@ -45,7 +45,7 @@ class SelectQueryFunctionTest {
 
     val generator = SelectQueryGenerator(file.namedQueries.first())
     assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo("""
-      |override fun select(value: kotlin.String, id: kotlin.Long): com.squareup.sqldelight.Query<com.example.Data> = select(value, id, com.example.Data::Impl)
+      |override fun select(value: kotlin.String, id: kotlin.Long): com.squareup.sqldelight.Query<com.example.Data> = select(value, id, ::com.example.Data)
       |""".trimMargin())
   }
 
@@ -230,7 +230,7 @@ class SelectQueryFunctionTest {
 
     val generator = SelectQueryGenerator(file.namedQueries.first())
     assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo("""
-      |override fun someSelect(minimum: kotlin.Long, offset: kotlin.Long): com.squareup.sqldelight.Query<com.example.Data> = someSelect(minimum, offset, com.example.Data::Impl)
+      |override fun someSelect(minimum: kotlin.Long, offset: kotlin.Long): com.squareup.sqldelight.Query<com.example.Data> = someSelect(minimum, offset, ::com.example.Data)
       |""".trimMargin())
   }
 
@@ -463,7 +463,7 @@ class SelectQueryFunctionTest {
 
     val generator = SelectQueryGenerator(file.namedQueries.first())
     assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo("""
-      |override fun selectData(): com.squareup.sqldelight.Query<com.example.SelectData> = selectData(com.example.SelectData::Impl)
+      |override fun selectData(): com.squareup.sqldelight.Query<com.example.SelectData> = selectData(::com.example.SelectData)
       |""".trimMargin())
   }
 

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/tables/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/tables/InterfaceGeneration.kt
@@ -46,20 +46,15 @@ class InterfaceGeneration {
       |import kotlin.Int
       |import kotlin.String
       |
-      |interface Test {
+      |data class Test(
       |  val annotated: @SomeAnnotation(cheese = ["havarti","provalone"], age = 10, type = List::class,
       |      otherAnnotation = SomeOtherAnnotation("value")) Int?
-      |
-      |  data class Impl(
-      |    override val annotated: @SomeAnnotation(cheese = ["havarti","provalone"], age = 10, type =
-      |        List::class, otherAnnotation = SomeOtherAnnotation("value")) Int?
-      |  ) : Test {
-      |    override fun toString(): String = ""${'"'}
-      |    |Test.Impl [
-      |    |  annotated: ${"$"}annotated
-      |    |]
-      |    ""${'"'}.trimMargin()
-      |  }
+      |) {
+      |  override fun toString(): String = ""${'"'}
+      |  |Test [
+      |  |  annotated: ${"$"}annotated
+      |  |]
+      |  ""${'"'}.trimMargin()
       |}
       |""".trimMargin())
   }
@@ -82,30 +77,20 @@ class InterfaceGeneration {
       |
       |import kotlin.String
       |
-      |interface Test {
-      |  val is_cool: String
-      |
-      |  val get_cheese: String?
-      |
-      |  val isle: String?
-      |
+      |data class Test(
+      |  val is_cool: String,
+      |  val get_cheese: String?,
+      |  val isle: String?,
       |  val stuff: String?
-      |
-      |  data class Impl(
-      |    override val is_cool: String,
-      |    override val get_cheese: String?,
-      |    override val isle: String?,
-      |    override val stuff: String?
-      |  ) : Test {
-      |    override fun toString(): String = ""${'"'}
-      |    |Test.Impl [
-      |    |  is_cool: ${"$"}is_cool
-      |    |  get_cheese: ${"$"}get_cheese
-      |    |  isle: ${"$"}isle
-      |    |  stuff: ${"$"}stuff
-      |    |]
-      |    ""${'"'}.trimMargin()
-      |  }
+      |) {
+      |  override fun toString(): String = ""${'"'}
+      |  |Test [
+      |  |  is_cool: ${"$"}is_cool
+      |  |  get_cheese: ${"$"}get_cheese
+      |  |  isle: ${"$"}isle
+      |  |  stuff: ${"$"}stuff
+      |  |]
+      |  ""${'"'}.trimMargin()
       |}
       |""".trimMargin())
   }
@@ -125,47 +110,29 @@ class InterfaceGeneration {
       |""".trimMargin(), tempFolder)
 
     val generator = TableInterfaceGenerator(result.sqliteStatements().first().statement.createTableStmt!!)
-    assertThat(generator.kotlinInterfaceSpec().toString()).isEqualTo("""
-      |interface Test {
-      |  val intValue: kotlin.Int
-      |
-      |  val intValue2: kotlin.Int
-      |
-      |  val booleanValue: kotlin.Boolean
-      |
-      |  val shortValue: kotlin.Short
-      |
-      |  val longValue: kotlin.Long
-      |
-      |  val floatValue: kotlin.Float
-      |
-      |  val doubleValue: kotlin.Double
-      |
+    assertThat(generator.kotlinImplementationSpec().toString()).isEqualTo("""
+      |data class Test(
+      |  val intValue: kotlin.Int,
+      |  val intValue2: kotlin.Int,
+      |  val booleanValue: kotlin.Boolean,
+      |  val shortValue: kotlin.Short,
+      |  val longValue: kotlin.Long,
+      |  val floatValue: kotlin.Float,
+      |  val doubleValue: kotlin.Double,
       |  val blobValue: kotlin.ByteArray
-      |
-      |  data class Impl(
-      |    override val intValue: kotlin.Int,
-      |    override val intValue2: kotlin.Int,
-      |    override val booleanValue: kotlin.Boolean,
-      |    override val shortValue: kotlin.Short,
-      |    override val longValue: kotlin.Long,
-      |    override val floatValue: kotlin.Float,
-      |    override val doubleValue: kotlin.Double,
-      |    override val blobValue: kotlin.ByteArray
-      |  ) : com.example.Test {
-      |    override fun toString(): kotlin.String = ""${'"'}
-      |    |Test.Impl [
-      |    |  intValue: ${"$"}intValue
-      |    |  intValue2: ${"$"}intValue2
-      |    |  booleanValue: ${"$"}booleanValue
-      |    |  shortValue: ${"$"}shortValue
-      |    |  longValue: ${"$"}longValue
-      |    |  floatValue: ${"$"}floatValue
-      |    |  doubleValue: ${"$"}doubleValue
-      |    |  blobValue: ${"$"}{blobValue.kotlin.collections.contentToString()}
-      |    |]
-      |    ""${'"'}.trimMargin()
-      |  }
+      |) {
+      |  override fun toString(): kotlin.String = ""${'"'}
+      |  |Test [
+      |  |  intValue: ${"$"}intValue
+      |  |  intValue2: ${"$"}intValue2
+      |  |  booleanValue: ${"$"}booleanValue
+      |  |  shortValue: ${"$"}shortValue
+      |  |  longValue: ${"$"}longValue
+      |  |  floatValue: ${"$"}floatValue
+      |  |  doubleValue: ${"$"}doubleValue
+      |  |  blobValue: ${"$"}{blobValue.kotlin.collections.contentToString()}
+      |  |]
+      |  ""${'"'}.trimMargin()
       |}
       |""".trimMargin())
   }
@@ -187,7 +154,7 @@ class InterfaceGeneration {
 
     val generator = TableInterfaceGenerator(result.sqliteStatements().first().statement.createTableStmt!!)
     val file = FileSpec.builder("", "Test")
-        .addType(generator.kotlinInterfaceSpec())
+        .addType(generator.kotlinImplementationSpec())
         .build()
     assertThat(file.toString()).isEqualTo("""
       |import com.squareup.sqldelight.ColumnAdapter
@@ -204,24 +171,30 @@ class InterfaceGeneration {
       |import kotlin.String
       |import kotlin.collections.contentToString
       |
-      |interface Test {
-      |  val arrayValue: Array<Int>
-      |
-      |  val booleanArrayValue: BooleanArray
-      |
-      |  val byteArrayValue: ByteArray
-      |
-      |  val charArrayValue: CharArray
-      |
-      |  val doubleArrayValue: DoubleArray
-      |
-      |  val floatArrayValue: FloatArray
-      |
-      |  val intArrayValue: IntArray
-      |
-      |  val longArrayValue: LongArray
-      |
+      |data class Test(
+      |  val arrayValue: Array<Int>,
+      |  val booleanArrayValue: BooleanArray,
+      |  val byteArrayValue: ByteArray,
+      |  val charArrayValue: CharArray,
+      |  val doubleArrayValue: DoubleArray,
+      |  val floatArrayValue: FloatArray,
+      |  val intArrayValue: IntArray,
+      |  val longArrayValue: LongArray,
       |  val shortArrayValue: ShortArray
+      |) {
+      |  override fun toString(): String = ""${'"'}
+      |  |Test [
+      |  |  arrayValue: ${'$'}{arrayValue.contentToString()}
+      |  |  booleanArrayValue: ${'$'}{booleanArrayValue.contentToString()}
+      |  |  byteArrayValue: ${'$'}{byteArrayValue.contentToString()}
+      |  |  charArrayValue: ${'$'}{charArrayValue.contentToString()}
+      |  |  doubleArrayValue: ${'$'}{doubleArrayValue.contentToString()}
+      |  |  floatArrayValue: ${'$'}{floatArrayValue.contentToString()}
+      |  |  intArrayValue: ${'$'}{intArrayValue.contentToString()}
+      |  |  longArrayValue: ${'$'}{longArrayValue.contentToString()}
+      |  |  shortArrayValue: ${'$'}{shortArrayValue.contentToString()}
+      |  |]
+      |  ""${'"'}.trimMargin()
       |
       |  class Adapter(
       |    val arrayValueAdapter: ColumnAdapter<Array<Int>, ByteArray>,
@@ -234,32 +207,6 @@ class InterfaceGeneration {
       |    val longArrayValueAdapter: ColumnAdapter<LongArray, ByteArray>,
       |    val shortArrayValueAdapter: ColumnAdapter<ShortArray, ByteArray>
       |  )
-      |
-      |  data class Impl(
-      |    override val arrayValue: Array<Int>,
-      |    override val booleanArrayValue: BooleanArray,
-      |    override val byteArrayValue: ByteArray,
-      |    override val charArrayValue: CharArray,
-      |    override val doubleArrayValue: DoubleArray,
-      |    override val floatArrayValue: FloatArray,
-      |    override val intArrayValue: IntArray,
-      |    override val longArrayValue: LongArray,
-      |    override val shortArrayValue: ShortArray
-      |  ) : com.example.Test {
-      |    override fun toString(): String = ""${'"'}
-      |    |Test.Impl [
-      |    |  arrayValue: ${'$'}{arrayValue.contentToString()}
-      |    |  booleanArrayValue: ${'$'}{booleanArrayValue.contentToString()}
-      |    |  byteArrayValue: ${'$'}{byteArrayValue.contentToString()}
-      |    |  charArrayValue: ${'$'}{charArrayValue.contentToString()}
-      |    |  doubleArrayValue: ${'$'}{doubleArrayValue.contentToString()}
-      |    |  floatArrayValue: ${'$'}{floatArrayValue.contentToString()}
-      |    |  intArrayValue: ${'$'}{intArrayValue.contentToString()}
-      |    |  longArrayValue: ${'$'}{longArrayValue.contentToString()}
-      |    |  shortArrayValue: ${'$'}{shortArrayValue.contentToString()}
-      |    |]
-      |    ""${'"'}.trimMargin()
-      |  }
       |}
       |""".trimMargin())
   }
@@ -272,23 +219,19 @@ class InterfaceGeneration {
       |""".trimMargin(), tempFolder)
 
     val generator = TableInterfaceGenerator(result.sqliteStatements().first().statement.createTableStmt!!)
-    assertThat(generator.kotlinInterfaceSpec().toString()).isEqualTo("""
-      |interface Test {
+    assertThat(generator.kotlinImplementationSpec().toString()).isEqualTo("""
+      |data class Test(
       |  val mapValue: kotlin.collections.Map<kotlin.collections.List<kotlin.collections.List<String>>, kotlin.collections.List<kotlin.collections.List<String>>>?
+      |) {
+      |  override fun toString(): kotlin.String = ""${'"'}
+      |  |Test [
+      |  |  mapValue: ${"$"}mapValue
+      |  |]
+      |  ""${'"'}.trimMargin()
       |
       |  class Adapter(
       |    val mapValueAdapter: com.squareup.sqldelight.ColumnAdapter<kotlin.collections.Map<kotlin.collections.List<kotlin.collections.List<String>>, kotlin.collections.List<kotlin.collections.List<String>>>, kotlin.Long>
       |  )
-      |
-      |  data class Impl(
-      |    override val mapValue: kotlin.collections.Map<kotlin.collections.List<kotlin.collections.List<String>>, kotlin.collections.List<kotlin.collections.List<String>>>?
-      |  ) : com.example.Test {
-      |    override fun toString(): kotlin.String = ""${'"'}
-      |    |Test.Impl [
-      |    |  mapValue: ${"$"}mapValue
-      |    |]
-      |    ""${'"'}.trimMargin()
-      |  }
       |}
       |""".trimMargin())
   }
@@ -307,32 +250,24 @@ class InterfaceGeneration {
       |""".trimMargin(), tempFolder)
 
     val generator = TableInterfaceGenerator(result.sqliteStatements().first().statement.createTableStmt!!)
-    assertThat(generator.kotlinInterfaceSpec().toString()).isEqualTo("""
-      |interface Test {
-      |  val _id: kotlin.Long
-      |
-      |  val enabledDays: kotlin.collections.Set<java.time.DayOfWeek>?
-      |
+    assertThat(generator.kotlinImplementationSpec().toString()).isEqualTo("""
+      |data class Test(
+      |  val _id: kotlin.Long,
+      |  val enabledDays: kotlin.collections.Set<java.time.DayOfWeek>?,
       |  val enabledWeeks: kotlin.collections.Set<com.gabrielittner.timetable.core.db.Week>?
+      |) {
+      |  override fun toString(): kotlin.String = ""${'"'}
+      |  |Test [
+      |  |  _id: ${"$"}_id
+      |  |  enabledDays: ${"$"}enabledDays
+      |  |  enabledWeeks: ${"$"}enabledWeeks
+      |  |]
+      |  ""${'"'}.trimMargin()
       |
       |  class Adapter(
       |    val enabledDaysAdapter: com.squareup.sqldelight.ColumnAdapter<kotlin.collections.Set<java.time.DayOfWeek>, kotlin.String>,
       |    val enabledWeeksAdapter: com.squareup.sqldelight.ColumnAdapter<kotlin.collections.Set<com.gabrielittner.timetable.core.db.Week>, kotlin.String>
       |  )
-      |
-      |  data class Impl(
-      |    override val _id: kotlin.Long,
-      |    override val enabledDays: kotlin.collections.Set<java.time.DayOfWeek>?,
-      |    override val enabledWeeks: kotlin.collections.Set<com.gabrielittner.timetable.core.db.Week>?
-      |  ) : com.example.Test {
-      |    override fun toString(): kotlin.String = ""${'"'}
-      |    |Test.Impl [
-      |    |  _id: ${"$"}_id
-      |    |  enabledDays: ${"$"}enabledDays
-      |    |  enabledWeeks: ${"$"}enabledWeeks
-      |    |]
-      |    ""${'"'}.trimMargin()
-      |  }
       |}
       |""".trimMargin())
   }
@@ -348,31 +283,21 @@ class InterfaceGeneration {
       |""".trimMargin(), tempFolder)
 
         val generator = TableInterfaceGenerator(result.sqliteStatements().first().statement.createTableStmt!!)
-        assertThat(generator.kotlinInterfaceSpec().toString()).isEqualTo("""
-      |interface Group {
-      |  val index1: kotlin.String?
-      |
-      |  val index2: kotlin.String?
-      |
-      |  val index3: kotlin.String?
-      |
+        assertThat(generator.kotlinImplementationSpec().toString()).isEqualTo("""
+      |data class Group(
+      |  val index1: kotlin.String?,
+      |  val index2: kotlin.String?,
+      |  val index3: kotlin.String?,
       |  val index4: kotlin.String?
-      |
-      |  data class Impl(
-      |    override val index1: kotlin.String?,
-      |    override val index2: kotlin.String?,
-      |    override val index3: kotlin.String?,
-      |    override val index4: kotlin.String?
-      |  ) : com.example.Group {
-      |    override fun toString(): kotlin.String = ""${'"'}
-      |    |Group.Impl [
-      |    |  index1: ${"$"}index1
-      |    |  index2: ${"$"}index2
-      |    |  index3: ${"$"}index3
-      |    |  index4: ${"$"}index4
-      |    |]
-      |    ""${'"'}.trimMargin()
-      |  }
+      |) {
+      |  override fun toString(): kotlin.String = ""${'"'}
+      |  |Group [
+      |  |  index1: ${"$"}index1
+      |  |  index2: ${"$"}index2
+      |  |  index3: ${"$"}index3
+      |  |  index4: ${"$"}index4
+      |  |]
+      |  ""${'"'}.trimMargin()
       |}
       |""".trimMargin())
     }

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/views/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/views/InterfaceGeneration.kt
@@ -45,22 +45,16 @@ class InterfaceGeneration {
       |import kotlin.Boolean
       |import kotlin.String
       |
-      |interface SomeView {
-      |  val val_: Boolean
-      |
+      |data class SomeView(
+      |  val val_: Boolean,
       |  val val__: Boolean
-      |
-      |  data class Impl(
-      |    override val val_: Boolean,
-      |    override val val__: Boolean
-      |  ) : SomeView {
-      |    override fun toString(): String = ""${'"'}
-      |    |SomeView.Impl [
-      |    |  val_: ${"$"}val_
-      |    |  val__: ${"$"}val__
-      |    |]
-      |    ""${'"'}.trimMargin()
-      |  }
+      |) {
+      |  override fun toString(): String = ""${'"'}
+      |  |SomeView [
+      |  |  val_: ${"$"}val_
+      |  |  val__: ${"$"}val__
+      |  |]
+      |  ""${'"'}.trimMargin()
       |}
       |""".trimMargin())
   }
@@ -94,22 +88,16 @@ class InterfaceGeneration {
       |import kotlin.Boolean
       |import kotlin.String
       |
-      |interface SomeView {
-      |  val val_: Boolean
-      |
+      |data class SomeView(
+      |  val val_: Boolean,
       |  val val__: Boolean
-      |
-      |  data class Impl(
-      |    override val val_: Boolean,
-      |    override val val__: Boolean
-      |  ) : SomeView {
-      |    override fun toString(): String = ""${'"'}
-      |    |SomeView.Impl [
-      |    |  val_: ${"$"}val_
-      |    |  val__: ${"$"}val__
-      |    |]
-      |    ""${'"'}.trimMargin()
-      |  }
+      |) {
+      |  override fun toString(): String = ""${'"'}
+      |  |SomeView [
+      |  |  val_: ${"$"}val_
+      |  |  val__: ${"$"}val__
+      |  |]
+      |  ""${'"'}.trimMargin()
       |}
       |""".trimMargin())
   }
@@ -155,54 +143,32 @@ class InterfaceGeneration {
       |import kotlin.String
       |import kotlin.collections.contentToString
       |
-      |interface SomeView {
-      |  val arrayValue: Array<Int>
-      |
-      |  val booleanArrayValue: BooleanArray
-      |
-      |  val byteArrayValue: ByteArray
-      |
-      |  val charArrayValue: CharArray
-      |
-      |  val doubleArrayValue: DoubleArray
-      |
-      |  val floatArrayValue: FloatArray
-      |
-      |  val intArrayValue: IntArray
-      |
-      |  val longArrayValue: LongArray
-      |
-      |  val shortArrayValue: ShortArray
-      |
+      |data class SomeView(
+      |  val arrayValue: Array<Int>,
+      |  val booleanArrayValue: BooleanArray,
+      |  val byteArrayValue: ByteArray,
+      |  val charArrayValue: CharArray,
+      |  val doubleArrayValue: DoubleArray,
+      |  val floatArrayValue: FloatArray,
+      |  val intArrayValue: IntArray,
+      |  val longArrayValue: LongArray,
+      |  val shortArrayValue: ShortArray,
       |  val expr: Long
-      |
-      |  data class Impl(
-      |    override val arrayValue: Array<Int>,
-      |    override val booleanArrayValue: BooleanArray,
-      |    override val byteArrayValue: ByteArray,
-      |    override val charArrayValue: CharArray,
-      |    override val doubleArrayValue: DoubleArray,
-      |    override val floatArrayValue: FloatArray,
-      |    override val intArrayValue: IntArray,
-      |    override val longArrayValue: LongArray,
-      |    override val shortArrayValue: ShortArray,
-      |    override val expr: Long
-      |  ) : SomeView {
-      |    override fun toString(): String = ""${'"'}
-      |    |SomeView.Impl [
-      |    |  arrayValue: ${'$'}{arrayValue.contentToString()}
-      |    |  booleanArrayValue: ${'$'}{booleanArrayValue.contentToString()}
-      |    |  byteArrayValue: ${'$'}{byteArrayValue.contentToString()}
-      |    |  charArrayValue: ${'$'}{charArrayValue.contentToString()}
-      |    |  doubleArrayValue: ${'$'}{doubleArrayValue.contentToString()}
-      |    |  floatArrayValue: ${'$'}{floatArrayValue.contentToString()}
-      |    |  intArrayValue: ${'$'}{intArrayValue.contentToString()}
-      |    |  longArrayValue: ${'$'}{longArrayValue.contentToString()}
-      |    |  shortArrayValue: ${'$'}{shortArrayValue.contentToString()}
-      |    |  expr: ${'$'}expr
-      |    |]
-      |    ""${'"'}.trimMargin()
-      |  }
+      |) {
+      |  override fun toString(): String = ""${'"'}
+      |  |SomeView [
+      |  |  arrayValue: ${'$'}{arrayValue.contentToString()}
+      |  |  booleanArrayValue: ${'$'}{booleanArrayValue.contentToString()}
+      |  |  byteArrayValue: ${'$'}{byteArrayValue.contentToString()}
+      |  |  charArrayValue: ${'$'}{charArrayValue.contentToString()}
+      |  |  doubleArrayValue: ${'$'}{doubleArrayValue.contentToString()}
+      |  |  floatArrayValue: ${'$'}{floatArrayValue.contentToString()}
+      |  |  intArrayValue: ${'$'}{intArrayValue.contentToString()}
+      |  |  longArrayValue: ${'$'}{longArrayValue.contentToString()}
+      |  |  shortArrayValue: ${'$'}{shortArrayValue.contentToString()}
+      |  |  expr: ${'$'}expr
+      |  |]
+      |  ""${'"'}.trimMargin()
       |}
       |""".trimMargin())
   }

--- a/sqldelight-compiler/src/test/query-interface-fixtures/query-requires-type/output/com/sample/JoinedWithUsing.kt
+++ b/sqldelight-compiler/src/test/query-interface-fixtures/query-requires-type/output/com/sample/JoinedWithUsing.kt
@@ -3,20 +3,14 @@ package com.sample
 import kotlin.Boolean
 import kotlin.String
 
-interface JoinedWithUsing {
-  val name: String
-
+data class JoinedWithUsing(
+  val name: String,
   val is_cool: Boolean
-
-  data class Impl(
-    override val name: String,
-    override val is_cool: Boolean
-  ) : JoinedWithUsing {
-    override fun toString(): String = """
-    |JoinedWithUsing.Impl [
-    |  name: $name
-    |  is_cool: $is_cool
-    |]
-    """.trimMargin()
-  }
+) {
+  override fun toString(): String = """
+  |JoinedWithUsing [
+  |  name: $name
+  |  is_cool: $is_cool
+  |]
+  """.trimMargin()
 }

--- a/sqldelight-compiler/src/test/table-interface-fixtures/requires-adapter/output/com/sample/Person.kt
+++ b/sqldelight-compiler/src/test/table-interface-fixtures/requires-adapter/output/com/sample/Person.kt
@@ -8,40 +8,26 @@ import kotlin.ByteArray
 import kotlin.Long
 import kotlin.String
 
-interface Person {
-  val _id: Long
-
-  val name: String
-
-  val last_name: String?
-
-  val is_cool: Boolean
-
-  val friends: List<Person>?
-
+data class Person(
+  val _id: Long,
+  val name: String,
+  val last_name: String?,
+  val is_cool: Boolean,
+  val friends: List<Person>?,
   val shhh_its_secret: @Redacted String
+) {
+  override fun toString(): String = """
+  |Person [
+  |  _id: $_id
+  |  name: $name
+  |  last_name: $last_name
+  |  is_cool: $is_cool
+  |  friends: $friends
+  |  shhh_its_secret: $shhh_its_secret
+  |]
+  """.trimMargin()
 
   class Adapter(
     val friendsAdapter: ColumnAdapter<List<Person>, ByteArray>
   )
-
-  data class Impl(
-    override val _id: Long,
-    override val name: String,
-    override val last_name: String?,
-    override val is_cool: Boolean,
-    override val friends: List<Person>?,
-    override val shhh_its_secret: @Redacted String
-  ) : Person {
-    override fun toString(): String = """
-    |Person.Impl [
-    |  _id: $_id
-    |  name: $name
-    |  last_name: $last_name
-    |  is_cool: $is_cool
-    |  friends: $friends
-    |  shhh_its_secret: $shhh_its_secret
-    |]
-    """.trimMargin()
-  }
 }

--- a/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/PersonAndFriends.kt
+++ b/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/PersonAndFriends.kt
@@ -5,28 +5,18 @@ import java.util.List
 import kotlin.Double
 import kotlin.String
 
-interface PersonAndFriends {
-  val full_name: String
-
-  val friends: List<Person>?
-
-  val shhh_its_secret: @Redacted String
-
+data class PersonAndFriends(
+  val full_name: String,
+  val friends: List<Person>?,
+  val shhh_its_secret: @Redacted String,
   val casted: Double
-
-  data class Impl(
-    override val full_name: String,
-    override val friends: List<Person>?,
-    override val shhh_its_secret: @Redacted String,
-    override val casted: Double
-  ) : PersonAndFriends {
-    override fun toString(): String = """
-    |PersonAndFriends.Impl [
-    |  full_name: $full_name
-    |  friends: $friends
-    |  shhh_its_secret: $shhh_its_secret
-    |  casted: $casted
-    |]
-    """.trimMargin()
-  }
+) {
+  override fun toString(): String = """
+  |PersonAndFriends [
+  |  full_name: $full_name
+  |  friends: $friends
+  |  shhh_its_secret: $shhh_its_secret
+  |  casted: $casted
+  |]
+  """.trimMargin()
 }

--- a/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/PersonCool.kt
+++ b/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/PersonCool.kt
@@ -6,40 +6,24 @@ import kotlin.Boolean
 import kotlin.Long
 import kotlin.String
 
-interface PersonCool {
-  val _id: Long
-
-  val name: String
-
-  val last_name: String?
-
-  val is_cool: Boolean
-
-  val friends: List<Person>?
-
-  val shhh_its_secret: @Redacted String
-
+data class PersonCool(
+  val _id: Long,
+  val name: String,
+  val last_name: String?,
+  val is_cool: Boolean,
+  val friends: List<Person>?,
+  val shhh_its_secret: @Redacted String,
   val how_cool: String
-
-  data class Impl(
-    override val _id: Long,
-    override val name: String,
-    override val last_name: String?,
-    override val is_cool: Boolean,
-    override val friends: List<Person>?,
-    override val shhh_its_secret: @Redacted String,
-    override val how_cool: String
-  ) : PersonCool {
-    override fun toString(): String = """
-    |PersonCool.Impl [
-    |  _id: $_id
-    |  name: $name
-    |  last_name: $last_name
-    |  is_cool: $is_cool
-    |  friends: $friends
-    |  shhh_its_secret: $shhh_its_secret
-    |  how_cool: $how_cool
-    |]
-    """.trimMargin()
-  }
+) {
+  override fun toString(): String = """
+  |PersonCool [
+  |  _id: $_id
+  |  name: $name
+  |  last_name: $last_name
+  |  is_cool: $is_cool
+  |  friends: $friends
+  |  shhh_its_secret: $shhh_its_secret
+  |  how_cool: $how_cool
+  |]
+  """.trimMargin()
 }

--- a/sqldelight-gradle-plugin/src/test/integration-android/src/androidTest/java/com/squareup/sqldelight/integration/IntegrationTests.java
+++ b/sqldelight-gradle-plugin/src/test/integration-android/src/androidTest/java/com/squareup/sqldelight/integration/IntegrationTests.java
@@ -35,32 +35,32 @@ public class IntegrationTests {
 
   @Test public void indexedArgs() {
     // ?1 is the only arg
-    Person person = personQueries.equivalentNames("Bob", AutoValue_MyPerson::new).executeAsOne();
-    assertThat(person).isEqualTo(new AutoValue_MyPerson(4, "Bob", "Bob"));
+    Person person = personQueries.equivalentNames("Bob").executeAsOne();
+    assertThat(person).isEqualTo(new Person(4, "Bob", "Bob"));
   }
 
   @Test public void startIndexAtTwo() {
     // ?2 is the only arg
-    Person person = personQueries.equivalentNames2("Bob", AutoValue_MyPerson::new).executeAsOne();
-    assertThat(person).isEqualTo(new AutoValue_MyPerson(4, "Bob", "Bob"));
+    Person person = personQueries.equivalentNames2("Bob").executeAsOne();
+    assertThat(person).isEqualTo(new Person(4, "Bob", "Bob"));
   }
 
   @Test public void namedIndexArgs() {
     // :name is the only arg
-    Person person = personQueries.equivalentNamesNamed("Bob", AutoValue_MyPerson::new).executeAsOne();
-    assertThat(person).isEqualTo(new AutoValue_MyPerson(4, "Bob", "Bob"));
+    Person person = personQueries.equivalentNamesNamed("Bob").executeAsOne();
+    assertThat(person).isEqualTo(new Person(4, "Bob", "Bob"));
   }
 
   @Test public void indexedArgLast() {
     // First arg declared is ?, second arg declared is ?1.
-    Person person = personQueries.indexedArgLast("Bob", AutoValue_MyPerson::new).executeAsOne();
-    assertThat(person).isEqualTo(new AutoValue_MyPerson(4, "Bob", "Bob"));
+    Person person = personQueries.indexedArgLast("Bob").executeAsOne();
+    assertThat(person).isEqualTo(new Person(4, "Bob", "Bob"));
   }
 
   @Test public void indexedArgLastTwo() {
     // First arg declared is ?, second arg declared is ?2.
-    Person person = personQueries.indexedArgLast2("Alec", "Strong", AutoValue_MyPerson::new).executeAsOne();
-    assertThat(person).isEqualTo(new AutoValue_MyPerson(1, "Alec", "Strong"));
+    Person person = personQueries.indexedArgLast2("Alec", "Strong").executeAsOne();
+    assertThat(person).isEqualTo(new Person(1, "Alec", "Strong"));
   }
 
   @Test public void nameIn() {
@@ -69,8 +69,8 @@ public class IntegrationTests {
   }
 
   @Test public void sqliteKeywordQuery() {
-    SqliteKeywords keywords = keywordsQueries.selectAll(AutoValue_SqliteKeywords::new).executeAsOne();
-    assertThat(keywords).isEqualTo(new AutoValue_SqliteKeywords(1, 10, 20));
+    Group keywords = keywordsQueries.selectAll().executeAsOne();
+    assertThat(keywords).isEqualTo(new Group(1, 10, 20));
   }
 
   @Test public void compiledStatement() {

--- a/sqldelight-gradle-plugin/src/test/integration-android/src/androidTest/java/com/squareup/sqldelight/integration/MigrationTest.java
+++ b/sqldelight-gradle-plugin/src/test/integration-android/src/androidTest/java/com/squareup/sqldelight/integration/MigrationTest.java
@@ -62,8 +62,8 @@ public class MigrationTest {
 
     // Assert info is correct
     Person person = queryWrapper.getPersonQueries()
-        .nameIn(Arrays.asList("alec"), AutoValue_MyPerson::new).executeAsOne();
-    assertThat(person).isEqualTo(new AutoValue_MyPerson(1, "alec", "sup"));
+        .nameIn(Arrays.asList("alec")).executeAsOne();
+    assertThat(person).isEqualTo(new Person(1, "alec", "sup"));
     database.close();
   }
 }

--- a/sqldelight-gradle-plugin/src/test/integration-android/src/main/java/com/squareup/sqldelight/integration/MyPerson.java
+++ b/sqldelight-gradle-plugin/src/test/integration-android/src/main/java/com/squareup/sqldelight/integration/MyPerson.java
@@ -1,5 +1,0 @@
-package com.squareup.sqldelight.integration;
-
-import com.google.auto.value.AutoValue;
-
-@AutoValue public abstract class MyPerson implements Person {}

--- a/sqldelight-gradle-plugin/src/test/integration-android/src/main/java/com/squareup/sqldelight/integration/SqliteKeywords.java
+++ b/sqldelight-gradle-plugin/src/test/integration-android/src/main/java/com/squareup/sqldelight/integration/SqliteKeywords.java
@@ -1,5 +1,0 @@
-package com.squareup.sqldelight.integration;
-
-import com.google.auto.value.AutoValue;
-
-@AutoValue public abstract class SqliteKeywords implements Group {}

--- a/sqldelight-gradle-plugin/src/test/integration-hsql/src/test/kotlin/com/squareup/sqldelight/hsql/integration/HsqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-hsql/src/test/kotlin/com/squareup/sqldelight/hsql/integration/HsqlTest.kt
@@ -25,7 +25,7 @@ class HsqlTest {
   @Test fun simpleSelect() {
     database.dogQueries.insertDog("Tilda", "Pomeranian", true)
     assertThat(database.dogQueries.selectDogs().executeAsOne())
-        .isEqualTo(Dog.Impl(
+        .isEqualTo(Dog(
             name = "Tilda",
             breed = "Pomeranian",
             is_good = true

--- a/sqldelight-gradle-plugin/src/test/integration-multiplatform/src/commonMain/kotlin/com/squareup/sqldelight/integration/common.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-multiplatform/src/commonMain/kotlin/com/squareup/sqldelight/integration/common.kt
@@ -15,5 +15,5 @@ expect class MPFuture<T> {
 }
 
 fun doThingsWithGeneratedCode() {
-  val stuff = Person.Impl(10, "Jesse", "Wilson")
+  val stuff = Person(10, "Jesse", "Wilson")
 }

--- a/sqldelight-gradle-plugin/src/test/integration-multiplatform/src/commonTest/kotlin/com/squareup/sqldelight/integration/IntegrationTests.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-multiplatform/src/commonTest/kotlin/com/squareup/sqldelight/integration/IntegrationTests.kt
@@ -35,31 +35,31 @@ class IntegrationTests {
   @Test fun indexedArgs() {
     // ?1 is the only arg
     val person = personQueries.equivalentNames("Bob").executeAsOne()
-    assertEquals(Person.Impl(4, "Bob", "Bob"), person)
+    assertEquals(Person(4, "Bob", "Bob"), person)
   }
 
   @Test fun startIndexAtTwo() {
     // ?2 is the only arg
     val person = personQueries.equivalentNames2("Bob").executeAsOne()
-    assertEquals(Person.Impl(4, "Bob", "Bob"), person)
+    assertEquals(Person(4, "Bob", "Bob"), person)
   }
 
   @Test fun namedIndexArgs() {
     // :name is the only arg
     val person = personQueries.equivalentNamesNamed("Bob").executeAsOne()
-    assertEquals(Person.Impl(4, "Bob", "Bob"), person)
+    assertEquals(Person(4, "Bob", "Bob"), person)
   }
 
   @Test fun indexedArgLast() {
     // First arg declared is ?, second arg declared is ?1.
     val person = personQueries.indexedArgLast("Bob").executeAsOne()
-    assertEquals(Person.Impl(4, "Bob", "Bob"), person)
+    assertEquals(Person(4, "Bob", "Bob"), person)
   }
 
   @Test fun indexedArgLastTwo() {
     // First arg declared is ?, second arg declared is ?2.
     val person = personQueries.indexedArgLast2("Alec", "Strong").executeAsOne()
-    assertEquals(Person.Impl(1, "Alec", "Strong"), person)
+    assertEquals(Person(1, "Alec", "Strong"), person)
   }
 
   @Test fun nameIn() {
@@ -68,15 +68,15 @@ class IntegrationTests {
   }
 
   @Test fun selectingWithNullParams() {
-    nullableTypesQueries.insertNullableType(NullableTypes.Impl(listOf("Yo"), "Yo"))
-    nullableTypesQueries.insertNullableType(NullableTypes.Impl(null, null))
+    nullableTypesQueries.insertNullableType(NullableTypes(listOf("Yo"), "Yo"))
+    nullableTypesQueries.insertNullableType(NullableTypes(null, null))
 
     assertEquals(null, nullableTypesQueries.exprOnNullableColumn(null).executeAsOne().val1)
   }
 
   @Test fun sqliteKeywordQuery() {
     val keywords = keywordsQueries.selectAll().executeAsOne()
-    assertEquals(Group.Impl(1, 10, 20), keywords)
+    assertEquals(Group(1, 10, 20), keywords)
   }
 
   @Test fun compiledStatement() {
@@ -110,9 +110,9 @@ class IntegrationTests {
 
   @Test
   fun nullableColumnsUseAdapterProperly() {
-    val cool = NullableTypes.Impl(listOf("Alec", "Matt", "Jake"), "Cool")
-    val notCool = NullableTypes.Impl(null, "Not Cool")
-    val nulled = NullableTypes.Impl(null, null)
+    val cool = NullableTypes(listOf("Alec", "Matt", "Jake"), "Cool")
+    val notCool = NullableTypes(null, "Not Cool")
+    val nulled = NullableTypes(null, null)
     nullableTypesQueries.insertNullableType(cool)
     nullableTypesQueries.insertNullableType(notCool)
     nullableTypesQueries.insertNullableType(nulled)
@@ -132,7 +132,7 @@ class IntegrationTests {
   }
 
   @Test fun bigTable() {
-    val bigTable = BigTable.Impl(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+    val bigTable = BigTable(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
         20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30)
 
     bigTableQueries.insert(bigTable)

--- a/sqldelight-gradle-plugin/src/test/integration-mysql/src/test/kotlin/com/squareup/sqldelight/mysql/integration/MySqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-mysql/src/test/kotlin/com/squareup/sqldelight/mysql/integration/MySqlTest.kt
@@ -20,7 +20,7 @@ class MySqlTest {
     @Test fun simpleSelect() {
         database.dogQueries.insertDog("Tilda", "Pomeranian", true)
         assertThat(database.dogQueries.selectDogs().executeAsOne())
-            .isEqualTo(Dog.Impl(
+            .isEqualTo(Dog(
                 name = "Tilda",
                 breed = "Pomeranian",
                 is_good = true

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/com/squareup/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/com/squareup/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -25,7 +25,7 @@ class PostgreSqlTest {
   @Test fun simpleSelect() {
     database.dogQueries.insertDog("Tilda", "Pomeranian", true)
     assertThat(database.dogQueries.selectDogs().executeAsOne())
-      .isEqualTo(Dog.Impl(
+      .isEqualTo(Dog(
         name = "Tilda",
         breed = "Pomeranian",
         is_good = true

--- a/sqldelight-gradle-plugin/src/test/integration-sqlite-3-24/src/test/java/com/squareup/sqldelight/integration/IntegrationTests.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-sqlite-3-24/src/test/java/com/squareup/sqldelight/integration/IntegrationTests.kt
@@ -24,11 +24,11 @@ class IntegrationTests {
 
     assertThat(personQueries.selectAll().executeAsList())
         .containsExactly(
-            Person.Impl(1, "Alec", "Strong"),
-            Person.Impl(2, "Matt", "Precious"),
-            Person.Impl(3, "Jake", "Wharton"),
-            Person.Impl(4, "Bob", "Bob"),
-            Person.Impl(5, "Bo", "Jangles")
+            Person(1, "Alec", "Strong"),
+            Person(2, "Matt", "Precious"),
+            Person(3, "Jake", "Wharton"),
+            Person(4, "Bob", "Bob"),
+            Person(5, "Bo", "Jangles")
         )
   }
 
@@ -38,10 +38,10 @@ class IntegrationTests {
 
     assertThat(personQueries.selectAll().executeAsList())
         .containsExactly(
-            Person.Impl(1, "Alec", "Strong"),
-            Person.Impl(2, "Matt", "Precious"),
-            Person.Impl(3, "James", "Mosley"),
-            Person.Impl(4, "Bob", "Bob")
+            Person(1, "Alec", "Strong"),
+            Person(2, "Matt", "Precious"),
+            Person(3, "James", "Mosley"),
+            Person(4, "Bob", "Bob")
         )
   }
 }

--- a/sqldelight-gradle-plugin/src/test/integration/src/test/java/com/squareup/sqldelight/integration/IntegrationTests.kt
+++ b/sqldelight-gradle-plugin/src/test/integration/src/test/java/com/squareup/sqldelight/integration/IntegrationTests.kt
@@ -37,31 +37,31 @@ class IntegrationTests {
   @Test fun indexedArgs() {
     // ?1 is the only arg
     val person = personQueries.equivalentNames("Bob").executeAsOne()
-    assertThat(person).isEqualTo(Person.Impl(4, "Bob", "Bob"))
+    assertThat(person).isEqualTo(Person(4, "Bob", "Bob"))
   }
 
   @Test fun startIndexAtTwo() {
     // ?2 is the only arg
     val person = personQueries.equivalentNames2("Bob").executeAsOne()
-    assertThat(person).isEqualTo(Person.Impl(4, "Bob", "Bob"))
+    assertThat(person).isEqualTo(Person(4, "Bob", "Bob"))
   }
 
   @Test fun namedIndexArgs() {
     // :name is the only arg
     val person = personQueries.equivalentNamesNamed("Bob").executeAsOne()
-    assertThat(person).isEqualTo(Person.Impl(4, "Bob", "Bob"))
+    assertThat(person).isEqualTo(Person(4, "Bob", "Bob"))
   }
 
   @Test fun indexedArgLast() {
     // First arg declared is ?, second arg declared is ?1.
     val person = personQueries.indexedArgLast("Bob").executeAsOne()
-    assertThat(person).isEqualTo(Person.Impl(4, "Bob", "Bob"))
+    assertThat(person).isEqualTo(Person(4, "Bob", "Bob"))
   }
 
   @Test fun indexedArgLastTwo() {
     // First arg declared is ?, second arg declared is ?2.
     val person = personQueries.indexedArgLast2("Alec", "Strong").executeAsOne()
-    assertThat(person).isEqualTo(Person.Impl(1, "Alec", "Strong"))
+    assertThat(person).isEqualTo(Person(1, "Alec", "Strong"))
   }
 
   @Test fun nameIn() {
@@ -71,7 +71,7 @@ class IntegrationTests {
 
   @Test fun sqliteKeywordQuery() {
     val keywords = keywordsQueries.selectAll().executeAsOne()
-    assertThat(keywords).isEqualTo(Group.Impl(1, 10, 20))
+    assertThat(keywords).isEqualTo(Group(1, 10, 20))
   }
 
   @Test fun compiledStatement() {
@@ -108,9 +108,9 @@ class IntegrationTests {
 
   @Test
   fun nullableColumnsUseAdapterProperly() {
-    val cool = NullableTypes.Impl(listOf("Alec", "Matt", "Jake"), "Cool")
-    val notCool = NullableTypes.Impl(null, "Not Cool")
-    val nulled = NullableTypes.Impl(null, null)
+    val cool = NullableTypes(listOf("Alec", "Matt", "Jake"), "Cool")
+    val notCool = NullableTypes(null, "Not Cool")
+    val nulled = NullableTypes(null, null)
     nullableTypesQueries.insertNullableType(cool)
     nullableTypesQueries.insertNullableType(notCool)
     nullableTypesQueries.insertNullableType(nulled)
@@ -125,7 +125,7 @@ class IntegrationTests {
   }
 
   @Test fun bigTable() {
-    val bigTable = BigTable.Impl(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+    val bigTable = BigTable(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
         20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30)
 
     bigTableQueries.insert(bigTable)

--- a/sqldelight-idea-plugin/testData/project/src/main/kotlin/com/example/KotlinClass.kt
+++ b/sqldelight-idea-plugin/testData/project/src/main/kotlin/com/example/KotlinClass.kt
@@ -6,9 +6,9 @@ class KotlinClass {
     queryWrapper.mainQueries.someQuery()
 
     queryWrapper.mainQueries.multiQuery()
-    queryWrapper.mainQueries.multiQuery(MultiQuery::Impl)
+    queryWrapper.mainQueries.multiQuery(::MultiQuery)
 
-    queryWrapper.mainQueries.generatesType(GeneratesType::Impl)
+    queryWrapper.mainQueries.generatesType(::GeneratesType)
     queryWrapper.mainQueries.generatesType(::GeneratesTypeImpl)
   }
 


### PR DESCRIPTION
Closes #1286.

Note that this introduces a backwards incompatible change as every instance of `QueryName.Impl(…)` will have to be replaced with `QueryName(…)`. However, per [this comment](https://github.com/cashapp/sqldelight/issues/1286#issuecomment-477388426), no loss in functionality should occur.