### PR TITLE
Use SNAPSHOT build of sql-psi in sql-psi-dev

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ allprojects {
     mavenCentral()
     google()
     jcenter()
+    maven {
+      url 'https://oss.sonatype.org/content/repositories/snapshots/'
+    }
   }
 
   tasks.withType(Test) {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -66,7 +66,7 @@ ext.deps = [
     intellijJavaPlugin: fileTree(dir: "$rootDir/lib/intellij-core/plugins/java/lib", include: [
         'java-api.jar',
     ]),
-    sqlitePsi: "com.alecstrong:sqlite-psi-core:0.3.8",
+    sqlitePsi: "com.alecstrong:sqlite-psi-core:0.4.0-SNAPSHOT",
     sqliteJdbc: "org.xerial:sqlite-jdbc:3.21.0.1",
     robolectric: 'org.robolectric:robolectric:4.1',
     rxJava2: "io.reactivex.rxjava2:rxjava:2.2.5",


### PR DESCRIPTION
**\*BUILD FAILURE EXPECTED\***

In reference to https://github.com/cashapp/sqldelight/pull/1955#issuecomment-695330110.

Just an initial commit to use the SNAPSHOT build of sql-psi in the branch `sql-psi-dev`. I suppose that this sort of commit will become common as, whenever there is a new sql-psi release, `sql-psi-dev` will need to: 

1. Create a commit replacing the SNAPSHOT with the new sql-psi release
2. Merge `sql-psi-dev` into `master`
3. Create a commit in `sql-psi-dev` with the next SNAPSHOT of sql-psi (basically like this PR)

Also, once this is merged, we can change the base branch of https://github.com/cashapp/sqldelight/pull/1955 to `sql-psi-dev` and see if the build passes.