### PR TITLE
Fix deprecated LightCodeInsightFixtureTestCase usage

### DIFF
--- a/sqldelight-idea-plugin/src/test/kotlin/com/squareup/sqldelight/intellij/SqlDelightFixtureTestCase.kt
+++ b/sqldelight-idea-plugin/src/test/kotlin/com/squareup/sqldelight/intellij/SqlDelightFixtureTestCase.kt
@@ -20,13 +20,13 @@ import com.alecstrong.sql.psi.core.DialectPreset
 import com.intellij.openapi.project.rootManager
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiDirectory
-import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
 import com.squareup.sqldelight.core.SqlDelightDatabaseName
 import com.squareup.sqldelight.core.SqlDelightFileIndex
 import com.squareup.sqldelight.core.SqldelightParserUtil
 import com.squareup.sqldelight.core.lang.SqlDelightFile
 
-abstract class SqlDelightFixtureTestCase : LightCodeInsightFixtureTestCase() {
+abstract class SqlDelightFixtureTestCase : LightJavaCodeInsightFixtureTestCase() {
   protected val sqldelightDir = "main/sqldelight/com/sample"
 
   open val fixtureDirectory: String = ""

--- a/sqldelight-idea-plugin/src/test/kotlin/com/squareup/sqldelight/intellij/SqlDelightProjectTestCase.kt
+++ b/sqldelight-idea-plugin/src/test/kotlin/com/squareup/sqldelight/intellij/SqlDelightProjectTestCase.kt
@@ -7,7 +7,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.util.PsiTreeUtil
-import com.intellij.testFramework.fixtures.LightCodeInsightFixtureTestCase
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
 import com.squareup.sqldelight.core.SqlDelightCompilationUnit
 import com.squareup.sqldelight.core.SqlDelightDatabaseProperties
 import com.squareup.sqldelight.core.SqlDelightFileIndex
@@ -22,7 +22,7 @@ import java.io.File
 import java.io.PrintStream
 import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
 
-abstract class SqlDelightProjectTestCase : LightCodeInsightFixtureTestCase() {
+abstract class SqlDelightProjectTestCase : LightJavaCodeInsightFixtureTestCase() {
   protected val tempRoot: VirtualFile
     get() = module.rootManager.contentRoots.single()
   override fun setUp() {


### PR DESCRIPTION
Per the deprecation notice:

> Use LightJavaCodeInsightFixtureTestCase for Java-dependent tests, BasePlatformTestCase for non-Java dependent tests.

And implementation:

```java
public abstract class LightCodeInsightFixtureTestCase extends LightJavaCodeInsightFixtureTestCase {
}
```