### PR TITLE
Revert to using tabs on website

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -164,8 +164,8 @@ theme:
   palette:
     primary: 'deep purple'
     accent: 'pink'
-  feature:
-    tabs: true
+  features:
+    - tabs
 
 extra_css:
   - 'css/app.css'


### PR DESCRIPTION
The format to specify the tabs has changed in 5.x (per mkdocs-material ["Upgrading" section](https://squidfunk.github.io/mkdocs-material/upgrading/#themefeature)). Perhaps we should be installing a specific version of `mkdocs` and `mkdocs-material` instead of defaulting to the latest version, so regressions like this won't happen again.

<img width="1401" alt="Screenshot 2020-08-22 at 11 22 34" src="https://user-images.githubusercontent.com/6900601/90953237-e8673b80-e469-11ea-80b4-f4e63bf42f1e.png">
