### PR TITLE
Separate projectArchives target to keep default installArchives task.

### DIFF
--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -10,7 +10,7 @@ mavenPublish {
   releaseSigningEnabled = !getGpgKey().isEmpty()
 
   targets {
-    projectArchives {
+    installLocally {
       releaseRepositoryUrl = file("${rootProject.buildDir}/localMaven").toURI().toString()
       snapshotRepositoryUrl = file("${rootProject.buildDir}/localMaven").toURI().toString()
     }

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -10,7 +10,7 @@ mavenPublish {
   releaseSigningEnabled = !getGpgKey().isEmpty()
 
   targets {
-    installArchives {
+    projectArchives {
       releaseRepositoryUrl = file("${rootProject.buildDir}/localMaven").toURI().toString()
       snapshotRepositoryUrl = file("${rootProject.buildDir}/localMaven").toURI().toString()
     }

--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -51,14 +51,14 @@ dependencies {
 test {
   // The integration tests require local installations of artifacts.
   dependsOn(
-          ":runtime:projectArchives",
-          ":drivers:android-driver:projectArchives",
-          ":drivers:sqlite-driver:projectArchives",
-          ":drivers:jdbc-driver:projectArchives",
-          ":drivers:native-driver:projectArchives",
-          ":sqlite-migrations:projectArchives",
-          ":sqldelight-compiler:projectArchives",
-          ":sqldelight-gradle-plugin:projectArchives",
+          ":runtime:publishAllPublicationsToProjectArchivesRepository",
+          ":drivers:android-driver:publishAllPublicationsToProjectArchivesRepository",
+          ":drivers:sqlite-driver:publishAllPublicationsToProjectArchivesRepository",
+          ":drivers:jdbc-driver:publishAllPublicationsToProjectArchivesRepository",
+          ":drivers:native-driver:publishAllPublicationsToProjectArchivesRepository",
+          ":sqlite-migrations:publishAllPublicationsToProjectArchivesRepository",
+          ":sqldelight-compiler:publishAllPublicationsToProjectArchivesRepository",
+          ":sqldelight-gradle-plugin:publishAllPublicationsToProjectArchivesRepository",
   )
   useJUnit {
     if (project.hasProperty("Instrumentation")) {

--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -51,14 +51,14 @@ dependencies {
 test {
   // The integration tests require local installations of artifacts.
   dependsOn(
-          ":runtime:installArchives",
-          ":drivers:android-driver:installArchives",
-          ":drivers:sqlite-driver:installArchives",
-          ":drivers:jdbc-driver:installArchives",
-          ":drivers:native-driver:installArchives",
-          ":sqlite-migrations:installArchives",
-          ":sqldelight-compiler:installArchives",
-          ":sqldelight-gradle-plugin:installArchives",
+          ":runtime:projectArchives",
+          ":drivers:android-driver:projectArchives",
+          ":drivers:sqlite-driver:projectArchives",
+          ":drivers:jdbc-driver:projectArchives",
+          ":drivers:native-driver:projectArchives",
+          ":sqlite-migrations:projectArchives",
+          ":sqldelight-compiler:projectArchives",
+          ":sqldelight-gradle-plugin:projectArchives",
   )
   useJUnit {
     if (project.hasProperty("Instrumentation")) {

--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -51,14 +51,14 @@ dependencies {
 test {
   // The integration tests require local installations of artifacts.
   dependsOn(
-          ":runtime:publishAllPublicationsToProjectArchivesRepository",
-          ":drivers:android-driver:publishAllPublicationsToProjectArchivesRepository",
-          ":drivers:sqlite-driver:publishAllPublicationsToProjectArchivesRepository",
-          ":drivers:jdbc-driver:publishAllPublicationsToProjectArchivesRepository",
-          ":drivers:native-driver:publishAllPublicationsToProjectArchivesRepository",
-          ":sqlite-migrations:publishAllPublicationsToProjectArchivesRepository",
-          ":sqldelight-compiler:publishAllPublicationsToProjectArchivesRepository",
-          ":sqldelight-gradle-plugin:publishAllPublicationsToProjectArchivesRepository",
+          ":runtime:publishAllPublicationsToInstallLocallyRepository",
+          ":drivers:android-driver:publishAllPublicationsToInstallLocallyRepository",
+          ":drivers:sqlite-driver:publishAllPublicationsToInstallLocallyRepository",
+          ":drivers:jdbc-driver:publishAllPublicationsToInstallLocallyRepository",
+          ":drivers:native-driver:publishAllPublicationsToInstallLocallyRepository",
+          ":sqlite-migrations:publishAllPublicationsToInstallLocallyRepository",
+          ":sqldelight-compiler:publishAllPublicationsToInstallLocallyRepository",
+          ":sqldelight-gradle-plugin:publishAllPublicationsToInstallLocallyRepository",
   )
   useJUnit {
     if (project.hasProperty("Instrumentation")) {


### PR DESCRIPTION
It's nice to have a default `installArchives` tasks that places the dependencies inside `mavenLocal`. For integration tests, we can define a new target.