### PR TITLE
Support generating schemas from migration files

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/TableInterfaceGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/TableInterfaceGenerator.kt
@@ -15,7 +15,7 @@
  */
 package com.squareup.sqldelight.core.compiler
 
-import com.alecstrong.sql.psi.core.psi.SqlCreateTableStmt
+import com.alecstrong.sql.psi.core.psi.LazyQuery
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.DATA
@@ -28,10 +28,11 @@ import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.joinToCode
 import com.squareup.sqldelight.core.compiler.SqlDelightCompiler.allocateName
 import com.squareup.sqldelight.core.lang.ADAPTER_NAME
+import com.squareup.sqldelight.core.lang.psi.ColumnDefMixin
 import com.squareup.sqldelight.core.lang.psi.ColumnDefMixin.Companion.isArrayType
-import com.squareup.sqldelight.core.lang.util.columns
+import com.squareup.sqldelight.core.lang.util.parentOfType
 
-internal class TableInterfaceGenerator(private val table: SqlCreateTableStmt) {
+internal class TableInterfaceGenerator(private val table: LazyQuery) {
   private val typeName = allocateName(table.tableName).capitalize()
 
   fun kotlinImplementationSpec(): TypeSpec {
@@ -89,4 +90,7 @@ internal class TableInterfaceGenerator(private val table: SqlCreateTableStmt) {
         .primaryConstructor(constructor.build())
         .build()
   }
+
+  private val LazyQuery.columns: Collection<ColumnDefMixin>
+    get() = query.columns.map { it.element.parentOfType<ColumnDefMixin>() }
 }

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/integration/TableIntegration.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/integration/TableIntegration.kt
@@ -1,0 +1,40 @@
+package com.squareup.sqldelight.core.compiler.integration
+
+import com.alecstrong.sql.psi.core.psi.LazyQuery
+import com.alecstrong.sql.psi.core.psi.SqlAlterTableStmt
+import com.alecstrong.sql.psi.core.psi.SqlCreateTableStmt
+import com.alecstrong.sql.psi.core.psi.SqlCreateViewStmt
+import com.alecstrong.sql.psi.core.psi.SqlCreateVirtualTableStmt
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.sqldelight.core.compiler.SqlDelightCompiler
+import com.squareup.sqldelight.core.lang.ADAPTER_NAME
+import com.squareup.sqldelight.core.lang.SqlDelightFile
+import com.squareup.sqldelight.core.lang.util.columns
+import com.squareup.sqldelight.core.psi.SqlDelightColumnDef
+
+internal fun LazyQuery.needsAdapters() = when (tableName.parent) {
+  is SqlCreateViewStmt, is SqlCreateVirtualTableStmt -> false
+  else -> columns().any { it.adapter() != null }
+}
+
+internal fun LazyQuery.adapterProperty(): PropertySpec {
+  val adapterType = ClassName(
+      (tableName.containingFile as SqlDelightFile).packageName,
+      SqlDelightCompiler.allocateName(tableName).capitalize(),
+      ADAPTER_NAME
+  )
+  return PropertySpec.builder(adapterName, adapterType, KModifier.INTERNAL)
+      .initializer(adapterName)
+      .build()
+}
+
+private fun LazyQuery.columns() = when (val parentRule = tableName.parent) {
+  is SqlCreateTableStmt -> parentRule.columns
+  is SqlAlterTableStmt -> query.columns.map { it.element.parent as SqlDelightColumnDef }
+  else -> throw IllegalStateException("Unexpected query parent $parentRule")
+}
+
+internal val LazyQuery.adapterName
+  get() = "${SqlDelightCompiler.allocateName(tableName)}$ADAPTER_NAME"

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/Constants.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/Constants.kt
@@ -1,11 +1,9 @@
 package com.squareup.sqldelight.core.lang
 
-import com.alecstrong.sql.psi.core.psi.SqlCreateTableStmt
 import com.intellij.openapi.vfs.VirtualFile
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.STAR
-import com.squareup.sqldelight.core.compiler.SqlDelightCompiler.allocateName
 
 internal val CURSOR_TYPE = ClassName("com.squareup.sqldelight.db", "SqlCursor")
 internal val CURSOR_NAME = "cursor"
@@ -17,9 +15,6 @@ internal val DATABASE_SCHEMA_TYPE = DRIVER_TYPE.nestedClass("Schema")
 internal val CUSTOM_DATABASE_NAME = "database"
 
 internal val ADAPTER_NAME = "Adapter"
-
-internal val SqlCreateTableStmt.adapterName
-  get() = "${allocateName(tableName)}$ADAPTER_NAME"
 
 internal val QUERY_TYPE = ClassName("com.squareup.sqldelight", "Query")
 

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
@@ -15,8 +15,8 @@
  */
 package com.squareup.sqldelight.core.lang
 
+import com.alecstrong.sql.psi.core.psi.Queryable
 import com.alecstrong.sql.psi.core.psi.SqlBindExpr
-import com.alecstrong.sql.psi.core.psi.SqlCreateTableStmt
 import com.squareup.kotlinpoet.ANY
 import com.squareup.kotlinpoet.BOOLEAN
 import com.squareup.kotlinpoet.BYTE
@@ -30,6 +30,7 @@ import com.squareup.kotlinpoet.SHORT
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
+import com.squareup.sqldelight.core.compiler.integration.adapterName
 import com.squareup.sqldelight.core.lang.psi.ColumnDefMixin
 import com.squareup.sqldelight.core.lang.util.isArrayParameter
 
@@ -79,7 +80,7 @@ internal data class IntermediateType(
   fun preparedStatementBinder(columnIndex: String): CodeBlock {
     val name = if (javaType.isNullable && extracted) "$name!!" else name
     val value = column?.adapter()?.let { adapter ->
-      val adapterName = (column.parent as SqlCreateTableStmt).adapterName
+      val adapterName = (column.parent as Queryable).tableExposed().adapterName
       CodeBlock.of("$CUSTOM_DATABASE_NAME.$adapterName.%N.encode($name)", adapter)
     } ?: when (javaType.copy(nullable = false)) {
       FLOAT -> CodeBlock.of("$name.toDouble()")
@@ -124,7 +125,7 @@ internal data class IntermediateType(
     }
 
     column?.adapter()?.let { adapter ->
-      val adapterName = (column.parent as SqlCreateTableStmt).adapterName
+      val adapterName = (column.parent as Queryable).tableExposed().adapterName
       resultSetGetter = if (javaType.isNullable) {
         CodeBlock.of("%L?.let($CUSTOM_DATABASE_NAME.$adapterName.%N::decode)", resultSetGetter, adapter)
       } else {

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/MigrationParserDefinition.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/MigrationParserDefinition.kt
@@ -1,13 +1,30 @@
 package com.squareup.sqldelight.core.lang
 
+import com.alecstrong.sql.psi.core.DialectPreset
+import com.alecstrong.sql.psi.core.SqlParser
 import com.alecstrong.sql.psi.core.SqlParserDefinition
+import com.intellij.openapi.project.Project
 import com.intellij.psi.FileViewProvider
 import com.intellij.psi.tree.IFileElementType
+import com.squareup.sqldelight.core.SqlDelightProjectService
+import com.squareup.sqldelight.core.SqldelightParserUtil
 
 class MigrationParserDefinition : SqlParserDefinition() {
+  private var dialect: DialectPreset? = null
+
   override fun createFile(viewProvider: FileViewProvider) = MigrationFile(viewProvider)
   override fun getFileNodeType() = FILE
   override fun getLanguage() = SqlDelightLanguage
+
+  override fun createParser(project: Project): SqlParser {
+    val newDialect = SqlDelightProjectService.getInstance(project).dialectPreset
+    if (newDialect != dialect) {
+      newDialect.setup()
+      SqldelightParserUtil.overrideSqlParser()
+      dialect = newDialect
+    }
+    return super.createParser(project)
+  }
 
   companion object {
     private val FILE = IFileElementType(MigrationLanguage)

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/migrations/MigrationQueryTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/migrations/MigrationQueryTest.kt
@@ -1,0 +1,30 @@
+package com.squareup.sqldelight.core.migrations
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.sqldelight.test.util.FixtureCompiler
+import com.squareup.sqldelight.test.util.withInvariantLineSeparators
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class MigrationQueryTest {
+  @get:Rule val tempFolder = TemporaryFolder()
+
+  @Test fun `alter table statements are reflected in queries`() {
+    checkFixtureCompiles("alter-table")
+  }
+
+  private fun checkFixtureCompiles(fixtureRoot: String) {
+    val result = FixtureCompiler.compileFixture(
+        fixtureRoot = "src/test/migration-interface-fixtures/$fixtureRoot",
+        generateDb = false,
+        deriveSchemaFromMigrations = true
+    )
+    for ((expectedFile, actualOutput) in result.compilerOutput) {
+      assertThat(expectedFile.exists()).named("No file with name $expectedFile").isTrue()
+      assertThat(actualOutput.toString())
+          .named(expectedFile.name)
+          .isEqualTo(expectedFile.readText().withInvariantLineSeparators())
+    }
+  }
+}

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/InterfaceGeneration.kt
@@ -608,9 +608,10 @@ class InterfaceGeneration {
 
   private fun checkFixtureCompiles(fixtureRoot: String) {
     val result = FixtureCompiler.compileFixture(
-        "src/test/query-interface-fixtures/$fixtureRoot",
-        SqlDelightCompiler::writeQueryInterfaces,
-        false)
+        fixtureRoot = "src/test/query-interface-fixtures/$fixtureRoot",
+        compilationMethod = SqlDelightCompiler::writeQueryInterfaces,
+        generateDb = false
+    )
     for ((expectedFile, actualOutput) in result.compilerOutput) {
       assertThat(expectedFile.exists()).named("No file with name $expectedFile").isTrue()
       assertThat(actualOutput.toString())

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/tables/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/tables/InterfaceGeneration.kt
@@ -109,7 +109,7 @@ class InterfaceGeneration {
       |);
       |""".trimMargin(), tempFolder)
 
-    val generator = TableInterfaceGenerator(result.sqliteStatements().first().statement.createTableStmt!!)
+    val generator = TableInterfaceGenerator(result.sqliteStatements().first().statement.createTableStmt!!.tableExposed())
     assertThat(generator.kotlinImplementationSpec().toString()).isEqualTo("""
       |data class Test(
       |  val intValue: kotlin.Int,
@@ -152,7 +152,7 @@ class InterfaceGeneration {
       |);
       |""".trimMargin(), tempFolder)
 
-    val generator = TableInterfaceGenerator(result.sqliteStatements().first().statement.createTableStmt!!)
+    val generator = TableInterfaceGenerator(result.sqliteStatements().first().statement.createTableStmt!!.tableExposed())
     val file = FileSpec.builder("", "Test")
         .addType(generator.kotlinImplementationSpec())
         .build()
@@ -218,7 +218,7 @@ class InterfaceGeneration {
       |);
       |""".trimMargin(), tempFolder)
 
-    val generator = TableInterfaceGenerator(result.sqliteStatements().first().statement.createTableStmt!!)
+    val generator = TableInterfaceGenerator(result.sqliteStatements().first().statement.createTableStmt!!.tableExposed())
     assertThat(generator.kotlinImplementationSpec().toString()).isEqualTo("""
       |data class Test(
       |  val mapValue: kotlin.collections.Map<kotlin.collections.List<kotlin.collections.List<String>>, kotlin.collections.List<kotlin.collections.List<String>>>?
@@ -249,7 +249,7 @@ class InterfaceGeneration {
       |);
       |""".trimMargin(), tempFolder)
 
-    val generator = TableInterfaceGenerator(result.sqliteStatements().first().statement.createTableStmt!!)
+    val generator = TableInterfaceGenerator(result.sqliteStatements().first().statement.createTableStmt!!.tableExposed())
     assertThat(generator.kotlinImplementationSpec().toString()).isEqualTo("""
       |data class Test(
       |  val _id: kotlin.Long,
@@ -282,7 +282,7 @@ class InterfaceGeneration {
       |);
       |""".trimMargin(), tempFolder)
 
-        val generator = TableInterfaceGenerator(result.sqliteStatements().first().statement.createTableStmt!!)
+        val generator = TableInterfaceGenerator(result.sqliteStatements().first().statement.createTableStmt!!.tableExposed())
         assertThat(generator.kotlinImplementationSpec().toString()).isEqualTo("""
       |data class Group(
       |  val index1: kotlin.String?,
@@ -304,9 +304,10 @@ class InterfaceGeneration {
 
   private fun checkFixtureCompiles(fixtureRoot: String) {
     val result = FixtureCompiler.compileFixture(
-        "src/test/table-interface-fixtures/$fixtureRoot",
-        SqlDelightCompiler::writeTableInterfaces,
-        false)
+        fixtureRoot = "src/test/table-interface-fixtures/$fixtureRoot",
+        compilationMethod = SqlDelightCompiler::writeTableInterfaces,
+        generateDb = false
+    )
     for ((expectedFile, actualOutput) in result.compilerOutput) {
       assertThat(expectedFile.exists()).named("No file with name $expectedFile").isTrue()
       assertThat(expectedFile.readText().withInvariantLineSeparators())

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/views/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/views/InterfaceGeneration.kt
@@ -175,9 +175,11 @@ class InterfaceGeneration {
 
   private fun checkFixtureCompiles(fixtureRoot: String) {
     val result = FixtureCompiler.compileFixture(
-        "src/test/view-interface-fixtures/$fixtureRoot",
-        SqlDelightCompiler::writeViewInterfaces,
-        false)
+        fixtureRoot = "src/test/view-interface-fixtures/$fixtureRoot",
+        compilationMethod = SqlDelightCompiler::writeViewInterfaces,
+        generateDb = false
+    )
+    assertThat(result.errors).isEmpty()
     for ((expectedFile, actualOutput) in result.compilerOutput) {
       assertThat(expectedFile.exists()).named("No file with name $expectedFile").isTrue()
       assertThat(expectedFile.readText().withInvariantLineSeparators())

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/com/example/1.sqm
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/com/example/1.sqm
@@ -1,0 +1,3 @@
+CREATE TABLE test (
+  first TEXT NOT NULL
+);

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/com/example/2.sqm
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/com/example/2.sqm
@@ -1,0 +1,3 @@
+import kotlin.collections.List;
+
+ALTER TABLE test ADD COLUMN second TEXT AS List<Int>;

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/com/example/3.sqm
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/com/example/3.sqm
@@ -1,0 +1,1 @@
+ALTER TABLE test RENAME TO new_test;

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/com/example/Data.sq
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/com/example/Data.sq
@@ -1,0 +1,3 @@
+migrationSelect:
+SELECT *
+FROM new_test;

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/output/com/example/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/output/com/example/DataQueries.kt
@@ -1,0 +1,14 @@
+package com.example
+
+import com.squareup.sqldelight.Query
+import com.squareup.sqldelight.Transacter
+import kotlin.Any
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.List
+
+interface DataQueries : Transacter {
+  fun <T : Any> migrationSelect(mapper: (first: String, second: List<Int>?) -> T): Query<T>
+
+  fun migrationSelect(): Query<New_test>
+}

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/output/com/example/New_test.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/output/com/example/New_test.kt
@@ -1,0 +1,22 @@
+package com.example
+
+import com.squareup.sqldelight.ColumnAdapter
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.List
+
+data class New_test(
+  val first: String,
+  val second: List<Int>?
+) {
+  override fun toString(): String = """
+  |New_test [
+  |  first: $first
+  |  second: $second
+  |]
+  """.trimMargin()
+
+  class Adapter(
+    val secondAdapter: ColumnAdapter<List<Int>, String>
+  )
+}

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightDatabase.kt
@@ -22,7 +22,8 @@ class SqlDelightDatabase(
   var packageName: String? = null,
   var schemaOutputDirectory: File? = null,
   var sourceFolders: Collection<String>? = null,
-  var dialect: String = "sqlite:3.18"
+  var dialect: String = "sqlite:3.18",
+  var deriveSchemaFromMigrations: Boolean = false
 ) {
   private val generatedSourcesDirectory
     get() = File(project.buildDir, "$FD_GENERATED/sqldelight/code/$name")
@@ -78,7 +79,8 @@ class SqlDelightDatabase(
           outputDirectory = generatedSourcesDirectory.toRelativeString(project.projectDir),
           className = name,
           dependencies = dependencies.map { SqlDelightDatabaseName(it.packageName!!, it.name) },
-          dialectPreset = dialect
+          dialectPreset = dialect,
+          deriveSchemaFromMigrations = deriveSchemaFromMigrations
       )
     } finally {
       recursionGuard = false

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/MigrationTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/MigrationTest.kt
@@ -45,6 +45,24 @@ class MigrationTest {
     )
   }
 
+  @Test fun `deriving schema from migration introduces failures in migration files`() {
+    val fixtureRoot = File("src/test/migration-schema-failure")
+
+    val output = GradleRunner.create()
+        .withProjectDir(fixtureRoot)
+        .withPluginClasspath()
+        .withArguments("clean", "build", "--stacktrace")
+        .buildAndFail()
+
+    assertThat(output.output).contains("""
+      |1.sqm line 5:22 - No column found with name new_column
+      |5    INSERT INTO test (id, new_column)
+      |                           ^^^^^^^^^^
+      |6    VALUES ("hello", "world")
+      """.trimMargin()
+    )
+  }
+
   @Test fun `successful migration works properly`() {
     val fixtureRoot = File("src/test/migration-success")
 

--- a/sqldelight-gradle-plugin/src/test/migration-schema-failure/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/migration-schema-failure/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+  id 'kotlin'
+  id 'com.squareup.sqldelight'
+}
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+  }
+  mavenCentral()
+}
+
+sqldelight {
+  Database {
+    packageName = "com.example"
+    deriveSchemaFromMigrations = true
+  }
+}

--- a/sqldelight-gradle-plugin/src/test/migration-schema-failure/src/main/sqldelight/migrations/1.sqm
+++ b/sqldelight-gradle-plugin/src/test/migration-schema-failure/src/main/sqldelight/migrations/1.sqm
@@ -1,0 +1,6 @@
+CREATE TABLE test (
+  id INTEGER NOT NULL
+);
+
+INSERT INTO test (id, new_column)
+VALUES ("hello", "world");

--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/lang/SqlDelightFileViewProviderFactory.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/lang/SqlDelightFileViewProviderFactory.kt
@@ -130,6 +130,7 @@ private class SqlDelightFileViewProvider(
       if (file is SqlDelightQueriesFile) {
         SqlDelightCompiler.writeInterfaces(module, file, module.name, fileAppender)
       } else if (file is MigrationFile) {
+        SqlDelightCompiler.writeInterfaces(module, file, module.name, fileAppender)
       }
       this.filesGenerated = files
     }

--- a/sqldelight-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/sqldelight-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -69,6 +69,10 @@
     <!-- Migration Extensions -->
     <lang.syntaxHighlighterFactory language="SqlDelightMigration"
         implementationClass="com.squareup.sqldelight.intellij.lang.SqlDelightSyntaxHighlighterFactory"/>
+    <lang.fileViewProviderFactory language="SqlDelightMigration"
+        implementationClass="com.squareup.sqldelight.intellij.lang.SqlDelightFileViewProviderFactory"/>
+    <lang.commenter language="SqlDelightMigration"
+        implementationClass="com.squareup.sqldelight.intellij.lang.SqlDelightCommenter"/>
 
     <intentionAction>
       <className>com.squareup.sqldelight.intellij.intentions.ExpandColumnNamesWildcardQuickFix</className>


### PR DESCRIPTION
 - Respects the deriveSchemaFromMigrations gradle flag
 - Basic support for IDE, there's probably bugs
 - Migration files now use the same dialect as queries files.
   Long term this isn't the plan, but short term it enables
   code gen and custom types in ALTER TABLE statements.