### PR TITLE
Add SQLDelight Live Templates that mimic built-in SQL Live Templates

### DIFF
--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightLiveTemplateContextType.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightLiveTemplateContextType.kt
@@ -1,0 +1,13 @@
+package com.squareup.sqldelight.intellij
+
+import com.intellij.codeInsight.template.TemplateContextType
+import com.intellij.psi.PsiFile
+import com.squareup.sqldelight.core.lang.MigrationFileType
+import com.squareup.sqldelight.core.lang.SqlDelightFileType
+
+class SqlDelightLiveTemplateContextType : TemplateContextType("SQLDELIGHT", "SqlDelight") {
+
+  private val supportedFileTypes = setOf(SqlDelightFileType, MigrationFileType)
+
+  override fun isInContext(file: PsiFile, offset: Int): Boolean = file.fileType in supportedFileTypes
+}

--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightLiveTemplatesProvider.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightLiveTemplatesProvider.kt
@@ -1,0 +1,10 @@
+package com.squareup.sqldelight.intellij
+
+import com.intellij.codeInsight.template.impl.DefaultLiveTemplatesProvider
+
+class SqlDelightLiveTemplatesProvider : DefaultLiveTemplatesProvider {
+
+  override fun getDefaultLiveTemplateFiles(): Array<String> = arrayOf("liveTemplates/SqlDelight")
+
+  override fun getHiddenLiveTemplateFiles(): Array<String>? = null
+}

--- a/sqldelight-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/sqldelight-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -39,6 +39,9 @@
     <internalFileTemplate name="SqlDelight Table"/>
     <internalFileTemplate name="SqlDelight Migration"/>
 
+    <defaultLiveTemplatesProvider implementation="com.squareup.sqldelight.intellij.SqlDelightLiveTemplatesProvider"/>
+    <liveTemplateContext implementation="com.squareup.sqldelight.intellij.SqlDelightLiveTemplateContextType"/>
+
     <fileIconProvider implementation="com.squareup.sqldelight.intellij.SqlDelightFileIconProvider" />
     <errorHandler implementation="com.squareup.sqldelight.intellij.SqlDelightErrorHandler"/>
 

--- a/sqldelight-idea-plugin/src/main/resources/liveTemplates/SqlDelight.xml
+++ b/sqldelight-idea-plugin/src/main/resources/liveTemplates/SqlDelight.xml
@@ -1,0 +1,55 @@
+<templateSet group="SQLDelight">
+  <template name="col" value="$col$ $type$ $null$$END$" description="new column definition" toReformat="true" toShortenFQNames="false">
+    <variable name="col" expression="" defaultValue="&quot;col&quot;" alwaysStopAt="true"/>
+    <variable name="type" expression="" defaultValue="&quot;INT&quot;" alwaysStopAt="true"/>
+    <variable name="null" expression="" defaultValue="&quot;NOT NULL&quot;" alwaysStopAt="true"/>
+    <context>
+      <option name="SQLDELIGHT" value="true"/>
+    </context>
+  </template>
+  <template name="ins" value="INSERT INTO $table$ ($columns$) VALUES ($info$$END$);" description="insert rows into a table" toReformat="true" toShortenFQNames="false">
+    <variable name="table" expression="complete()" defaultValue="" alwaysStopAt="true"/>
+    <variable name="columns" expression="complete()" defaultValue="" alwaysStopAt="true"/>
+    <variable name="info" expression="showParameterInfo()" defaultValue="" alwaysStopAt="true"/>
+    <context>
+      <option name="SQLDELIGHT" value="true"/>
+    </context>
+  </template>
+  <template name="sel" value="SELECT * FROM $table$$END$;" description="select all rows from a table" toReformat="true" toShortenFQNames="false">
+    <variable name="table" expression="complete()" defaultValue="" alwaysStopAt="true"/>
+    <context>
+      <option name="SQLDELIGHT" value="true"/>
+    </context>
+  </template>
+  <template name="selc" value="SELECT COUNT(*) FROM $table$ $alias$ WHERE $alias$.$END$;" description="select the number of specific rows in a table" toReformat="true" toShortenFQNames="false">
+    <variable name="table" expression="complete()" defaultValue="" alwaysStopAt="true"/>
+    <variable name="alias" expression="complete()" defaultValue="&quot;alias&quot;" alwaysStopAt="true"/>
+    <context>
+      <option name="SQLDELIGHT" value="true"/>
+    </context>
+  </template>
+  <template name="selw" value="SELECT * FROM $table$ $alias$ WHERE $alias$.$END$;" description="select specific rows from a table" toReformat="true" toShortenFQNames="false">
+    <variable name="table" expression="complete()" defaultValue="" alwaysStopAt="true"/>
+    <variable name="alias" expression="complete()" defaultValue="&quot;alias&quot;" alwaysStopAt="true"/>
+    <context>
+      <option name="SQLDELIGHT" value="true"/>
+    </context>
+  </template>
+  <template name="tab" value="CREATE TABLE $table$ (&#10;  $col$ $type$ $null$$END$&#10;);" description="new table definition" toReformat="true" toShortenFQNames="false">
+    <variable name="table" expression="" defaultValue="&quot;new_table&quot;" alwaysStopAt="true"/>
+    <variable name="col" expression="" defaultValue="&quot;col&quot;" alwaysStopAt="true"/>
+    <variable name="type" expression="" defaultValue="&quot;INT&quot;" alwaysStopAt="true"/>
+    <variable name="null" expression="" defaultValue="&quot;NOT NULL&quot;" alwaysStopAt="true"/>
+    <context>
+      <option name="SQLDELIGHT" value="true"/>
+    </context>
+  </template>
+  <template name="upd" value="UPDATE $table_name$ SET $col$ = $value$ WHERE $END$;" description="update values in a table" toReformat="true" toShortenFQNames="false">
+    <variable name="table_name" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="col" expression="complete()" defaultValue="" alwaysStopAt="true"/>
+    <variable name="value" expression="" defaultValue="" alwaysStopAt="true"/>
+    <context>
+      <option name="SQLDELIGHT" value="true"/>
+    </context>
+  </template>
+</templateSet>


### PR DESCRIPTION
Closes (?) https://github.com/cashapp/sqldelight/issues/1154 — Not sure as the referenced issue discusses live templates that aren't in this PR.

I copied the live templates of the built-in "SQL" template group just to keep some parity between the live templates when editing raw SQL files and SQLDelight files in IntelliJ. Also note that the "SQL" template group indicates that their live templates can be used for **all** SQL dialects, meaning that the proposed SQLDelight live templates are independent of the selected dialect.

![Live](https://user-images.githubusercontent.com/6900601/84316198-01e72f80-ab6b-11ea-929b-5d342109bc4d.gif)
