### PR TITLE
Bind args generation fails when numbered nullable parameter used twice

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/QueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/QueryGenerator.kt
@@ -92,7 +92,7 @@ abstract class QueryGenerator(private val query: BindableQuery) {
       } else {
         nonArrayBindArgsCount += 1
         if (type.javaType.isNullable) {
-          val parent = type.bindArg?.parent
+          val parent = bindArg?.parent
           if (parent is SqlBinaryEqualityExpr) {
             needsFreshStatement = true
 


### PR DESCRIPTION
The test passes, this codegen is wrong

@JGulbronson 