### PR TITLE
Use extensions for sourceSets

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/kotlin/SourceRoots.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/kotlin/SourceRoots.kt
@@ -46,7 +46,7 @@ internal fun SqlDelightDatabase.sources(): List<Source> {
   }
 
   // Kotlin project.
-  val sourceSets = project.property("sourceSets") as SourceSetContainer
+  val sourceSets = project.extensions.getByName("sourceSets") as SourceSetContainer
   return listOf(Source(
       type = KotlinPlatformType.jvm,
       name = "main",


### PR DESCRIPTION
While it technically works to access extensions via `property()`, this is a sort of wonky Gradle behavior where `property()` calls will try properties, extensions, extra properties, and even _tasks_ to try to fulfill the request. This makes the extension lookup explicit, since that's where `sourceSets` are defined.