### PR TITLE
Avoid creating duplicate argument arrays for the same parameter

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
@@ -79,8 +79,9 @@ internal data class IntermediateType(
    */
   fun preparedStatementBinder(
     columnIndex: String,
-    name: String = if (javaType.isNullable && extracted) "${this.name}!!" else this.name
+    overrideName: String? = null
   ): CodeBlock {
+    val name = if (javaType.isNullable && extracted) "${this.name}!!" else this.name
     val value = column?.adapter()?.let { adapter ->
       val adapterName = (column.parent as Queryable).tableExposed().adapterName
       CodeBlock.of("$CUSTOM_DATABASE_NAME.$adapterName.%N.encode($name)", adapter)
@@ -91,7 +92,7 @@ internal data class IntermediateType(
       INT -> CodeBlock.of("$name.toLong()")
       BOOLEAN -> CodeBlock.of("if ($name) 1L else 0L")
       else -> {
-        return sqliteType.prepareStatementBinder(columnIndex, CodeBlock.of(name))
+        return sqliteType.prepareStatementBinder(columnIndex, CodeBlock.of(overrideName ?: this.name))
       }
     }
 

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
@@ -77,8 +77,10 @@ internal data class IntermediateType(
    *
    * eg: statement.bindBytes(0, queryWrapper.tableNameAdapter.columnNameAdapter.encode(column))
    */
-  fun preparedStatementBinder(columnIndex: String): CodeBlock {
-    val name = if (javaType.isNullable && extracted) "$name!!" else name
+  fun preparedStatementBinder(
+      columnIndex: String,
+      name: String = if (javaType.isNullable && extracted) "${this.name}!!" else this.name
+  ): CodeBlock {
     val value = column?.adapter()?.let { adapter ->
       val adapterName = (column.parent as Queryable).tableExposed().adapterName
       CodeBlock.of("$CUSTOM_DATABASE_NAME.$adapterName.%N.encode($name)", adapter)
@@ -89,7 +91,7 @@ internal data class IntermediateType(
       INT -> CodeBlock.of("$name.toLong()")
       BOOLEAN -> CodeBlock.of("if ($name) 1L else 0L")
       else -> {
-        return sqliteType.prepareStatementBinder(columnIndex, CodeBlock.of(this.name))
+        return sqliteType.prepareStatementBinder(columnIndex, CodeBlock.of(name))
       }
     }
 

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
@@ -78,8 +78,8 @@ internal data class IntermediateType(
    * eg: statement.bindBytes(0, queryWrapper.tableNameAdapter.columnNameAdapter.encode(column))
    */
   fun preparedStatementBinder(
-      columnIndex: String,
-      name: String = if (javaType.isNullable && extracted) "${this.name}!!" else this.name
+    columnIndex: String,
+    name: String = if (javaType.isNullable && extracted) "${this.name}!!" else this.name
   ): CodeBlock {
     val value = column?.adapter()?.let { adapter ->
       val adapterName = (column.parent as Queryable).tableExposed().adapterName

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryFunctionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryFunctionTest.kt
@@ -251,8 +251,8 @@ class MutatorQueryFunctionTest {
       |  |WHERE id IN ${"$"}idIndexes
       |  ""${'"'}.trimMargin(), 1 + id.size) {
       |    bindString(1, if (value == null) null else database.dataAdapter.valueAdapter.encode(value))
-      |    id.forEachIndexed { index, id ->
-      |        bindLong(index + 2, id)
+      |    id.forEachIndexed { index, id_ ->
+      |        bindLong(index + 2, id_)
       |        }
       |  }
       |}

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryFunctionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryFunctionTest.kt
@@ -199,11 +199,11 @@ class SelectQueryFunctionTest {
       |    |FROM data
       |    |WHERE id IN ${"$"}goodIndexes AND id NOT IN ${"$"}badIndexes
       |    ""${'"'}.trimMargin(), good.size + bad.size) {
-      |      good.forEachIndexed { index, good ->
-      |          bindLong(index + 1, good)
+      |      good.forEachIndexed { index, good_ ->
+      |          bindLong(index + 1, good_)
       |          }
-      |      bad.forEachIndexed { index, bad ->
-      |          bindLong(index + good.size + 1, bad)
+      |      bad.forEachIndexed { index, bad_ ->
+      |          bindLong(index + good.size + 1, bad_)
       |          }
       |    }
       |  }

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryTypeTest.kt
@@ -156,8 +156,8 @@ class SelectQueryTypeTest {
       |          bindLong(index + 1, id_)
       |          }
       |      bindString(id.size + 1, message)
-      |      id.forEachIndexed { index, id_ ->
-      |          bindLong(index + id.size + 2, id_)
+      |      id.forEachIndexed { index, id__ ->
+      |          bindLong(index + id.size + 2, id__)
       |          }
       |    }
       |  }

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryTypeTest.kt
@@ -111,8 +111,8 @@ class SelectQueryTypeTest {
       |    |FROM data
       |    |WHERE id IN ${"$"}idIndexes
       |    ""${'"'}.trimMargin(), id.size) {
-      |      id.forEachIndexed { index, id ->
-      |          bindLong(index + 1, id)
+      |      id.forEachIndexed { index, id_ ->
+      |          bindLong(index + 1, id_)
       |          }
       |    }
       |  }
@@ -152,12 +152,12 @@ class SelectQueryTypeTest {
       |    |FROM data
       |    |WHERE id IN ${"$"}idIndexes AND message != ? AND id IN ${"$"}idIndexes
       |    ""${'"'}.trimMargin(), 1 + id.size + id.size) {
-      |      id.forEachIndexed { index, id ->
-      |          bindLong(index + 1, id)
+      |      id.forEachIndexed { index, id_ ->
+      |          bindLong(index + 1, id_)
       |          }
       |      bindString(id.size + 1, message)
-      |      id.forEachIndexed { index, id ->
-      |          bindLong(index + id.size + 2, id)
+      |      id.forEachIndexed { index, id_ ->
+      |          bindLong(index + id.size + 2, id_)
       |          }
       |    }
       |  }
@@ -366,14 +366,14 @@ class SelectQueryTypeTest {
       |    |  AND token IN ${"$"}token_Indexes
       |    ""${'"'}.trimMargin(), 4 + id.size + token_.size) {
       |      bindString(1, token)
-      |      id.forEachIndexed { index, id ->
-      |          bindLong(index + 2, id)
+      |      id.forEachIndexed { index, id_ ->
+      |          bindLong(index + 2, id_)
       |          }
       |      bindString(id.size + 2, token)
       |      bindString(id.size + 3, name)
       |      bindString(id.size + 4, name)
-      |      token_.forEachIndexed { index, token_ ->
-      |          bindString(index + id.size + 5, token_)
+      |      token_.forEachIndexed { index, token__ ->
+      |          bindString(index + id.size + 5, token__)
       |          }
       |    }
       |  }


### PR DESCRIPTION
I will update `createArguments` in a followup, since `offset` is no longer needed