### PR TITLE
Also cache gradle with github actions

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -30,6 +30,13 @@ jobs:
         with:
           path: lib/download
           key: intellij-${{ hashFiles('gradle/dependencies.gradle') }}
+      - name: Cache gradle
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
       - name: Run ubuntu tests
         if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
They increased the size to 5gb which should be enough for our deps now