### PR TITLE
Remove !! for intermediate types

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
@@ -80,7 +80,6 @@ internal data class IntermediateType(
   fun preparedStatementBinder(
     columnIndex: String
   ): CodeBlock {
-    val name = if (javaType.isNullable && extracted) "${this.name}!!" else this.name
     val value = column?.adapter()?.let { adapter ->
       val adapterName = (column.parent as Queryable).tableExposed().adapterName
       CodeBlock.of("$CUSTOM_DATABASE_NAME.$adapterName.%N.encode($name)", adapter)

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryFunctionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryFunctionTest.kt
@@ -116,7 +116,7 @@ class MutatorQueryFunctionTest {
       |  |VALUES (?, ?)
       |  ""${'"'}.trimMargin(), 2) {
       |    bindLong(1, data.id)
-      |    bindString(2, if (data.value == null) null else database.dataAdapter.valueAdapter.encode(data.value!!))
+      |    bindString(2, if (data.value == null) null else database.dataAdapter.valueAdapter.encode(data.value))
       |  }
       |}
       |""".trimMargin())
@@ -174,7 +174,7 @@ class MutatorQueryFunctionTest {
       |  |VALUES (?, ?)
       |  ""${'"'}.trimMargin(), 2) {
       |    bindLong(1, data.id)
-      |    bindString(2, if (data.value == null) null else database.dataAdapter.valueAdapter.encode(data.value!!))
+      |    bindString(2, if (data.value == null) null else database.dataAdapter.valueAdapter.encode(data.value))
       |  }
       |}
       |""".trimMargin())
@@ -364,7 +364,7 @@ class MutatorQueryFunctionTest {
       |  |INSERT INTO nullableTypes
       |  |VALUES (?, ?)
       |  ""${'"'}.trimMargin(), 2) {
-      |    bindString(1, if (nullableTypes.val1 == null) null else database.nullableTypesAdapter.val1Adapter.encode(nullableTypes.val1!!))
+      |    bindString(1, if (nullableTypes.val1 == null) null else database.nullableTypesAdapter.val1Adapter.encode(nullableTypes.val1))
       |    bindString(2, nullableTypes.val2)
       |  }
       |}


### PR DESCRIPTION
Fixes #1750. This isn't needed anymore, since Kotlin null-safety guarantees are improved now that we're referencing a `data class` property directly instead of going through an `interface`.