### PR TITLE
Dynamically change .sq file icon based on dialect

### DIFF
--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightFileIconProvider.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightFileIconProvider.kt
@@ -1,0 +1,28 @@
+package com.squareup.sqldelight.intellij
+
+import com.alecstrong.sql.psi.core.DialectPreset
+import com.intellij.icons.AllIcons
+import com.intellij.ide.FileIconProvider
+import com.intellij.lang.LanguageUtil
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.squareup.sqldelight.core.SqlDelightProjectService
+import com.squareup.sqldelight.core.lang.SqlDelightLanguage
+import javax.swing.Icon
+
+class SqlDelightFileIconProvider : FileIconProvider {
+
+  override fun getIcon(file: VirtualFile, flags: Int, project: Project?): Icon? {
+    return if (project != null && LanguageUtil.getFileLanguage(file) == SqlDelightLanguage) {
+      when (SqlDelightProjectService.getInstance(project).dialectPreset) {
+        DialectPreset.SQLITE_3_18 -> AllIcons.Providers.Sqlite
+        DialectPreset.SQLITE_3_24 -> AllIcons.Providers.Sqlite
+        DialectPreset.MYSQL -> AllIcons.Providers.Mysql
+        DialectPreset.POSTGRESQL -> AllIcons.Providers.Postgresql
+        DialectPreset.HSQL -> AllIcons.Providers.Hsqldb
+      }
+    } else {
+      null
+    }
+  }
+}

--- a/sqldelight-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/sqldelight-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -23,6 +23,7 @@
 
   <extensions defaultExtensionNs="com.intellij">
     <fileTypeFactory implementation="com.squareup.sqldelight.intellij.lang.SqlDelightFileTypeFactory"/>
+    <fileIconProvider implementation="com.squareup.sqldelight.intellij.SqlDelightFileIconProvider" />
     <errorHandler implementation="com.squareup.sqldelight.intellij.SqlDelightErrorHandler" />
 
     <annotator language="SqlDelight"


### PR DESCRIPTION
Based on the conversation from https://github.com/cashapp/sqldelight/pull/1715. Surprisingly not as difficult as expected!

![ezgif-2-00690f179a97](https://user-images.githubusercontent.com/6900601/83570035-ac38d480-a525-11ea-8441-4562fdfa3283.gif)

Caveat: This gives a weird result for multi-dialect projects where the `.sq` file icon is randomly assigned to one of the project dialect icons. This is most likely due to the following `TODO`:

https://github.com/cashapp/sqldelight/blob/34ecf08f14b8caf15bc1c88125e64c064bb3ef06/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightProjectComponent.kt#L68-L77