### PR TITLE
Fix leaky DataSource

### DIFF
--- a/extensions/android-paging/src/main/java/com/squareup/sqldelight/android/paging/QueryDataSourceFactory.kt
+++ b/extensions/android-paging/src/main/java/com/squareup/sqldelight/android/paging/QueryDataSourceFactory.kt
@@ -21,8 +21,31 @@ private class QueryDataSource<RowType : Any>(
 ) : PositionalDataSource<RowType>(),
     Query.Listener {
   private var query: Query<RowType>? = null
+  private val callbacks = linkedSetOf<InvalidatedCallback>()
 
   override fun queryResultsChanged() = invalidate()
+
+  override fun invalidate() {
+    query?.removeListener(this)
+    query = null
+    super.invalidate()
+  }
+
+  override fun addInvalidatedCallback(onInvalidatedCallback: InvalidatedCallback) {
+    super.addInvalidatedCallback(onInvalidatedCallback)
+    if (callbacks.isEmpty()) {
+      query?.addListener(this)
+    }
+    callbacks.add(onInvalidatedCallback)
+  }
+
+  override fun removeInvalidatedCallback(onInvalidatedCallback: InvalidatedCallback) {
+    super.removeInvalidatedCallback(onInvalidatedCallback)
+    callbacks.remove(onInvalidatedCallback)
+    if (callbacks.isEmpty()) {
+      query?.removeListener(this)
+    }
+  }
 
   override fun loadRange(
     params: LoadRangeParams,
@@ -30,7 +53,9 @@ private class QueryDataSource<RowType : Any>(
   ) {
     query?.removeListener(this)
     queryProvider(params.loadSize.toLong(), params.startPosition.toLong()).let { query ->
-      query.addListener(this)
+      if (callbacks.isNotEmpty()) {
+        query.addListener(this)
+      }
       this.query = query
       if (!isInvalid) {
         callback.onResult(query.executeAsList())
@@ -44,7 +69,9 @@ private class QueryDataSource<RowType : Any>(
   ) {
     query?.removeListener(this)
     queryProvider(params.requestedLoadSize.toLong(), params.requestedStartPosition.toLong()).let { query ->
-      query.addListener(this)
+      if (callbacks.isNotEmpty()) {
+        query.addListener(this)
+      }
       this.query = query
       if (!isInvalid) {
         transacter.transaction {


### PR DESCRIPTION
Fixesx #1628 

Conceptually whats changing here: we should only be calling invalidate if there are invalidation listeners, meaning we should only have a query listener if there are invalidation listeners

the rx api on top of paging (and im assuming other apis) remove their listener on `dispose` dropping it to zero, which would then trigger the data source to remove the query listener