### PR TITLE
Add workflow that automatically rebases sql-psi-dev onto master

### DIFF
--- a/.github/workflows/sql-psi-dev.yml
+++ b/.github/workflows/sql-psi-dev.yml
@@ -1,0 +1,20 @@
+name: Rebase sql-psi-dev onto master
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: |
+          git config --global user.name "$(git --no-pager log --format=format:'%an' -n 1)"
+          git config --global user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
+          git checkout sql-psi-dev
+          git rebase master
+          git push -f origin sql-psi-dev


### PR DESCRIPTION
As discussed in https://github.com/cashapp/sqldelight/pull/1955#issuecomment-695330110, whenever someone pushes to `master`, the branch `sql-psi-dev` will automatically rebase onto the `HEAD` of `master`.

If `git rebase master` encounters a merge conflict, this workflow will just fail ([example workflow](https://github.com/veyndan/sqldelight/runs/1138866881?check_suite_focus=true)), and the branch must be manually rebased and have its conflicts resolved (couldn't think of a better solution around this atm).

I've also already created a branch in this repo called `sql-psi-dev` (if there's a better branch name we can always change it).