### PR TITLE
Defer reference to AGP type

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/kotlin/SourceRoots.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/kotlin/SourceRoots.kt
@@ -41,8 +41,8 @@ internal fun SqlDelightDatabase.sources(): List<Source> {
   }
 
   // Android project.
-  project.extensions.findByType(BaseExtension::class.java)?.let {
-    return it.sources(project)
+  project.extensions.findByName("android")?.let {
+    return (it as BaseExtension).sources(project)
   }
 
   // Kotlin project.


### PR DESCRIPTION
This is needed on the road to making AGP a compileOnly dependency.

Refs #1362