### PR TITLE
Return connections to the data source pool

### DIFF
--- a/drivers/sqlite-driver/src/main/kotlin/com/squareup/sqldelight/sqlite/driver/JdbcSqliteDriver.kt
+++ b/drivers/sqlite-driver/src/main/kotlin/com/squareup/sqldelight/sqlite/driver/JdbcSqliteDriver.kt
@@ -1,5 +1,6 @@
 package com.squareup.sqldelight.sqlite.driver
 
+import java.sql.Connection
 import java.sql.DriverManager
 import java.util.Properties
 import kotlin.DeprecationLevel.ERROR
@@ -20,7 +21,16 @@ class JdbcSqliteDriver constructor(
       ReplaceWith("JdbcSqliteDriver(IN_MEMORY, properties)"), ERROR)
   constructor(properties: Properties = Properties()) : this(IN_MEMORY, properties)
 
+  // SQLite only uses a single connection.
   private val connection = DriverManager.getConnection(url, properties)
 
+  override fun closeConnection(connection: Connection) {
+    // No-op
+  }
+
   override fun getConnection() = connection
+
+  override fun close() {
+    connection.close()
+  }
 }

--- a/sqldelight-gradle-plugin/src/test/integration-hsql/src/test/kotlin/com/squareup/sqldelight/hsql/integration/HsqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-hsql/src/test/kotlin/com/squareup/sqldelight/hsql/integration/HsqlTest.kt
@@ -2,6 +2,7 @@ package com.squareup.sqldelight.hsql.integration
 
 import com.google.common.truth.Truth.assertThat
 import com.squareup.sqldelight.sqlite.driver.JdbcDriver
+import java.sql.Connection
 import java.sql.DriverManager
 import org.junit.After
 import org.junit.Before
@@ -11,6 +12,7 @@ class HsqlTest {
   val conn = DriverManager.getConnection("jdbc:hsqldb:mem:mymemdb")
   val driver = object : JdbcDriver() {
     override fun getConnection() = conn
+    override fun closeConnection(connection: Connection) = Unit
   }
   val database = MyDatabase(driver)
 

--- a/sqldelight-gradle-plugin/src/test/integration-mysql/src/test/kotlin/com/squareup/sqldelight/mysql/integration/MySqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-mysql/src/test/kotlin/com/squareup/sqldelight/mysql/integration/MySqlTest.kt
@@ -17,6 +17,7 @@ class MySqlTest {
         connection = DriverManager.getConnection("jdbc:tc:mysql:///myDb")
         val driver = object : JdbcDriver() {
             override fun getConnection() = connection
+            override fun closeConnection(connection: Connection) = Unit
         }
         val database = MyDatabase(driver)
 

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/com/squareup/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/com/squareup/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -2,6 +2,7 @@ package com.squareup.sqldelight.postgresql.integration
 
 import com.google.common.truth.Truth.assertThat
 import com.squareup.sqldelight.sqlite.driver.JdbcDriver
+import java.sql.Connection
 import java.sql.DriverManager
 import org.junit.After
 import org.junit.Before
@@ -11,6 +12,7 @@ class PostgreSqlTest {
   val conn = DriverManager.getConnection("jdbc:tc:postgresql:9.6.8:///my_db")
   val driver = object : JdbcDriver() {
     override fun getConnection() = conn
+    override fun closeConnection(connection: Connection) = Unit
   }
   val database = MyDatabase(driver)
 


### PR DESCRIPTION
Closes #1614

I'm not in love with this API, but need something to give connections back to the jdbcDriver implementor. I figure we just entirely forego doing connection pooling in our driver and let the dataSource handle it, which I'm assuming is how this will usually be used.

cc @nikolajakshic in case you have thoughts here