### PR TITLE
Normalize case when preparing fts5 sql

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/util/TreeUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/util/TreeUtil.kt
@@ -96,7 +96,7 @@ private fun PsiElement.rangesToReplace(): List<Pair<IntRange, String>> {
             (javaTypeName!!.node.startOffset + javaTypeName!!.node.textLength),
         second = ""
     ))
-  } else if (this is SqlModuleArgument && moduleArgumentDef?.columnDef != null && (parent as SqlCreateVirtualTableStmt).moduleName?.text == "fts5") {
+  } else if (this is SqlModuleArgument && moduleArgumentDef?.columnDef != null && (parent as SqlCreateVirtualTableStmt).moduleName?.text?.toLowerCase() == "fts5") {
     val columnDef = moduleArgumentDef!!.columnDef!!
     // If there is a space at the end of the constraints, preserve it.
     val lengthModifier = if (columnDef.columnConstraintList.isNotEmpty() && columnDef.columnConstraintList.last()?.lastChild?.prevSibling is PsiWhiteSpace) 1 else 0

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/util/TreeUtilTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/util/TreeUtilTest.kt
@@ -113,4 +113,22 @@ class TreeUtilTest {
       |)
     """.trimMargin())
   }
+
+  @Test fun `rawSqlText removes type and constraints for FTS5`() {
+    val file = FixtureCompiler.parseSql("""
+      |CREATE VIRTUAL TABLE data USING FTS5 (
+      |  value TEXT NOT NULL,
+      |  prefix='2 3 4 5 6'
+      |);
+    """.trimMargin(), temporaryFolder)
+
+    val createTable = file.sqliteStatements().first().statement.createVirtualTableStmt!!
+
+    assertThat(createTable.rawSqlText()).isEqualTo("""
+      |CREATE VIRTUAL TABLE data USING FTS5 (
+      |  value,
+      |  prefix='2 3 4 5 6'
+      |)
+    """.trimMargin())
+  }
 }


### PR DESCRIPTION
This fixes #1767 — allows any case fts5, which sqlite appears to be cool with.