### PR TITLE
Improve unsupported dialect error message

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightDatabase.kt
@@ -56,14 +56,16 @@ class SqlDelightDatabase(
     check(!recursionGuard) { "Found a circular dependency in $project with database $name" }
     recursionGuard = true
 
-    val dialect = when (dialect) {
-      "sqlite:3.18" -> DialectPreset.SQLITE_3_18
-      "sqlite:3.24" -> DialectPreset.SQLITE_3_24
-      "mysql" -> DialectPreset.MYSQL
-      "postgresql" -> DialectPreset.POSTGRESQL
-      "hsql" -> DialectPreset.HSQL
-      else -> throw GradleException("Unknown dialect $dialect")
-    }
+    val dialectMapping = mapOf(
+        "sqlite:3.18" to DialectPreset.SQLITE_3_18,
+        "sqlite:3.24" to DialectPreset.SQLITE_3_24,
+        "mysql" to DialectPreset.MYSQL,
+        "postgresql" to DialectPreset.POSTGRESQL,
+        "hsql" to DialectPreset.HSQL
+    )
+
+    val dialect = dialectMapping[dialect]
+        ?: throw GradleException("The dialect $dialect is not supported. Supported dialects: ${dialectMapping.keys.joinToString()}.")
 
     try {
       return SqlDelightDatabaseProperties(


### PR DESCRIPTION
When an unsupported dialect is specified in `build.gradle`, throw an error with the dialects supported by SQLDelight.

For example, if the `dialect` is set to `"postgres"`, the following error message is displayed:

```
> The dialect postgres is not supported. Supported dialects: sqlite:3.18, sqlite:3.24, mysql, postgresql, hsql.
```

Hopefully, this can save some people (including myself) some trips to the documentation 😄 