### PR TITLE
Add support for sqlite fts5 auxiliary functions highlight, snippet, and bm25

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/util/ExprUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/util/ExprUtil.kt
@@ -183,13 +183,14 @@ private fun SqlFunctionExpr.functionType() = when (functionName.text.toLowerCase
   }
 
   "randomblob", "zeroblob" -> IntermediateType(BLOB)
-  "total" -> IntermediateType(REAL)
+  "total", "bm25" -> IntermediateType(REAL)
   "avg" -> IntermediateType(REAL).asNullable()
   "abs", "likelihood", "likely", "unlikely" -> exprList[0].type()
   "coalesce", "ifnull" -> encapsulatingType(exprList, INTEGER, REAL, TEXT, BLOB)
   "nullif" -> exprList[0].type().asNullable()
   "max" -> encapsulatingType(exprList, INTEGER, REAL, TEXT, BLOB).asNullable()
   "min" -> encapsulatingType(exprList, BLOB, TEXT, INTEGER, REAL).asNullable()
+  "highlight", "snippet" -> IntermediateType(TEXT).asNullable()
   else -> when ((containingFile as SqlDelightFile).dialect) {
     DialectPreset.MYSQL -> mySqlFunctionType()
     DialectPreset.POSTGRESQL -> postgreSqlFunctionType()


### PR DESCRIPTION
As far as I can tell these are the only changes required to make them work (it worked correctly in my testing), but I'm happy to make further changes if necessary.

https://www.sqlite.org/fts5.html#_auxiliary_functions_