### PR TITLE
Add a new method for returning a value from a transaction

### DIFF
--- a/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/TransacterTest.kt
+++ b/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/TransacterTest.kt
@@ -193,4 +193,23 @@ abstract class TransacterTest {
       assertTrue("Exception thrown in rollback not in message($e)") { e.toString().contains("ExceptionB") }
     }
   }
+
+  @Test
+  fun `we can return a value from a transaction`() {
+    val result: String = transacter.transactionWithResult {
+      return@transactionWithResult "sup"
+    }
+
+    assertEquals(result, "sup")
+  }
+
+  @Test
+  fun `we can rollback with value from a transaction`() {
+    val result: String = transacter.transactionWithResult {
+      rollback("rollback")
+      return@transactionWithResult "sup"
+    }
+
+    assertEquals(result, "rollback")
+  }
 }


### PR DESCRIPTION
thank you @ansman for prior art

Closes #1219 

I think this is still binary compatible?

Also open to other ideas here, I would love to overload and just have both methods be called `transaction` but the compiler was incapable of resolving to the one with a return value