### PR TITLE
Fix issue with invalid Kotlin being generated

### DIFF
--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/testmodule/TestDatabaseImpl.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/testmodule/TestDatabaseImpl.kt
@@ -105,8 +105,13 @@ private class TeamQueriesImpl(
     )
   }
 
-  override fun teamForCoach(coach: String): Query<TeamForCoach> = teamForCoach(coach,
-      ::TeamForCoach)
+  override fun teamForCoach(coach: String): Query<TeamForCoach> = teamForCoach(coach) { name,
+      captain ->
+    com.example.TeamForCoach(
+      name,
+      captain
+    )
+  }
 
   override fun <T : Any> forInnerType(inner_type: Shoots.Type?, mapper: (
     name: String,
@@ -122,8 +127,15 @@ private class TeamQueriesImpl(
     )
   }
 
-  override fun forInnerType(inner_type: Shoots.Type?): Query<Team> = forInnerType(inner_type,
-      ::Team)
+  override fun forInnerType(inner_type: Shoots.Type?): Query<Team> = forInnerType(inner_type) {
+      name, captain, inner_type, coach ->
+    com.example.Team(
+      name,
+      captain,
+      inner_type,
+      coach
+    )
+  }
 
   private inner class TeamForCoachQuery<out T : Any>(
     @JvmField
@@ -187,7 +199,14 @@ private class PlayerQueriesImpl(
     )
   }
 
-  override fun allPlayers(): Query<Player> = allPlayers(::Player)
+  override fun allPlayers(): Query<Player> = allPlayers { name, number, team, shoots ->
+    com.example.Player(
+      name,
+      number,
+      team,
+      shoots
+    )
+  }
 
   override fun <T : Any> playersForTeam(team: String?, mapper: (
     name: String,
@@ -203,7 +222,15 @@ private class PlayerQueriesImpl(
     )
   }
 
-  override fun playersForTeam(team: String?): Query<Player> = playersForTeam(team, ::Player)
+  override fun playersForTeam(team: String?): Query<Player> = playersForTeam(team) { name, number,
+      team, shoots ->
+    com.example.Player(
+      name,
+      number,
+      team,
+      shoots
+    )
+  }
 
   override fun <T : Any> playersForNumbers(number: Collection<Long>, mapper: (
     name: String,
@@ -220,7 +247,14 @@ private class PlayerQueriesImpl(
   }
 
   override fun playersForNumbers(number: Collection<Long>): Query<Player> =
-      playersForNumbers(number, ::Player)
+      playersForNumbers(number) { name, number, team, shoots ->
+    com.example.Player(
+      name,
+      number,
+      team,
+      shoots
+    )
+  }
 
   override fun <T : Any> selectNull(mapper: (expr: Void?) -> T): Query<T> = Query(106890351,
       selectNull, driver, "Player.sq", "selectNull", "SELECT NULL") { cursor ->
@@ -229,7 +263,11 @@ private class PlayerQueriesImpl(
     )
   }
 
-  override fun selectNull(): Query<SelectNull> = selectNull(::SelectNull)
+  override fun selectNull(): Query<SelectNull> = selectNull { expr ->
+    com.example.SelectNull(
+      expr
+    )
+  }
 
   override fun insertPlayer(
     name: String,

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/QueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/QueriesTypeTest.kt
@@ -101,7 +101,12 @@ class QueriesTypeTest {
       |    )
       |  }
       |
-      |  override fun selectForId(id: Long): Query<Data> = selectForId(id, ::Data)
+      |  override fun selectForId(id: Long): Query<Data> = selectForId(id) { id, value ->
+      |    com.example.Data(
+      |      id,
+      |      value
+      |    )
+      |  }
       |
       |  override fun insertData(id: Long?, value: List?) {
       |    driver.execute(${insert.id}, ""${'"'}
@@ -224,7 +229,12 @@ class QueriesTypeTest {
       |    )
       |  }
       |
-      |  override fun selectForId(id: Long): Query<Data> = selectForId(id, ::Data)
+      |  override fun selectForId(id: Long): Query<Data> = selectForId(id) { id, value ->
+      |    com.example.Data(
+      |      id,
+      |      value
+      |    )
+      |  }
       |
       |  override fun insertData(id: Long?, value: List?) {
       |    driver.execute(${insert.id}, ""${'"'}

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/ExpressionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/ExpressionTest.kt
@@ -30,7 +30,13 @@ class ExpressionTest {
 
     val generator = SelectQueryGenerator(file.namedQueries.first())
     assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo("""
-      |override fun testQuery(SecondId: kotlin.Long, value: kotlin.String): com.squareup.sqldelight.Query<com.example.Test> = testQuery(SecondId, value, ::com.example.Test)
+      |override fun testQuery(SecondId: kotlin.Long, value: kotlin.String): com.squareup.sqldelight.Query<com.example.Test> = testQuery(SecondId, value) { TestId, TestText, SecondId ->
+      |  com.example.Test(
+      |    TestId,
+      |    TestText,
+      |    SecondId
+      |  )
+      |}
       |""".trimMargin())
   }
 

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/JavadocTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/JavadocTest.kt
@@ -26,7 +26,12 @@ class JavadocTest {
       |/**
       | * Queries all values.
       | */
-      |override fun selectAll(): com.squareup.sqldelight.Query<com.example.Test> = selectAll(::com.example.Test)
+      |override fun selectAll(): com.squareup.sqldelight.Query<com.example.Test> = selectAll { _id, value ->
+      |  com.example.Test(
+      |    _id,
+      |    value
+      |  )
+      |}
       |""".trimMargin())
   }
 
@@ -52,7 +57,12 @@ class JavadocTest {
       |/**
       | * Queries all values.
       | */
-      |override fun selectAll(): com.squareup.sqldelight.Query<com.example.Test> = selectAll(::com.example.Test)
+      |override fun selectAll(): com.squareup.sqldelight.Query<com.example.Test> = selectAll { _id, value ->
+      |  com.example.Test(
+      |    _id,
+      |    value
+      |  )
+      |}
       |""".trimMargin())
   }
 
@@ -77,7 +87,12 @@ class JavadocTest {
       | *
       | * @deprecated Don't use it!
       | */
-      |override fun selectAll(): com.squareup.sqldelight.Query<com.example.Test> = selectAll(::com.example.Test)
+      |override fun selectAll(): com.squareup.sqldelight.Query<com.example.Test> = selectAll { _id, value ->
+      |  com.example.Test(
+      |    _id,
+      |    value
+      |  )
+      |}
       |""".trimMargin())
   }
 
@@ -102,7 +117,12 @@ class JavadocTest {
       | *
       | * ** @deprecated Don't use it!
       | */
-      |override fun selectAll(): com.squareup.sqldelight.Query<com.example.Test> = selectAll(::com.example.Test)
+      |override fun selectAll(): com.squareup.sqldelight.Query<com.example.Test> = selectAll { _id, value ->
+      |  com.example.Test(
+      |    _id,
+      |    value
+      |  )
+      |}
       |""".trimMargin())
   }
 
@@ -119,7 +139,12 @@ class JavadocTest {
       |/**
       | * Queries all values.
       | */
-      |override fun selectAll(): com.squareup.sqldelight.Query<com.example.Test> = selectAll(::com.example.Test)
+      |override fun selectAll(): com.squareup.sqldelight.Query<com.example.Test> = selectAll { _id, value ->
+      |  com.example.Test(
+      |    _id,
+      |    value
+      |  )
+      |}
       |""".trimMargin())
   }
 
@@ -138,7 +163,12 @@ class JavadocTest {
       |/**
       | * Queries all values.
       | */
-      |override fun selectAll(): com.squareup.sqldelight.Query<com.example.Test> = selectAll(::com.example.Test)
+      |override fun selectAll(): com.squareup.sqldelight.Query<com.example.Test> = selectAll { _id, value ->
+      |  com.example.Test(
+      |    _id,
+      |    value
+      |  )
+      |}
       |""".trimMargin())
   }
 

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryFunctionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryFunctionTest.kt
@@ -25,7 +25,12 @@ class SelectQueryFunctionTest {
 
     val generator = SelectQueryGenerator(file.namedQueries.first())
     assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo("""
-      |override fun selectForId(id: kotlin.Long): com.squareup.sqldelight.Query<com.example.Data> = selectForId(id, ::com.example.Data)
+      |override fun selectForId(id: kotlin.Long): com.squareup.sqldelight.Query<com.example.Data> = selectForId(id) { id, value ->
+      |  com.example.Data(
+      |    id,
+      |    value
+      |  )
+      |}
       |""".trimMargin())
   }
 
@@ -60,7 +65,13 @@ class SelectQueryFunctionTest {
       |  channelId: kotlin.String,
       |  from: com.example.LocalDateTime,
       |  to: com.example.LocalDateTime
-      |): com.squareup.sqldelight.Query<com.example.Data> = selectByChannelId(channelId, from, to, ::com.example.Data)
+      |): com.squareup.sqldelight.Query<com.example.Data> = selectByChannelId(channelId, from, to) { channelId, startTime, endTime ->
+      |  com.example.Data(
+      |    channelId,
+      |    startTime,
+      |    endTime
+      |  )
+      |}
       |""".trimMargin())
   }
 
@@ -80,7 +91,12 @@ class SelectQueryFunctionTest {
 
     val generator = SelectQueryGenerator(file.namedQueries.first())
     assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo("""
-      |override fun select(value: kotlin.String, id: kotlin.Long): com.squareup.sqldelight.Query<com.example.Data> = select(value, id, ::com.example.Data)
+      |override fun select(value: kotlin.String, id: kotlin.Long): com.squareup.sqldelight.Query<com.example.Data> = select(value, id) { id, value ->
+      |  com.example.Data(
+      |    id,
+      |    value
+      |  )
+      |}
       |""".trimMargin())
   }
 
@@ -265,7 +281,12 @@ class SelectQueryFunctionTest {
 
     val generator = SelectQueryGenerator(file.namedQueries.first())
     assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo("""
-      |override fun someSelect(minimum: kotlin.Long, offset: kotlin.Long): com.squareup.sqldelight.Query<com.example.Data> = someSelect(minimum, offset, ::com.example.Data)
+      |override fun someSelect(minimum: kotlin.Long, offset: kotlin.Long): com.squareup.sqldelight.Query<com.example.Data> = someSelect(minimum, offset) { some_column, some_column2 ->
+      |  com.example.Data(
+      |    some_column,
+      |    some_column2
+      |  )
+      |}
       |""".trimMargin())
   }
 
@@ -498,7 +519,13 @@ class SelectQueryFunctionTest {
 
     val generator = SelectQueryGenerator(file.namedQueries.first())
     assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo("""
-      |override fun selectData(): com.squareup.sqldelight.Query<com.example.SelectData> = selectData(::com.example.SelectData)
+      |override fun selectData(): com.squareup.sqldelight.Query<com.example.SelectData> = selectData { coalesce, value, value2 ->
+      |  com.example.SelectData(
+      |    coalesce,
+      |    value,
+      |    value2
+      |  )
+      |}
       |""".trimMargin())
   }
 


### PR DESCRIPTION
  - If two sq files have labeled queries with the same name that return a custom type there will be a compiler error
  - The second one will have an implementation that uses the form  which is not valid Kotlin
    - https://github.com/square/kotlinpoet/blob/eff1ce460f42e0c8f489155a46da479c8e9a8c15/kotlinpoet/src/main/java/com/squareup/kotlinpoet/TypeName.kt#L406

I made this more to illustrate the problem. I have a feeling this isn't the desired fix, but I wanted to get something out there.