### PR TITLE
Make AGP dependency compileOnly

### DIFF
--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 
   compileOnly gradleApi()
   implementation deps.plugins.kotlin
-  implementation deps.plugins.androidDependency
+  compileOnly deps.plugins.androidDependency
 
   testImplementation deps.junit
   testImplementation deps.truth
@@ -48,13 +48,16 @@ dependencies {
 }
 
 test {
-  // The integration tests require local installations of some of the runtimes.
+  // The integration tests require local installations of artifacts.
   dependsOn(
           ":runtime:installArchives",
           ":drivers:android-driver:installArchives",
           ":drivers:sqlite-driver:installArchives",
           ":drivers:jdbc-driver:installArchives",
           ":drivers:native-driver:installArchives",
+          ":sqlite-migrations:installArchives",
+          ":sqldelight-compiler:installArchives",
+          ":sqldelight-gradle-plugin:installArchives",
   )
   useJUnit {
     if (project.hasProperty("Instrumentation")) {

--- a/sqldelight-gradle-plugin/src/test/fulfilled-table-variant/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/fulfilled-table-variant/build.gradle
@@ -1,10 +1,24 @@
-plugins {
-  id 'com.android.application'
-  id 'com.squareup.sqldelight'
-  id 'org.jetbrains.kotlin.android'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+    jcenter()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+    classpath deps.plugins.android
+  }
 }
 
-apply from: '../../../../gradle/dependencies.gradle'
+apply plugin: 'com.android.library'
+apply plugin: 'com.squareup.sqldelight'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 repositories {
   maven {

--- a/sqldelight-gradle-plugin/src/test/integration-android-library/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-android-library/build.gradle
@@ -1,26 +1,24 @@
-//buildscript {
-//  apply from: '../../../../gradle/dependencies.gradle'
-//
-//  repositories {
-//    google()
-//    mavenCentral()
-//  }
-//  dependencies {
-//    classpath deps.plugins.android
-//    classpath deps.plugins.kotlin
-//  }
-//}
-//
-//apply plugin: 'com.android.application'
-//apply plugin: 'kotlin-android'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
 
-plugins {
-  id 'com.android.library'
-  id 'org.jetbrains.kotlin.android'
-  id 'com.squareup.sqldelight'
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+    jcenter()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+    classpath deps.plugins.android
+  }
 }
 
-apply from: '../../../../gradle/dependencies.gradle'
+apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'com.squareup.sqldelight'
 
 repositories {
   maven {

--- a/sqldelight-gradle-plugin/src/test/integration-android-library/gradle.properties
+++ b/sqldelight-gradle-plugin/src/test/integration-android-library/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/sqldelight-gradle-plugin/src/test/integration-android/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-android/build.gradle
@@ -1,26 +1,24 @@
-//buildscript {
-//  apply from: '../../../../gradle/dependencies.gradle'
-//
-//  repositories {
-//    google()
-//    mavenCentral()
-//  }
-//  dependencies {
-//    classpath deps.plugins.android
-//    classpath deps.plugins.kotlin
-//  }
-//}
-//
-//apply plugin: 'com.android.application'
-//apply plugin: 'kotlin-android'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
 
-plugins {
-  id 'com.android.application'
-  id 'com.squareup.sqldelight'
-  id 'org.jetbrains.kotlin.android'
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+    jcenter()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+    classpath deps.plugins.android
+  }
 }
 
-apply from: '../../../../gradle/dependencies.gradle'
+apply plugin: 'com.android.application'
+apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'com.squareup.sqldelight'
 
 repositories {
   maven {

--- a/sqldelight-gradle-plugin/src/test/integration-android/gradle.properties
+++ b/sqldelight-gradle-plugin/src/test/integration-android/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/sqldelight-gradle-plugin/src/test/integration-hsql/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-hsql/build.gradle
@@ -1,9 +1,21 @@
-plugins {
-    id 'kotlin'
-    id 'com.squareup.sqldelight'
+buildscript {
+    apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+    repositories {
+        maven {
+            url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+        }
+        mavenCentral()
+        google()
+    }
+    dependencies {
+        classpath 'com.squareup.sqldelight:gradle-plugin:+'
+        classpath deps.plugins.kotlin
+    }
 }
 
-apply from: '../../../../gradle/dependencies.gradle'
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.squareup.sqldelight'
 
 sqldelight {
     MyDatabase {

--- a/sqldelight-gradle-plugin/src/test/integration-multiplatform/android-build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-multiplatform/android-build.gradle
@@ -7,10 +7,12 @@ buildscript {
     }
     mavenCentral()
     google()
+    jcenter()
   }
   dependencies {
     classpath 'com.squareup.sqldelight:gradle-plugin:+'
     classpath deps.plugins.kotlin
+    classpath deps.plugins.android
   }
 }
 
@@ -26,7 +28,6 @@ repositories {
   }
   mavenCentral()
   google()
-  jcenter()
 }
 
 android {

--- a/sqldelight-gradle-plugin/src/test/integration-multiplatform/android-build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-multiplatform/android-build.gradle
@@ -1,8 +1,22 @@
-plugins {
-  id 'com.android.library'
-  id 'org.jetbrains.kotlin.multiplatform'
-  id 'com.squareup.sqldelight'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+  }
 }
+
+apply plugin: 'org.jetbrains.kotlin.multiplatform'
+apply plugin: 'com.squareup.sqldelight'
+apply plugin: 'com.android.library'
 
 apply from: '../../../../gradle/dependencies.gradle'
 

--- a/sqldelight-gradle-plugin/src/test/integration-multiplatform/gradle.properties
+++ b/sqldelight-gradle-plugin/src/test/integration-multiplatform/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/sqldelight-gradle-plugin/src/test/integration-multiplatform/ios-build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-multiplatform/ios-build.gradle
@@ -1,7 +1,20 @@
-plugins {
-  id 'org.jetbrains.kotlin.multiplatform'
-  id 'com.squareup.sqldelight'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+  }
 }
+
+apply plugin: 'org.jetbrains.kotlin.multiplatform'
+apply plugin: 'com.squareup.sqldelight'
 
 apply from: '../../../../gradle/dependencies.gradle'
 
@@ -10,10 +23,7 @@ repositories {
     url "file://${projectDir.absolutePath}/../../../../build/localMaven"
   }
   mavenCentral()
-  google()
-  jcenter()
 }
-
 
 sqldelight {
   QueryWrapper {

--- a/sqldelight-gradle-plugin/src/test/integration-multiplatform/ios-build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-multiplatform/ios-build.gradle
@@ -6,6 +6,7 @@ buildscript {
       url "file://${projectDir.absolutePath}/../../../../build/localMaven"
     }
     mavenCentral()
+    google()
   }
   dependencies {
     classpath 'com.squareup.sqldelight:gradle-plugin:+'

--- a/sqldelight-gradle-plugin/src/test/integration-mysql-schema/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-mysql-schema/build.gradle
@@ -1,9 +1,21 @@
-plugins {
-    id 'kotlin'
-    id 'com.squareup.sqldelight'
+buildscript {
+    apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+    repositories {
+        maven {
+            url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+        }
+        mavenCentral()
+        google()
+    }
+    dependencies {
+        classpath 'com.squareup.sqldelight:gradle-plugin:+'
+        classpath deps.plugins.kotlin
+    }
 }
 
-apply from: '../../../../gradle/dependencies.gradle'
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.squareup.sqldelight'
 
 sqldelight {
     MyDatabase {

--- a/sqldelight-gradle-plugin/src/test/integration-mysql/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-mysql/build.gradle
@@ -1,9 +1,21 @@
-plugins {
-    id 'kotlin'
-    id 'com.squareup.sqldelight'
+buildscript {
+    apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+    repositories {
+        maven {
+            url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+        }
+        mavenCentral()
+        google()
+    }
+    dependencies {
+        classpath 'com.squareup.sqldelight:gradle-plugin:+'
+        classpath deps.plugins.kotlin
+    }
 }
 
-apply from: '../../../../gradle/dependencies.gradle'
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.squareup.sqldelight'
 
 sqldelight {
     MyDatabase {

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/build.gradle
@@ -1,9 +1,21 @@
-plugins {
-    id 'kotlin'
-    id 'com.squareup.sqldelight'
+buildscript {
+    apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+    repositories {
+        maven {
+            url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+        }
+        mavenCentral()
+        google()
+    }
+    dependencies {
+        classpath 'com.squareup.sqldelight:gradle-plugin:+'
+        classpath deps.plugins.kotlin
+    }
 }
 
-apply from: '../../../../gradle/dependencies.gradle'
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.squareup.sqldelight'
 
 sqldelight {
     MyDatabase {

--- a/sqldelight-gradle-plugin/src/test/integration-sqlite-3-24/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-sqlite-3-24/build.gradle
@@ -1,9 +1,21 @@
-plugins {
-  id 'kotlin'
-  id 'com.squareup.sqldelight'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+  }
 }
 
-apply from: '../../../../gradle/dependencies.gradle'
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.squareup.sqldelight'
 
 repositories {
   maven {

--- a/sqldelight-gradle-plugin/src/test/integration/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration/build.gradle
@@ -1,9 +1,22 @@
-plugins {
-  id 'kotlin'
-  id 'com.squareup.sqldelight'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+    jcenter()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+  }
 }
 
-apply from: '../../../../gradle/dependencies.gradle'
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.squareup.sqldelight'
 
 repositories {
   maven {

--- a/sqldelight-gradle-plugin/src/test/kotlin-mpp-1.3.20/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/kotlin-mpp-1.3.20/build.gradle
@@ -6,6 +6,7 @@ buildscript {
       url "file://${projectDir.absolutePath}/../../../../build/localMaven"
     }
     mavenCentral()
+    google()
   }
   dependencies {
     classpath 'com.squareup.sqldelight:gradle-plugin:+'

--- a/sqldelight-gradle-plugin/src/test/kotlin-mpp-1.3.20/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/kotlin-mpp-1.3.20/build.gradle
@@ -1,9 +1,21 @@
-plugins {
-  id 'org.jetbrains.kotlin.multiplatform'
-  id 'com.squareup.sqldelight'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+  }
 }
 
-apply from: '../../../../gradle/dependencies.gradle'
+apply plugin: 'org.jetbrains.kotlin.multiplatform'
+apply plugin: 'com.squareup.sqldelight'
 
 repositories {
   maven {

--- a/sqldelight-gradle-plugin/src/test/kotlin-mpp-1.3.20/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/kotlin-mpp-1.3.20/build.gradle
@@ -6,7 +6,6 @@ buildscript {
       url "file://${projectDir.absolutePath}/../../../../build/localMaven"
     }
     mavenCentral()
-    google()
   }
   dependencies {
     classpath 'com.squareup.sqldelight:gradle-plugin:+'

--- a/sqldelight-gradle-plugin/src/test/kotlin-mpp-configure-on-demand/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/kotlin-mpp-configure-on-demand/build.gradle
@@ -1,9 +1,21 @@
-plugins {
-  id 'org.jetbrains.kotlin.multiplatform'
-  id 'com.squareup.sqldelight'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+  }
 }
 
-apply from: '../../../../gradle/dependencies.gradle'
+apply plugin: 'org.jetbrains.kotlin.multiplatform'
+apply plugin: 'com.squareup.sqldelight'
 
 repositories {
   maven {

--- a/sqldelight-gradle-plugin/src/test/kotlin-mpp/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/kotlin-mpp/build.gradle
@@ -1,9 +1,21 @@
-plugins {
-  id 'org.jetbrains.kotlin.multiplatform'
-  id 'com.squareup.sqldelight'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+  }
 }
 
-apply from: '../../../../gradle/dependencies.gradle'
+apply plugin: 'org.jetbrains.kotlin.multiplatform'
+apply plugin: 'com.squareup.sqldelight'
 
 repositories {
   maven {

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/CompilationUnitTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/CompilationUnitTests.kt
@@ -12,9 +12,30 @@ class CompilationUnitTests {
   fun `JVM kotlin`() {
     withTemporaryFixture {
       gradleFile("""
-        |plugins {
-        |  id 'org.jetbrains.kotlin.jvm'
-        |  id 'com.squareup.sqldelight'
+        |buildscript {
+        |  apply from: "${"$"}{rootDir}/../../../../gradle/dependencies.gradle"
+        |
+        |  repositories {
+        |    maven {
+        |      url "file://${"$"}{rootDir}/../../../../build/localMaven"
+        |    }
+        |    mavenCentral()
+        |    google()
+        |  }
+        |  dependencies {
+        |    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+        |    classpath deps.plugins.kotlin
+        |  }
+        |}
+        |
+        |apply plugin: 'org.jetbrains.kotlin.jvm'
+        |apply plugin: 'com.squareup.sqldelight'
+        |apply from: "${"$"}{rootDir}/../../../../gradle/dependencies.gradle"
+        |
+        |repositories {
+        |  maven {
+        |    url "file://${"$"}{rootDir}/../../../../build/localMaven"
+        |  }
         |}
         |
         |sqldelight {
@@ -45,9 +66,30 @@ class CompilationUnitTests {
   fun `JVM kotlin with multiple databases`() {
     withTemporaryFixture {
       gradleFile("""
-        |plugins {
-        |  id 'org.jetbrains.kotlin.jvm'
-        |  id 'com.squareup.sqldelight'
+        |buildscript {
+        |  apply from: "${"$"}{rootDir}/../../../../gradle/dependencies.gradle"
+        |
+        |  repositories {
+        |    maven {
+        |      url "file://${"$"}{rootDir}/../../../../build/localMaven"
+        |    }
+        |    mavenCentral()
+        |    google()
+        |  }
+        |  dependencies {
+        |    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+        |    classpath deps.plugins.kotlin
+        |  }
+        |}
+        |
+        |apply plugin: 'org.jetbrains.kotlin.jvm'
+        |apply plugin: 'com.squareup.sqldelight'
+        |apply from: "${"$"}{rootDir}/../../../../gradle/dependencies.gradle"
+        |
+        |repositories {
+        |  maven {
+        |    url "file://${"$"}{rootDir}/../../../../build/localMaven"
+        |  }
         |}
         |
         |sqldelight {
@@ -102,9 +144,30 @@ class CompilationUnitTests {
   fun `Multiplatform project with multiple targets`() {
     withTemporaryFixture {
       gradleFile("""
-        |plugins {
-        |  id 'org.jetbrains.kotlin.multiplatform'
-        |  id 'com.squareup.sqldelight'
+        |buildscript {
+        |  apply from: "${"$"}{rootDir}/../../../../gradle/dependencies.gradle"
+        |
+        |  repositories {
+        |    maven {
+        |      url "file://${"$"}{rootDir}/../../../../build/localMaven"
+        |    }
+        |    mavenCentral()
+        |    google()
+        |  }
+        |  dependencies {
+        |    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+        |    classpath deps.plugins.kotlin
+        |  }
+        |}
+        |
+        |apply plugin: 'org.jetbrains.kotlin.multiplatform'
+        |apply plugin: 'com.squareup.sqldelight'
+        |apply from: "${"$"}{rootDir}/../../../../gradle/dependencies.gradle"
+        |
+        |repositories {
+        |  maven {
+        |    url "file://${"$"}{rootDir}/../../../../build/localMaven"
+        |  }
         |}
         |
         |sqldelight {
@@ -186,13 +249,35 @@ class CompilationUnitTests {
   fun `Multiplatform project with android and ios targets`() {
     withTemporaryFixture {
       gradleFile("""
-        |plugins {
-        |  id 'org.jetbrains.kotlin.multiplatform'
-        |  id 'com.android.application'
-        |  id 'com.squareup.sqldelight'
+        |buildscript {
+        |  apply from: "${"$"}{rootDir}/../../../../gradle/dependencies.gradle"
+        |
+        |  repositories {
+        |    maven {
+        |      url "file://${"$"}{rootDir}/../../../../build/localMaven"
+        |    }
+        |    mavenCentral()
+        |    google()
+        |    jcenter()
+        |  }
+        |  dependencies {
+        |    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+        |    classpath deps.plugins.kotlin
+        |    classpath deps.plugins.android
+        |  }
         |}
         |
-        |apply from: '../../../../gradle/dependencies.gradle'
+        |apply plugin: 'org.jetbrains.kotlin.multiplatform'
+        |apply plugin: 'com.android.application'
+        |apply plugin: 'com.squareup.sqldelight'
+        |apply from: "${"$"}{rootDir}/../../../../gradle/dependencies.gradle"
+        |
+        |repositories {
+        |  maven {
+        |    url "file://${"$"}{rootDir}/../../../../build/localMaven"
+        |  }
+        |}
+        |
         |
         |sqldelight {
         |  CommonDb {
@@ -397,13 +482,34 @@ class CompilationUnitTests {
   fun `android project with multiple flavors`() {
     withTemporaryFixture {
       gradleFile("""
-        |plugins {
-        |  id 'com.android.application'
-        |  id 'org.jetbrains.kotlin.android'
-        |  id 'com.squareup.sqldelight'
+        |buildscript {
+        |  apply from: "${"$"}{rootDir}/../../../../gradle/dependencies.gradle"
+        |
+        |  repositories {
+        |    maven {
+        |      url "file://${"$"}{rootDir}/../../../../build/localMaven"
+        |    }
+        |    mavenCentral()
+        |    google()
+        |    jcenter()
+        |  }
+        |  dependencies {
+        |    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+        |    classpath deps.plugins.kotlin
+        |    classpath deps.plugins.android
+        |  }
         |}
         |
-        |apply from: '../../../../gradle/dependencies.gradle'
+        |apply plugin: 'com.android.application'
+        |apply plugin: 'org.jetbrains.kotlin.android'
+        |apply plugin: 'com.squareup.sqldelight'
+        |apply from: "${"$"}{rootDir}/../../../../gradle/dependencies.gradle"
+        |
+        |repositories {
+        |  maven {
+        |    url "file://${"$"}{rootDir}/../../../../build/localMaven"
+        |  }
+        |}
         |
         |sqldelight {
         |  CommonDb {

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/FailureTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/FailureTest.kt
@@ -11,7 +11,6 @@ class FailureTest {
 
     val output = GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
         .withArguments("clean", "generateMainDatabaseInterface", "--stacktrace")
         .buildAndFail()
 

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/GenerateSchemaTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/GenerateSchemaTest.kt
@@ -13,7 +13,6 @@ class GenerateSchemaTest {
 
     GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
         .withArguments("clean", "generateMainDatabaseSchema", "--stacktrace")
         .build()
 
@@ -31,7 +30,6 @@ class GenerateSchemaTest {
 
     GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
         .withArguments("clean", "generateMainDatabaseSchema", "--stacktrace")
         .build()
 
@@ -47,7 +45,6 @@ class GenerateSchemaTest {
 
     GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
         .withArguments("clean", "--rerun-tasks", "generateMainDatabaseSchema", "--stacktrace")
         .build()
 
@@ -63,7 +60,6 @@ class GenerateSchemaTest {
 
     GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
         .withArguments("clean", "generateMainDatabaseSchema", "--stacktrace")
         .build()
 
@@ -82,7 +78,6 @@ class GenerateSchemaTest {
 
     GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
         .withArguments("clean", "generateMainDatabaseSchema", "--stacktrace")
         .build()
 

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/GradlePluginCombinationTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/GradlePluginCombinationTests.kt
@@ -7,15 +7,35 @@ class GradlePluginCombinationTests {
   fun `sqldelight can be applied after kotlin-android-extensions`() {
     withTemporaryFixture {
       gradleFile("""
-        |plugins {
-        |    id 'kotlin-multiplatform'
-        |    id 'com.android.application'
-        |    id 'kotlin-android-extensions'
-        |    id 'com.squareup.sqldelight'
+        |buildscript {
+        |  apply from: "${"$"}{rootDir}/../../../../gradle/dependencies.gradle"
+        |
+        |  repositories {
+        |    maven {
+        |      url "file://${"$"}{rootDir}/../../../../build/localMaven"
+        |    }
+        |    mavenCentral()
+        |    google()
+        |    jcenter()
+        |  }
+        |  dependencies {
+        |    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+        |    classpath deps.plugins.kotlin
+        |    classpath deps.plugins.android
+        |  }
         |}
         |
-        |apply from: "${'$'}{rootDir}/../../../../gradle/dependencies.gradle"
+        |apply plugin: 'org.jetbrains.kotlin.multiplatform'
+        |apply plugin: 'com.android.application'
+        |apply plugin: 'com.squareup.sqldelight'
+        |apply plugin: 'kotlin-android-extensions'
+        |apply from: "${"$"}{rootDir}/../../../../gradle/dependencies.gradle"
         |
+        |repositories {
+        |  maven {
+        |    url "file://${"$"}{rootDir}/../../../../build/localMaven"
+        |  }
+        |}
         |
         |sqldelight {
         |  CommonDb {
@@ -40,13 +60,31 @@ class GradlePluginCombinationTests {
   fun `sqldelight fails when linkSqlite=false on native without additional linker settings`() {
     withTemporaryFixture {
       gradleFile("""
-    |plugins {
-    |    id 'kotlin-multiplatform'
-    |    id 'com.squareup.sqldelight'
+    |buildscript {
+    |  apply from: "${"$"}{rootDir}/../../../../gradle/dependencies.gradle"
+    |
+    |  repositories {
+    |    maven {
+    |      url "file://${"$"}{rootDir}/../../../../build/localMaven"
+    |    }
+    |    mavenCentral()
+    |    google()
+    |  }
+    |  dependencies {
+    |    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    |    classpath deps.plugins.kotlin
+    |  }
     |}
     |
-    |apply from: "${'$'}{rootDir}/../../../../gradle/dependencies.gradle"
+    |apply plugin: 'org.jetbrains.kotlin.multiplatform'
+    |apply plugin: 'com.squareup.sqldelight'
+    |apply from: "${"$"}{rootDir}/../../../../gradle/dependencies.gradle"
     |
+    |repositories {
+    |  maven {
+    |    url "file://${"$"}{rootDir}/../../../../build/localMaven"
+    |  }
+    |}
     |
     |sqldelight {
     |  linkSqlite = false

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/IntegrationTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/IntegrationTest.kt
@@ -32,7 +32,6 @@ class IntegrationTest {
 
     val runner = GradleRunner.create()
         .withProjectDir(integrationRoot)
-        .withPluginClasspath()
         .withArguments("clean", "check", "--stacktrace")
 
     val result = runner.build()
@@ -48,7 +47,6 @@ class IntegrationTest {
 
     val runner = GradleRunner.create()
         .withProjectDir(integrationRoot)
-        .withPluginClasspath()
         .withArguments("clean", "check", "--stacktrace")
 
     val result = runner.build()
@@ -64,7 +62,6 @@ class IntegrationTest {
 
     val runner = GradleRunner.create()
         .withProjectDir(integrationRoot)
-        .withPluginClasspath()
         .withArguments("clean", "check", "--stacktrace")
 
     val result = runner.build()
@@ -80,7 +77,6 @@ class IntegrationTest {
 
     val runner = GradleRunner.create()
         .withProjectDir(integrationRoot)
-        .withPluginClasspath()
         .withArguments("clean", "check", "--stacktrace")
 
     val result = runner.build()
@@ -96,7 +92,6 @@ class IntegrationTest {
 
     val runner = GradleRunner.create()
         .withProjectDir(integrationRoot)
-        .withPluginClasspath()
         .withArguments("clean", "generateMainMyDatabaseMigrations", "--stacktrace")
 
     val result = runner.build()
@@ -115,7 +110,6 @@ class IntegrationTest {
 
     val runner = GradleRunner.create()
         .withProjectDir(integrationRoot)
-        .withPluginClasspath()
         .withArguments("clean", "check", "--stacktrace")
 
     val result = runner.build()
@@ -131,7 +125,6 @@ class IntegrationTest {
 
     val runner = GradleRunner.create()
         .withProjectDir(integrationRoot)
-        .withPluginClasspath()
         .withArguments("clean", "check", "--stacktrace")
 
     val result = runner.build()
@@ -149,7 +142,6 @@ class IntegrationTest {
 
     val runner = GradleRunner.create()
         .withProjectDir(integrationRoot)
-        .withPluginClasspath()
         .withArguments("clean", "connectedCheck", "--stacktrace")
 
     val result = runner.build()
@@ -175,7 +167,6 @@ class IntegrationTest {
 
       val runner = GradleRunner.create()
           .withProjectDir(integrationRoot)
-          .withPluginClasspath()
           .withArguments("clean", "connectedCheck", "--stacktrace")
 
       val result = runner.build()
@@ -200,7 +191,6 @@ class IntegrationTest {
 
     val runner = GradleRunner.create()
         .withProjectDir(integrationRoot)
-        .withPluginClasspath()
         .withArguments("clean", "test", "--stacktrace")
 
     val result = runner.build()
@@ -221,7 +211,6 @@ class IntegrationTest {
     val runner = GradleRunner.create()
         .forwardOutput()
         .withProjectDir(integrationRoot)
-        .withPluginClasspath()
         .withArguments("clean", "iosTest", "--stacktrace")
 
     val result = runner.build()
@@ -242,7 +231,6 @@ class IntegrationTest {
     val runner = GradleRunner.create()
         .forwardOutput()
         .withProjectDir(integrationRoot)
-        .withPluginClasspath()
         .withArguments("clean", "compileKotlinMetadata", "--stacktrace")
 
     val result = runner.build()

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/MigrationTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/MigrationTest.kt
@@ -11,7 +11,6 @@ class MigrationTest {
 
     val output = GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
         .withArguments("clean", "verifyMainDatabaseMigration", "--stacktrace")
         .buildAndFail()
 
@@ -34,7 +33,6 @@ class MigrationTest {
 
     val output = GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
         .withArguments("clean", "verifyMainDatabaseMigration", "--stacktrace")
         .buildAndFail()
 
@@ -50,7 +48,6 @@ class MigrationTest {
 
     val output = GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
         .withArguments("clean", "build", "--stacktrace")
         .buildAndFail()
 
@@ -68,7 +65,6 @@ class MigrationTest {
 
     val output = GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
         .withArguments("clean", "verifyMainDatabaseMigration", "--stacktrace")
         .build()
 
@@ -80,7 +76,6 @@ class MigrationTest {
 
     var output = GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
         .withArguments("clean", "verifyMainDatabaseAMigration", "--stacktrace")
         .build()
 
@@ -88,7 +83,6 @@ class MigrationTest {
 
     output = GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
         .withArguments("clean", "verifyMainDatabaseBMigration", "--stacktrace")
         .build()
 
@@ -100,7 +94,6 @@ class MigrationTest {
 
     val output = GradleRunner.create()
             .withProjectDir(fixtureRoot)
-            .withPluginClasspath()
             .withArguments("clean", "verifyMainDatabaseMigration", "--stacktrace")
             .build()
 
@@ -112,7 +105,6 @@ class MigrationTest {
 
     val output = GradleRunner.create()
             .withProjectDir(fixtureRoot)
-            .withPluginClasspath()
             .withArguments("clean", "verifyMainDatabaseMigration", "--stacktrace", "--debug")
             .build()
 
@@ -124,7 +116,6 @@ class MigrationTest {
 
     val output = GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
         .withArguments("clean", "verifyMainDatabaseMigration", "--stacktrace")
         .buildAndFail()
 

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/MultiModuleTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/MultiModuleTests.kt
@@ -18,7 +18,6 @@ class MultiModuleTests {
 
     GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
         .withArguments("clean", "--stacktrace")
         .build()
 
@@ -51,7 +50,6 @@ class MultiModuleTests {
 
     val runner = GradleRunner.create()
         .withProjectDir(integrationRoot)
-        .withPluginClasspath()
         .withArguments("clean", ":ProjectA:check", "--stacktrace")
 
     val result = runner.build()
@@ -71,7 +69,6 @@ class MultiModuleTests {
 
     val runner = GradleRunner.create()
         .withProjectDir(integrationRoot)
-        .withPluginClasspath()
         .withArguments("clean", ":AndroidProject:connectedCheck", "--stacktrace")
 
     val result = runner.build()
@@ -87,7 +84,6 @@ class MultiModuleTests {
 
     GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
         .withArguments("clean", "--stacktrace")
         .forwardOutput()
         .build()

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/PluginTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/PluginTest.kt
@@ -11,7 +11,6 @@ class PluginTest {
     val fixtureRoot = File("src/test/no-kotlin")
     val runner = GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
 
     val result = runner
         .withArguments("build", "--stacktrace")
@@ -27,7 +26,6 @@ class PluginTest {
 
     val runner = GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
 
     val result = runner
         .withArguments("build", "--stacktrace")
@@ -44,7 +42,6 @@ class PluginTest {
 
     val runner = GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
 
     val result = runner
         .withArguments("clean", "generateDebugDatabaseInterface", "--stacktrace")
@@ -57,7 +54,6 @@ class PluginTest {
     val fixtureRoot = File("src/test/kotlin-mpp")
     val runner = GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
 
     val result = runner
         .withArguments("clean", "generateJvmMainDatabaseInterface", "--stacktrace")
@@ -76,7 +72,6 @@ class PluginTest {
     val fixtureRoot = File("src/test/kotlin-mpp")
     val runner = GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
 
     val buildDir = File(fixtureRoot, "build/generated/sqldelight")
 
@@ -93,7 +88,6 @@ class PluginTest {
     val fixtureRoot = File("src/test/kotlin-mpp")
     val runner = GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
 
     val buildDir = File(fixtureRoot, "build/generated/sqldelight")
 
@@ -110,7 +104,6 @@ class PluginTest {
     val fixtureRoot = File("src/test/kotlin-mpp-configure-on-demand")
     val runner = GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
         .forwardOutput()
 
     val buildDir = File(fixtureRoot, "build/generated/sqldelight")
@@ -128,7 +121,6 @@ class PluginTest {
     val fixtureRoot = File("src/test/kotlin-mpp")
     val runner = GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
 
     val buildDir = File(fixtureRoot, "build/generated/sqldelight")
 
@@ -153,7 +145,6 @@ class PluginTest {
     val fixtureRoot = File("src/test/kotlin-mpp-1.3.20")
     val runner = GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
 
     val buildDir = File(fixtureRoot, "build/generated/sqldelight")
 
@@ -171,7 +162,6 @@ class PluginTest {
     val fixtureRoot = File("src/test/kotlin-mpp")
     val runner = GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
 
     val buildDir = File(fixtureRoot, "build/generated/sqldelight")
 
@@ -199,7 +189,6 @@ class PluginTest {
 
     val runner = GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
 
     val outputFolder = File(fixtureRoot, "build/generated/sqldelight").apply { mkdirs() }
     val garbage = File(outputFolder, "sup.txt").apply { createNewFile() }

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/PropertiesFileTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/PropertiesFileTest.kt
@@ -15,7 +15,6 @@ class PropertiesFileTest {
 
     GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
         .withArguments("clean", "generateMainDatabaseInterface", "--stacktrace")
         .build()
 
@@ -39,13 +38,34 @@ class PropertiesFileTest {
   @Test fun `properties file for an android multiplatform module`() {
     withTemporaryFixture {
       gradleFile("""|
-        |plugins {
-        |  id 'org.jetbrains.kotlin.multiplatform'
-        |  id 'com.squareup.sqldelight'
-        |  id 'com.android.library'
+        |buildscript {
+        |  apply from: "${"$"}{rootDir}/../../../../gradle/dependencies.gradle"
+        |
+        |  repositories {
+        |    maven {
+        |      url "file://${"$"}{rootDir}/../../../../build/localMaven"
+        |    }
+        |    mavenCentral()
+        |    google()
+        |    jcenter()
+        |  }
+        |  dependencies {
+        |    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+        |    classpath deps.plugins.kotlin
+        |    classpath deps.plugins.android
+        |  }
         |}
         |
+        |apply plugin: 'org.jetbrains.kotlin.multiplatform'
+        |apply plugin: 'com.squareup.sqldelight'
+        |apply plugin: 'com.android.library'
         |apply from: "${"$"}{rootDir}/../../../../gradle/dependencies.gradle"
+        |
+        |repositories {
+        |  maven {
+        |    url "file://${"$"}{rootDir}/../../../../build/localMaven"
+        |  }
+        |}
         |
         |archivesBaseName = 'Test'
         |

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/TemporaryFixture.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/TemporaryFixture.kt
@@ -25,7 +25,6 @@ internal class TemporaryFixture : AutoCloseable {
   internal fun configure(runTask: String = "clean") {
     val result = GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
         .withArguments(runTask, "--stacktrace")
         .forwardOutput()
         .build()

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/VariantTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/VariantTest.kt
@@ -16,7 +16,6 @@ class VariantTest {
 
     val runner = GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
 
     val result = runner
         .withArguments("clean", "generateInternalDatabaseInterface", "--stacktrace")
@@ -41,7 +40,6 @@ class VariantTest {
 
     val runner = GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
 
     val result = runner
         .withArguments("clean", "assemble", "--stacktrace", "--continue")
@@ -63,7 +61,6 @@ class VariantTest {
 
     GradleRunner.create()
         .withProjectDir(fixtureRoot)
-        .withPluginClasspath()
         .withArguments("clean", "--stacktrace", "--continue")
         .build()
 

--- a/sqldelight-gradle-plugin/src/test/library-project/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/library-project/build.gradle
@@ -1,10 +1,24 @@
-plugins {
-  id 'com.android.library'
-  id 'com.squareup.sqldelight'
-  id 'org.jetbrains.kotlin.android'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+    jcenter()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+    classpath deps.plugins.android
+  }
 }
 
-apply from: '../../../../gradle/dependencies.gradle'
+apply plugin: 'com.android.library'
+apply plugin: 'com.squareup.sqldelight'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 repositories {
   maven {

--- a/sqldelight-gradle-plugin/src/test/migration-failure/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/migration-failure/build.gradle
@@ -1,7 +1,21 @@
-plugins {
-  id 'kotlin'
-  id 'com.squareup.sqldelight'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+  }
 }
+
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.squareup.sqldelight'
 
 repositories {
   maven {

--- a/sqldelight-gradle-plugin/src/test/migration-gap-failure/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/migration-gap-failure/build.gradle
@@ -1,7 +1,21 @@
-plugins {
-  id 'kotlin'
-  id 'com.squareup.sqldelight'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+  }
 }
+
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.squareup.sqldelight'
 
 repositories {
   maven {

--- a/sqldelight-gradle-plugin/src/test/migration-schema-failure/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/migration-schema-failure/build.gradle
@@ -1,7 +1,21 @@
-plugins {
-  id 'kotlin'
-  id 'com.squareup.sqldelight'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+  }
 }
+
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.squareup.sqldelight'
 
 repositories {
   maven {

--- a/sqldelight-gradle-plugin/src/test/migration-success/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/migration-success/build.gradle
@@ -1,7 +1,21 @@
-plugins {
-  id 'kotlin'
-  id 'com.squareup.sqldelight'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+  }
 }
+
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.squareup.sqldelight'
 
 repositories {
   maven {

--- a/sqldelight-gradle-plugin/src/test/migration-syntax-failure/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/migration-syntax-failure/build.gradle
@@ -1,7 +1,21 @@
-plugins {
-  id 'kotlin'
-  id 'com.squareup.sqldelight'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+  }
 }
+
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.squareup.sqldelight'
 
 repositories {
   maven {

--- a/sqldelight-gradle-plugin/src/test/multi-module/AndroidProject/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/multi-module/AndroidProject/build.gradle
@@ -1,10 +1,6 @@
-plugins {
-  id 'com.android.application'
-  id 'org.jetbrains.kotlin.android'
-  id 'com.squareup.sqldelight'
-}
-
-apply from: "${rootDir}/../../../../gradle/dependencies.gradle"
+apply plugin: 'com.android.application'
+apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'com.squareup.sqldelight'
 
 sqldelight {
   CommonDb {

--- a/sqldelight-gradle-plugin/src/test/multi-module/MultiplatformProject/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/multi-module/MultiplatformProject/build.gradle
@@ -1,10 +1,6 @@
-plugins {
-  id 'org.jetbrains.kotlin.multiplatform'
-  id 'com.android.library'
-  id 'com.squareup.sqldelight'
-}
-
-apply from: "${rootDir}/../../../../gradle/dependencies.gradle"
+apply plugin: 'org.jetbrains.kotlin.multiplatform'
+apply plugin: 'com.android.library'
+apply plugin: 'com.squareup.sqldelight'
 
 sqldelight {
   CommonDb {

--- a/sqldelight-gradle-plugin/src/test/multi-module/ProjectA/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/multi-module/ProjectA/build.gradle
@@ -1,9 +1,5 @@
-plugins {
-  id 'kotlin'
-  id 'com.squareup.sqldelight'
-}
-
-apply from: "${rootDir.absolutePath}/../../../../gradle/dependencies.gradle"
+apply plugin: 'kotlin'
+apply plugin: 'com.squareup.sqldelight'
 
 sqldelight {
   Database {

--- a/sqldelight-gradle-plugin/src/test/multi-module/ProjectB/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/multi-module/ProjectB/build.gradle
@@ -1,9 +1,5 @@
-plugins {
-  id 'kotlin'
-  id 'com.squareup.sqldelight'
-}
-
-apply from: "${rootDir}/../../../../gradle/dependencies.gradle"
+apply plugin: 'kotlin'
+apply plugin: 'com.squareup.sqldelight'
 
 sqldelight {
   Database {

--- a/sqldelight-gradle-plugin/src/test/multi-module/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/multi-module/build.gradle
@@ -1,7 +1,25 @@
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+    jcenter()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+    classpath deps.plugins.android
+  }
+}
+
 allprojects {
   repositories {
     maven {
-      url "file://${rootDir.absolutePath}/../../../../build/localMaven"
+      url "file://${rootDir}/../../../../build/localMaven"
     }
     mavenCentral()
     google()

--- a/sqldelight-gradle-plugin/src/test/multiple-project-migration-success/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/multiple-project-migration-success/build.gradle
@@ -1,7 +1,21 @@
-plugins {
-  id 'kotlin'
-  id 'com.squareup.sqldelight'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+  }
 }
+
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.squareup.sqldelight'
 
 repositories {
   maven {

--- a/sqldelight-gradle-plugin/src/test/no-kotlin-android/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/no-kotlin-android/build.gradle
@@ -1,9 +1,22 @@
-plugins {
-  id 'com.android.application'
-  id 'com.squareup.sqldelight'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+    jcenter()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.android
+  }
 }
 
-apply from: '../../../../gradle/dependencies.gradle'
+apply plugin: 'com.android.application'
+apply plugin: 'com.squareup.sqldelight'
 
 repositories {
   maven {

--- a/sqldelight-gradle-plugin/src/test/no-kotlin/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/no-kotlin/build.gradle
@@ -1,9 +1,16 @@
-plugins {
-  id 'com.squareup.sqldelight'
-}
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
 
-repositories {
-  maven {
-    url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
   }
 }
+
+apply plugin: 'com.squareup.sqldelight'

--- a/sqldelight-gradle-plugin/src/test/no-package/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/no-package/build.gradle
@@ -1,7 +1,21 @@
-plugins {
-  id 'kotlin'
-  id 'com.squareup.sqldelight'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+  }
 }
+
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.squareup.sqldelight'
 
 sqldelight {
   Database {

--- a/sqldelight-gradle-plugin/src/test/properties-file/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/properties-file/build.gradle
@@ -1,7 +1,21 @@
-plugins {
-  id 'kotlin'
-  id 'com.squareup.sqldelight'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+  }
 }
+
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.squareup.sqldelight'
 
 repositories {
   maven {

--- a/sqldelight-gradle-plugin/src/test/schema-file-android/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/schema-file-android/build.gradle
@@ -1,8 +1,22 @@
-plugins {
-  id 'com.android.application'
-  id 'com.squareup.sqldelight'
-  id 'org.jetbrains.kotlin.android'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+  }
 }
+
+apply plugin: 'com.android.application'
+apply plugin: 'com.squareup.sqldelight'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 apply from: '../../../../gradle/dependencies.gradle'
 

--- a/sqldelight-gradle-plugin/src/test/schema-file-sqm/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/schema-file-sqm/build.gradle
@@ -1,7 +1,21 @@
-plugins {
-  id 'kotlin'
-  id 'com.squareup.sqldelight'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+  }
 }
+
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.squareup.sqldelight'
 
 repositories {
   maven {

--- a/sqldelight-gradle-plugin/src/test/schema-file/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/schema-file/build.gradle
@@ -1,7 +1,21 @@
-plugins {
-  id 'kotlin'
-  id 'com.squareup.sqldelight'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+  }
 }
+
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.squareup.sqldelight'
 
 repositories {
   maven {

--- a/sqldelight-gradle-plugin/src/test/schema-file/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/schema-file/build.gradle
@@ -11,6 +11,7 @@ buildscript {
   dependencies {
     classpath 'com.squareup.sqldelight:gradle-plugin:+'
     classpath deps.plugins.kotlin
+    classpath deps.sqliteJdbc
   }
 }
 
@@ -28,8 +29,4 @@ sqldelight {
     packageName = "com.example"
     schemaOutputDirectory = file('src/main/sqldelight/databases')
   }
-}
-
-dependencies {
-  implementation deps.sqliteJdbc
 }

--- a/sqldelight-gradle-plugin/src/test/schema-file/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/schema-file/build.gradle
@@ -29,3 +29,7 @@ sqldelight {
     schemaOutputDirectory = file('src/main/sqldelight/databases')
   }
 }
+
+dependencies {
+  implementation deps.sqliteJdbc
+}

--- a/sqldelight-gradle-plugin/src/test/schema-output/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/schema-output/build.gradle
@@ -1,9 +1,21 @@
-plugins {
-    id 'kotlin'
-    id 'com.squareup.sqldelight'
+buildscript {
+    apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+    repositories {
+        maven {
+            url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+        }
+        mavenCentral()
+        google()
+    }
+    dependencies {
+        classpath 'com.squareup.sqldelight:gradle-plugin:+'
+        classpath deps.plugins.kotlin
+    }
 }
 
-apply from: '../../../../gradle/dependencies.gradle'
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.squareup.sqldelight'
 
 sqldelight {
     MyDatabase {

--- a/sqldelight-gradle-plugin/src/test/variants/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/variants/build.gradle
@@ -1,11 +1,24 @@
-plugins {
-  id 'com.android.application'
-  id 'com.squareup.sqldelight'
-  id 'org.jetbrains.kotlin.android'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+    jcenter()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+    classpath deps.plugins.android
+  }
 }
 
-apply from: '../../../../gradle/dependencies.gradle'
-
+apply plugin: 'com.android.application'
+apply plugin: 'com.squareup.sqldelight'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 repositories {
   maven {

--- a/sqldelight-gradle-plugin/src/test/working-variants/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/working-variants/build.gradle
@@ -1,10 +1,24 @@
-plugins {
-  id 'com.android.application'
-  id 'com.squareup.sqldelight'
-  id 'org.jetbrains.kotlin.android'
+buildscript {
+  apply from: "${projectDir.absolutePath}/../../../../gradle/dependencies.gradle"
+
+  repositories {
+    maven {
+      url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+    jcenter()
+  }
+  dependencies {
+    classpath 'com.squareup.sqldelight:gradle-plugin:+'
+    classpath deps.plugins.kotlin
+    classpath deps.plugins.android
+  }
 }
 
-apply from: '../../../../gradle/dependencies.gradle'
+apply plugin: 'com.android.application'
+apply plugin: 'com.squareup.sqldelight'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 repositories {
   maven {


### PR DESCRIPTION
This in turn removes the ability to use withPluginClasspath in Gradle TestKit which generally interacts poorly resolving dependencies across the plugin classpath and declared dependencies on the classpath of the project under test. Instead, we replicate the end-user configuration much more accurately by installing to a local maven repository and using good 'ol fashioned buildscript classpath.

Refs #1362