### PR TITLE
Preserve named arguments in MySQL

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/BindableQuery.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/BindableQuery.kt
@@ -21,7 +21,6 @@ import com.alecstrong.sql.psi.core.psi.SqlCreateTableStmt
 import com.alecstrong.sql.psi.core.psi.SqlIdentifier
 import com.alecstrong.sql.psi.core.psi.SqlInsertStmt
 import com.alecstrong.sql.psi.core.psi.SqlTypes
-import com.alecstrong.sql.psi.core.sqlite_3_18.psi.BindParameter
 import com.intellij.psi.PsiElement
 import com.squareup.sqldelight.core.compiler.SqlDelightCompiler.allocateName
 import com.squareup.sqldelight.core.lang.IntermediateType

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/BindableQuery.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/BindableQuery.kt
@@ -152,9 +152,7 @@ abstract class BindableQuery(
   }
 
   private val SqlBindParameter.identifier: SqlIdentifier?
-    get() =
-      if (this is BindParameter) childOfType(SqlTypes.IDENTIFIER) as? SqlIdentifier
-      else null
+    get() = childOfType(SqlTypes.IDENTIFIER) as? SqlIdentifier
 
   internal fun javadocText(): String? {
     if (javadoc == null) return null

--- a/test-util/src/main/kotlin/com/squareup/sqldelight/test/util/FixtureCompiler.kt
+++ b/test-util/src/main/kotlin/com/squareup/sqldelight/test/util/FixtureCompiler.kt
@@ -16,6 +16,7 @@
 
 package com.squareup.sqldelight.test.util
 
+import com.alecstrong.sql.psi.core.DialectPreset
 import com.alecstrong.sql.psi.core.SqlAnnotationHolder
 import com.intellij.openapi.module.Module
 import com.intellij.psi.PsiDocumentManager
@@ -60,11 +61,12 @@ object FixtureCompiler {
   fun parseSql(
     sql: String,
     temporaryFolder: TemporaryFolder,
-    fileName: String = "Test.sq"
+    fileName: String = "Test.sq",
+    dialectPreset: DialectPreset = DialectPreset.SQLITE_3_18
   ): SqlDelightQueriesFile {
     writeSql(sql, temporaryFolder, fileName)
     val errors = mutableListOf<String>()
-    val parser = TestEnvironment()
+    val parser = TestEnvironment(dialectPreset = dialectPreset)
     val environment = parser.build(temporaryFolder.fixtureRoot().path,
         createAnnotationHolder(errors)
     )

--- a/test-util/src/main/kotlin/com/squareup/sqldelight/test/util/TestEnvironment.kt
+++ b/test-util/src/main/kotlin/com/squareup/sqldelight/test/util/TestEnvironment.kt
@@ -10,7 +10,8 @@ import java.io.File
 
 internal class TestEnvironment(
   private val outputDirectory: File = File("output"),
-  private val deriveSchemaFromMigrations: Boolean = false
+  private val deriveSchemaFromMigrations: Boolean = false,
+  private val dialectPreset: DialectPreset = DialectPreset.SQLITE_3_18
 ) {
   fun build(root: String): SqlCoreEnvironment {
     return build(root, object : SqlAnnotationHolder {
@@ -33,7 +34,7 @@ internal class TestEnvironment(
             dependencies = emptyList(),
             compilationUnits = emptyList(),
             outputDirectory = outputDirectory.absolutePath,
-            dialectPreset = DialectPreset.SQLITE_3_18,
+            dialectPreset = dialectPreset,
             deriveSchemaFromMigrations = deriveSchemaFromMigrations
         ),
         outputDirectory = outputDirectory,


### PR DESCRIPTION
This should actually preserve in Postgres as well, it just removes the non Sqlite specific code.

