### PR TITLE
Implement JS tests for coroutines-extensions

### DIFF
--- a/extensions/coroutines-extensions/build.gradle
+++ b/extensions/coroutines-extensions/build.gradle
@@ -54,8 +54,20 @@ kotlin {
 
   // https://github.com/cashapp/sqldelight/pull/1919
   js(LEGACY) {
-    nodejs {}
-    browser {}
+    nodejs {
+      testTask {
+        useMocha {
+          timeout = "5s"
+        }
+      }
+    }
+    browser {
+      testTask {
+        useMocha {
+          timeout = "5s"
+        }
+      }
+    }
     compilations.all {
       it.compileKotlinTask.kotlinOptions {
         moduleKind = "umd"

--- a/extensions/coroutines-extensions/build.gradle
+++ b/extensions/coroutines-extensions/build.gradle
@@ -32,6 +32,7 @@ kotlin {
     jsTest {
       dependencies {
         implementation deps.kotlin.test.js
+        implementation project(':drivers:sqljs-driver')
       }
     }
     nativeMain {
@@ -51,15 +52,21 @@ kotlin {
     }
   }
 
-  targets {
-    targetFromPreset(presets.jvm, 'jvm')
-    targetFromPreset(presets.js, 'js') {
-      tasks.getByName(compilations.main.compileKotlinTaskName).kotlinOptions {
-        moduleKind = 'umd'
+  // https://github.com/cashapp/sqldelight/pull/1919
+  js(LEGACY) {
+    nodejs {}
+    browser {}
+    compilations.all {
+      it.compileKotlinTask.kotlinOptions {
+        moduleKind = "umd"
         sourceMap = true
-        metaInfo = true
+        sourceMapEmbedSources = null
       }
     }
+  }
+
+  targets {
+    targetFromPreset(presets.jvm, 'jvm')
     targetFromPreset(presets.iosX64, 'iosX64')
     targetFromPreset(presets.iosArm32, 'iosArm32')
     targetFromPreset(presets.iosArm64, 'iosArm64')

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/DbTest.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/DbTest.kt
@@ -1,0 +1,5 @@
+package com.squareup.sqldelight.runtime.coroutines
+
+interface DbTest {
+  suspend fun setupDb(): TestDb
+}

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/MappingTest.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/MappingTest.kt
@@ -6,23 +6,14 @@ import com.squareup.sqldelight.internal.copyOnWriteList
 import com.squareup.sqldelight.runtime.coroutines.Employee.Companion.MAPPER
 import com.squareup.sqldelight.runtime.coroutines.Employee.Companion.SELECT_EMPLOYEES
 import com.squareup.sqldelight.runtime.coroutines.TestDb.Companion.TABLE_EMPLOYEE
-import kotlin.test.AfterTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
-import kotlin.test.assertSame
-import kotlin.test.assertTrue
-import kotlin.test.fail
 import kotlinx.coroutines.flow.take
+import kotlin.test.*
 
-class MappingTest {
-  private val db = TestDb()
+class MappingTest : DbTest {
 
-  @AfterTest fun tearDown() {
-    db.close()
-  }
+  override suspend fun setupDb(): TestDb = TestDb(testDriver())
 
-  @Test fun mapToOne() = runTest {
+  @Test fun mapToOne() = runTest { db ->
     db.createQuery(TABLE_EMPLOYEE, "$SELECT_EMPLOYEES LIMIT 1", MAPPER)
         .asFlow()
         .mapToOne()
@@ -32,7 +23,7 @@ class MappingTest {
         }
   }
 
-  @Test fun mapToOneThrowsFromMapFunction() = runTest {
+  @Test fun mapToOneThrowsFromMapFunction() = runTest { db ->
     val expected = IllegalStateException("test exception")
 
     db.createQuery(TABLE_EMPLOYEE, "$SELECT_EMPLOYEES LIMIT 1", { throw expected })
@@ -46,7 +37,7 @@ class MappingTest {
         }
   }
 
-  @Test fun mapToOneThrowsFromQueryExecute() = runTest {
+  @Test fun mapToOneThrowsFromQueryExecute() = runTest { db ->
     val expected = IllegalStateException("test exception")
 
     val query = object : Query<Any>(copyOnWriteList(), { fail() }) {
@@ -63,7 +54,7 @@ class MappingTest {
         }
   }
 
-  @Test fun mapToOneThrowsOnMultipleRows() = runTest {
+  @Test fun mapToOneThrowsOnMultipleRows() = runTest { db ->
     db.createQuery(TABLE_EMPLOYEE, "$SELECT_EMPLOYEES LIMIT 2", MAPPER)
         .asFlow()
         .mapToOne()
@@ -73,7 +64,7 @@ class MappingTest {
         }
   }
 
-  @Test fun mapToOneOrDefault() = runTest {
+  @Test fun mapToOneOrDefault() = runTest { db ->
     db.createQuery(TABLE_EMPLOYEE, "$SELECT_EMPLOYEES LIMIT 1", MAPPER)
         .asFlow()
         .mapToOneOrDefault(Employee("fred", "Fred Frederson"))
@@ -83,7 +74,7 @@ class MappingTest {
         }
   }
 
-  @Test fun mapToOneOrDefaultThrowsFromMapFunction() = runTest {
+  @Test fun mapToOneOrDefaultThrowsFromMapFunction() = runTest { db ->
     val expected = IllegalStateException("test exception")
 
     db.createQuery(TABLE_EMPLOYEE, "$SELECT_EMPLOYEES LIMIT 1", { throw expected })
@@ -97,7 +88,7 @@ class MappingTest {
         }
   }
 
-  @Test fun mapToOneOrDefaultThrowsFromQueryExecute() = runTest {
+  @Test fun mapToOneOrDefaultThrowsFromQueryExecute() = runTest { db ->
     val expected = IllegalStateException("test exception")
 
     val query = object : Query<Any>(copyOnWriteList(), { fail() }) {
@@ -114,7 +105,7 @@ class MappingTest {
         }
   }
 
-  @Test fun mapToOneOrDefaultThrowsOnMultipleRows() = runTest {
+  @Test fun mapToOneOrDefaultThrowsOnMultipleRows() = runTest { db ->
     db.createQuery(TABLE_EMPLOYEE, "$SELECT_EMPLOYEES LIMIT 2", MAPPER) //
         .asFlow()
         .mapToOneOrDefault(Employee("fred", "Fred Frederson"))
@@ -124,7 +115,7 @@ class MappingTest {
         }
   }
 
-  @Test fun mapToOneOrDefaultReturnsDefaultWhenNoResults() = runTest {
+  @Test fun mapToOneOrDefaultReturnsDefaultWhenNoResults() = runTest { db ->
     val defaultEmployee = Employee("fred", "Fred Frederson")
 
     db.createQuery(TABLE_EMPLOYEE, "$SELECT_EMPLOYEES LIMIT 0", MAPPER) //
@@ -136,7 +127,7 @@ class MappingTest {
         }
   }
 
-  @Test fun mapToList() = runTest {
+  @Test fun mapToList() = runTest { db ->
     db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES, MAPPER)
         .asFlow()
         .mapToList()
@@ -150,7 +141,7 @@ class MappingTest {
         }
   }
 
-  @Test fun mapToListThrowsFromMapFunction() = runTest {
+  @Test fun mapToListThrowsFromMapFunction() = runTest { db ->
     val expected = IllegalStateException("test exception")
 
     db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES, { throw expected })
@@ -164,7 +155,7 @@ class MappingTest {
         }
   }
 
-  @Test fun mapToListThrowsFromQueryExecute() = runTest {
+  @Test fun mapToListThrowsFromQueryExecute() = runTest { db ->
     val expected = IllegalStateException("test exception")
 
     val query = object : Query<Any>(copyOnWriteList(), { fail() }) {
@@ -181,7 +172,7 @@ class MappingTest {
         }
   }
 
-  @Test fun mapToListEmptyWhenNoRows() = runTest {
+  @Test fun mapToListEmptyWhenNoRows() = runTest { db ->
     db.createQuery(TABLE_EMPLOYEE, "$SELECT_EMPLOYEES WHERE 1=2", MAPPER)
         .asFlow()
         .mapToList()
@@ -191,7 +182,7 @@ class MappingTest {
         }
   }
 
-  @Test fun mapToOneOrNull() = runTest {
+  @Test fun mapToOneOrNull() = runTest { db ->
     db.createQuery(TABLE_EMPLOYEE, "$SELECT_EMPLOYEES LIMIT 1", MAPPER)
         .asFlow()
         .mapToOneOrNull()
@@ -201,7 +192,7 @@ class MappingTest {
         }
   }
 
-  @Test fun mapToOneOrNullThrowsFromMapFunction() = runTest {
+  @Test fun mapToOneOrNullThrowsFromMapFunction() = runTest { db ->
     val expected = IllegalStateException("test exception")
     db.createQuery(TABLE_EMPLOYEE, "$SELECT_EMPLOYEES LIMIT 1", { throw expected })
         .asFlow()
@@ -214,7 +205,7 @@ class MappingTest {
         }
   }
 
-  @Test fun mapToOneOrNullThrowsFromQueryExecute() = runTest {
+  @Test fun mapToOneOrNullThrowsFromQueryExecute() = runTest { db ->
     val expected = IllegalStateException("test exception")
 
     val query = object : Query<Any>(copyOnWriteList(), { fail() }) {
@@ -231,7 +222,7 @@ class MappingTest {
         }
   }
 
-  @Test fun mapToOneOrNullThrowsOnMultipleRows() = runTest {
+  @Test fun mapToOneOrNullThrowsOnMultipleRows() = runTest { db ->
     db.createQuery(TABLE_EMPLOYEE, "$SELECT_EMPLOYEES LIMIT 2", MAPPER) //
         .asFlow()
         .mapToOneOrNull()
@@ -241,7 +232,7 @@ class MappingTest {
         }
   }
 
-  @Test fun mapToOneOrNullEmptyWhenNoResults() = runTest {
+  @Test fun mapToOneOrNullEmptyWhenNoResults() = runTest { db ->
     db.createQuery(TABLE_EMPLOYEE, "$SELECT_EMPLOYEES LIMIT 0", MAPPER) //
         .asFlow()
         .mapToOneOrNull()
@@ -251,7 +242,7 @@ class MappingTest {
         }
   }
 
-  @Test fun mapToOneNonNull() = runTest {
+  @Test fun mapToOneNonNull() = runTest { db ->
     db.createQuery(TABLE_EMPLOYEE, "$SELECT_EMPLOYEES LIMIT 1", MAPPER)
         .asFlow()
         .mapToOneNotNull()
@@ -261,7 +252,7 @@ class MappingTest {
         }
   }
 
-  @Test fun mapToOneNonNullThrowsFromMapFunction() = runTest {
+  @Test fun mapToOneNonNullThrowsFromMapFunction() = runTest { db ->
     val expected = IllegalStateException("test exception")
 
     db.createQuery(TABLE_EMPLOYEE, "$SELECT_EMPLOYEES LIMIT 1", { throw expected })
@@ -275,7 +266,7 @@ class MappingTest {
         }
   }
 
-  @Test fun mapToOneNonNullThrowsFromQueryExecute() = runTest {
+  @Test fun mapToOneNonNullThrowsFromQueryExecute() = runTest { db ->
     val expected = IllegalStateException("test exception")
 
     val query = object : Query<Any>(copyOnWriteList(), { fail() }) {
@@ -292,7 +283,7 @@ class MappingTest {
         }
   }
 
-  @Test fun mapToOneNonNullDoesNotEmitForNoResults() = runTest {
+  @Test fun mapToOneNonNullDoesNotEmitForNoResults() = runTest { db ->
     db.createQuery(TABLE_EMPLOYEE, "$SELECT_EMPLOYEES LIMIT 0", MAPPER)
         .asFlow()
         .take(1) // Ensure we have an event (complete) that the script can validate.

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/MappingTest.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/MappingTest.kt
@@ -6,14 +6,13 @@ import com.squareup.sqldelight.internal.copyOnWriteList
 import com.squareup.sqldelight.runtime.coroutines.Employee.Companion.MAPPER
 import com.squareup.sqldelight.runtime.coroutines.Employee.Companion.SELECT_EMPLOYEES
 import com.squareup.sqldelight.runtime.coroutines.TestDb.Companion.TABLE_EMPLOYEE
-import kotlinx.coroutines.flow.take
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlin.test.fail
-
+import kotlinx.coroutines.flow.take
 
 class MappingTest : DbTest {
 

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/MappingTest.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/MappingTest.kt
@@ -7,13 +7,20 @@ import com.squareup.sqldelight.runtime.coroutines.Employee.Companion.MAPPER
 import com.squareup.sqldelight.runtime.coroutines.Employee.Companion.SELECT_EMPLOYEES
 import com.squareup.sqldelight.runtime.coroutines.TestDb.Companion.TABLE_EMPLOYEE
 import kotlinx.coroutines.flow.take
-import kotlin.test.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
 
 class MappingTest : DbTest {
 
   override suspend fun setupDb(): TestDb = TestDb(testDriver())
 
-  @Test fun mapToOne() = runTest { db ->
+  @Test
+  fun mapToOne() = runTest { db ->
     db.createQuery(TABLE_EMPLOYEE, "$SELECT_EMPLOYEES LIMIT 1", MAPPER)
         .asFlow()
         .mapToOne()
@@ -88,7 +95,7 @@ class MappingTest : DbTest {
         }
   }
 
-  @Test fun mapToOneOrDefaultThrowsFromQueryExecute() = runTest { db ->
+  @Test fun mapToOneOrDefaultThrowsFromQueryExecute() = runTest {
     val expected = IllegalStateException("test exception")
 
     val query = object : Query<Any>(copyOnWriteList(), { fail() }) {
@@ -155,7 +162,7 @@ class MappingTest : DbTest {
         }
   }
 
-  @Test fun mapToListThrowsFromQueryExecute() = runTest { db ->
+  @Test fun mapToListThrowsFromQueryExecute() = runTest {
     val expected = IllegalStateException("test exception")
 
     val query = object : Query<Any>(copyOnWriteList(), { fail() }) {
@@ -205,7 +212,7 @@ class MappingTest : DbTest {
         }
   }
 
-  @Test fun mapToOneOrNullThrowsFromQueryExecute() = runTest { db ->
+  @Test fun mapToOneOrNullThrowsFromQueryExecute() = runTest {
     val expected = IllegalStateException("test exception")
 
     val query = object : Query<Any>(copyOnWriteList(), { fail() }) {
@@ -266,7 +273,7 @@ class MappingTest : DbTest {
         }
   }
 
-  @Test fun mapToOneNonNullThrowsFromQueryExecute() = runTest { db ->
+  @Test fun mapToOneNonNullThrowsFromQueryExecute() = runTest {
     val expected = IllegalStateException("test exception")
 
     val query = object : Query<Any>(copyOnWriteList(), { fail() }) {

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/QueryAsFlowTest.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/QueryAsFlowTest.kt
@@ -7,6 +7,7 @@ import com.squareup.sqldelight.runtime.coroutines.Employee.Companion.USERNAME
 import com.squareup.sqldelight.runtime.coroutines.TestDb.Companion.TABLE_EMPLOYEE
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.seconds
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.yield
 
@@ -85,7 +86,7 @@ class QueryAsFlowTest : DbTest {
     }
   }
 
-  @Test fun queryCanBeCollectedMoreThanOnce() = runTest { db ->
+  @Test fun queryCanBeCollectedMoreThanOnce() = runTest(cleanupAfter = 1.seconds) { db ->
     val flow = db.createQuery(TABLE_EMPLOYEE, "$SELECT_EMPLOYEES WHERE $USERNAME = 'john'", MAPPER)
         .asFlow()
         .mapToOneNotNull()

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/QueryAsFlowTest.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/QueryAsFlowTest.kt
@@ -5,10 +5,10 @@ import com.squareup.sqldelight.runtime.coroutines.Employee.Companion.MAPPER
 import com.squareup.sqldelight.runtime.coroutines.Employee.Companion.SELECT_EMPLOYEES
 import com.squareup.sqldelight.runtime.coroutines.Employee.Companion.USERNAME
 import com.squareup.sqldelight.runtime.coroutines.TestDb.Companion.TABLE_EMPLOYEE
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.yield
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
 
 class QueryAsFlowTest : DbTest {
 

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/QueryAsFlowTest.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/QueryAsFlowTest.kt
@@ -12,18 +12,11 @@ import kotlin.test.assertEquals
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.yield
 
-class QueryAsFlowTest {
-  private lateinit var db: TestDb
+class QueryAsFlowTest : DbTest {
 
-  @BeforeTest fun setup() {
-    db = TestDb()
-  }
+  override suspend fun setupDb(): TestDb = TestDb(testDriver())
 
-  @AfterTest fun tearDown() {
-    db.close()
-  }
-
-  @Test fun query() = runTest {
+  @Test fun query() = runTest { db ->
     db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES, MAPPER)
         .asFlow()
         .test {
@@ -37,7 +30,7 @@ class QueryAsFlowTest {
         }
   }
 
-  @Test fun queryObservesNotification() = runTest {
+  @Test fun queryObservesNotification() = runTest { db ->
     db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES, MAPPER)
         .asFlow()
         .test {
@@ -59,7 +52,7 @@ class QueryAsFlowTest {
         }
   }
 
-  @Test fun queryNotNotifiedAfterCancel() = runTest {
+  @Test fun queryNotNotifiedAfterCancel() = runTest { db ->
     db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES, MAPPER)
         .asFlow()
         .test {
@@ -77,7 +70,7 @@ class QueryAsFlowTest {
         }
   }
 
-  @Test fun queryOnlyNotifiedAfterCollect() = runTest {
+  @Test fun queryOnlyNotifiedAfterCollect() = runTest { db ->
     val flow = db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES, MAPPER)
         .asFlow()
 
@@ -94,7 +87,7 @@ class QueryAsFlowTest {
     }
   }
 
-  @Test fun queryCanBeCollectedMoreThanOnce() = runTest {
+  @Test fun queryCanBeCollectedMoreThanOnce() = runTest { db ->
     val flow = db.createQuery(TABLE_EMPLOYEE, "$SELECT_EMPLOYEES WHERE $USERNAME = 'john'", MAPPER)
         .asFlow()
         .mapToOneNotNull()

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/QueryAsFlowTest.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/QueryAsFlowTest.kt
@@ -5,12 +5,10 @@ import com.squareup.sqldelight.runtime.coroutines.Employee.Companion.MAPPER
 import com.squareup.sqldelight.runtime.coroutines.Employee.Companion.SELECT_EMPLOYEES
 import com.squareup.sqldelight.runtime.coroutines.Employee.Companion.USERNAME
 import com.squareup.sqldelight.runtime.coroutines.TestDb.Companion.TABLE_EMPLOYEE
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.yield
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class QueryAsFlowTest : DbTest {
 

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/QueryAsFlowTest.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/QueryAsFlowTest.kt
@@ -92,7 +92,7 @@ class QueryAsFlowTest : DbTest {
 
     val employee = Employee("john", "John Johnson")
 
-    val timesCancelled = AtomicInt()
+    val timesCancelled = AtomicInt(0)
     repeat(5) {
       launch {
         flow.test {

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/TestDb.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/TestDb.kt
@@ -13,10 +13,10 @@ import com.squareup.sqldelight.internal.setValue
 import com.squareup.sqldelight.runtime.coroutines.TestDb.Companion.TABLE_EMPLOYEE
 import com.squareup.sqldelight.runtime.coroutines.TestDb.Companion.TABLE_MANAGER
 
-expect fun testDriver(): SqlDriver
+expect suspend fun testDriver(): SqlDriver
 
 class TestDb(
-  val db: SqlDriver = testDriver()
+  val db: SqlDriver
 ) : TransacterImpl(db) {
   val queries = frozenHashMap<String, MutableList<Query<*>>>()
 

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
@@ -16,6 +16,8 @@
 
 package com.squareup.sqldelight.runtime.coroutines
 
+import kotlin.time.Duration
+import kotlin.time.seconds
 import kotlinx.coroutines.CoroutineScope
 
-expect fun DbTest.runTest(body: suspend CoroutineScope.(TestDb) -> Unit)
+expect fun DbTest.runTest(cleanupAfter: Duration = 0.seconds, body: suspend CoroutineScope.(TestDb) -> Unit)

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
@@ -16,8 +16,11 @@
 
 package com.squareup.sqldelight.runtime.coroutines
 
-import kotlin.time.Duration
-import kotlin.time.seconds
 import kotlinx.coroutines.CoroutineScope
 
-expect fun DbTest.runTest(cleanupAfter: Duration = 0.seconds, body: suspend CoroutineScope.(TestDb) -> Unit)
+expect fun DbTest.runTest(body: suspend CoroutineScope.(TestDb) -> Unit)
+
+expect class AtomicInt() {
+  var value: Int
+  fun increment()
+}

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
@@ -18,4 +18,4 @@ package com.squareup.sqldelight.runtime.coroutines
 
 import kotlinx.coroutines.CoroutineScope
 
-expect fun runTest(body: suspend CoroutineScope.() -> Unit)
+expect fun DbTest.runTest(body: suspend CoroutineScope.(TestDb) -> Unit)

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.CoroutineScope
 
 expect fun DbTest.runTest(body: suspend CoroutineScope.(TestDb) -> Unit)
 
-expect class AtomicInt() {
+expect class AtomicInt(value_: Int) {
   var value: Int
   fun increment()
 }

--- a/extensions/coroutines-extensions/src/jsTest/kotlin/com/squareup/sqldelight/runtime/coroutines/TestDb.kt
+++ b/extensions/coroutines-extensions/src/jsTest/kotlin/com/squareup/sqldelight/runtime/coroutines/TestDb.kt
@@ -17,5 +17,7 @@
 package com.squareup.sqldelight.runtime.coroutines
 
 import com.squareup.sqldelight.db.SqlDriver
+import com.squareup.sqldelight.drivers.sqljs.initSqlDriver
+import kotlinx.coroutines.await
 
-actual fun testDriver(): SqlDriver = TODO()
+actual suspend fun testDriver(): SqlDriver = initSqlDriver().await()

--- a/extensions/coroutines-extensions/src/jsTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
+++ b/extensions/coroutines-extensions/src/jsTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
@@ -16,12 +16,16 @@
 
 package com.squareup.sqldelight.runtime.coroutines
 
+import kotlin.time.Duration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.promise
 
-actual fun DbTest.runTest(body: suspend CoroutineScope.(TestDb) -> Unit): dynamic = GlobalScope.promise {
+actual fun DbTest.runTest(cleanupAfter: Duration, body: suspend CoroutineScope.(TestDb) -> Unit): dynamic = GlobalScope.promise {
   val db = setupDb()
   body(db)
+
+  delay(cleanupAfter)
   db.close()
 }

--- a/extensions/coroutines-extensions/src/jsTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
+++ b/extensions/coroutines-extensions/src/jsTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
@@ -20,5 +20,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.promise
 
-actual fun runTest(body: suspend CoroutineScope.() -> Unit): dynamic =
-    GlobalScope.promise { body() }
+actual fun DbTest.runTest(body: suspend CoroutineScope.(TestDb) -> Unit): dynamic = GlobalScope.promise {
+  val db = setupDb()
+  body(db)
+  db.close()
+}

--- a/extensions/coroutines-extensions/src/jsTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
+++ b/extensions/coroutines-extensions/src/jsTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
@@ -27,8 +27,8 @@ actual fun DbTest.runTest(body: suspend CoroutineScope.(TestDb) -> Unit): dynami
   db.close()
 }
 
-actual class AtomicInt {
-  actual var value: Int = 0
+actual class AtomicInt actual constructor(value_: Int) {
+  actual var value: Int = value_
 
   actual fun increment() {
     value++

--- a/extensions/coroutines-extensions/src/jsTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
+++ b/extensions/coroutines-extensions/src/jsTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
@@ -16,16 +16,21 @@
 
 package com.squareup.sqldelight.runtime.coroutines
 
-import kotlin.time.Duration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.promise
 
-actual fun DbTest.runTest(cleanupAfter: Duration, body: suspend CoroutineScope.(TestDb) -> Unit): dynamic = GlobalScope.promise {
+actual fun DbTest.runTest(body: suspend CoroutineScope.(TestDb) -> Unit): dynamic = GlobalScope.promise {
   val db = setupDb()
   body(db)
 
-  delay(cleanupAfter)
   db.close()
+}
+
+actual class AtomicInt {
+  actual var value: Int = 0
+
+  actual fun increment() {
+    value++
+  }
 }

--- a/extensions/coroutines-extensions/src/jvmTest/kotlin/com/squareup/sqldelight/runtime/coroutines/MappingJvmTest.kt
+++ b/extensions/coroutines-extensions/src/jvmTest/kotlin/com/squareup/sqldelight/runtime/coroutines/MappingJvmTest.kt
@@ -19,20 +19,17 @@ package com.squareup.sqldelight.runtime.coroutines
 import com.squareup.sqldelight.runtime.coroutines.Employee.Companion.MAPPER
 import com.squareup.sqldelight.runtime.coroutines.Employee.Companion.SELECT_EMPLOYEES
 import com.squareup.sqldelight.runtime.coroutines.TestDb.Companion.TABLE_EMPLOYEE
-import java.util.concurrent.TimeUnit.SECONDS
-import kotlin.test.assertEquals
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineContext
-import org.junit.After
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.Timeout
+import java.util.concurrent.TimeUnit.SECONDS
+import kotlin.test.assertEquals
 
 class MappingJvmTest : DbTest {
   @get:Rule val timeout = Timeout(1, SECONDS)

--- a/extensions/coroutines-extensions/src/jvmTest/kotlin/com/squareup/sqldelight/runtime/coroutines/MappingJvmTest.kt
+++ b/extensions/coroutines-extensions/src/jvmTest/kotlin/com/squareup/sqldelight/runtime/coroutines/MappingJvmTest.kt
@@ -19,6 +19,8 @@ package com.squareup.sqldelight.runtime.coroutines
 import com.squareup.sqldelight.runtime.coroutines.Employee.Companion.MAPPER
 import com.squareup.sqldelight.runtime.coroutines.Employee.Companion.SELECT_EMPLOYEES
 import com.squareup.sqldelight.runtime.coroutines.TestDb.Companion.TABLE_EMPLOYEE
+import java.util.concurrent.TimeUnit.SECONDS
+import kotlin.test.assertEquals
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -28,8 +30,6 @@ import kotlinx.coroutines.test.TestCoroutineContext
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.Timeout
-import java.util.concurrent.TimeUnit.SECONDS
-import kotlin.test.assertEquals
 
 class MappingJvmTest : DbTest {
   @get:Rule val timeout = Timeout(1, SECONDS)

--- a/extensions/coroutines-extensions/src/jvmTest/kotlin/com/squareup/sqldelight/runtime/coroutines/TestDb.kt
+++ b/extensions/coroutines-extensions/src/jvmTest/kotlin/com/squareup/sqldelight/runtime/coroutines/TestDb.kt
@@ -20,4 +20,4 @@ import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
 import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver.Companion.IN_MEMORY
 
-actual fun testDriver(): SqlDriver = JdbcSqliteDriver(IN_MEMORY)
+actual suspend fun testDriver(): SqlDriver = JdbcSqliteDriver(IN_MEMORY)

--- a/extensions/coroutines-extensions/src/jvmTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
+++ b/extensions/coroutines-extensions/src/jvmTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
@@ -27,8 +27,8 @@ actual fun DbTest.runTest(body: suspend CoroutineScope.(TestDb) -> Unit) = runBl
   db.close()
 }
 
-actual class AtomicInt {
-  private val atomicInteger = AtomicInteger()
+actual class AtomicInt actual constructor(value_: Int) {
+  private val atomicInteger = AtomicInteger(value_)
   actual var value: Int
     get() = atomicInteger.get()
     set(value) = atomicInteger.set(value)

--- a/extensions/coroutines-extensions/src/jvmTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
+++ b/extensions/coroutines-extensions/src/jvmTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
@@ -19,4 +19,8 @@ package com.squareup.sqldelight.runtime.coroutines
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
 
-actual fun runTest(body: suspend CoroutineScope.() -> Unit) = runBlocking { body() }
+actual fun DbTest.runTest(body: suspend CoroutineScope.(TestDb) -> Unit) = runBlocking {
+  val db = setupDb()
+  body(db)
+  db.close()
+}

--- a/extensions/coroutines-extensions/src/jvmTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
+++ b/extensions/coroutines-extensions/src/jvmTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
@@ -16,15 +16,24 @@
 
 package com.squareup.sqldelight.runtime.coroutines
 
-import kotlin.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 
-actual fun DbTest.runTest(cleanupAfter: Duration, body: suspend CoroutineScope.(TestDb) -> Unit) = runBlocking {
+actual fun DbTest.runTest(body: suspend CoroutineScope.(TestDb) -> Unit) = runBlocking {
   val db = setupDb()
   body(db)
 
-  delay(cleanupAfter)
   db.close()
+}
+
+actual class AtomicInt {
+  private val atomicInteger = AtomicInteger()
+  actual var value: Int
+    get() = atomicInteger.get()
+    set(value) = atomicInteger.set(value)
+
+  actual fun increment() {
+    atomicInteger.incrementAndGet()
+  }
 }

--- a/extensions/coroutines-extensions/src/jvmTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
+++ b/extensions/coroutines-extensions/src/jvmTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
@@ -16,11 +16,15 @@
 
 package com.squareup.sqldelight.runtime.coroutines
 
+import kotlin.time.Duration
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 
-actual fun DbTest.runTest(body: suspend CoroutineScope.(TestDb) -> Unit) = runBlocking {
+actual fun DbTest.runTest(cleanupAfter: Duration, body: suspend CoroutineScope.(TestDb) -> Unit) = runBlocking {
   val db = setupDb()
   body(db)
+
+  delay(cleanupAfter)
   db.close()
 }

--- a/extensions/coroutines-extensions/src/nativeTest/kotlin/com/squareup/sqldelight/runtime/coroutines/TestDb.kt
+++ b/extensions/coroutines-extensions/src/nativeTest/kotlin/com/squareup/sqldelight/runtime/coroutines/TestDb.kt
@@ -32,7 +32,7 @@ private fun defaultSchema(): SqlDriver.Schema {
     }
 }
 
-actual fun testDriver(): SqlDriver {
+actual suspend fun testDriver(): SqlDriver {
     val name = "testdb"
     DatabaseFileContext.deleteDatabase(name)
     return NativeSqliteDriver(defaultSchema(), name)

--- a/extensions/coroutines-extensions/src/nativeTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
+++ b/extensions/coroutines-extensions/src/nativeTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
@@ -16,11 +16,15 @@
 
 package com.squareup.sqldelight.runtime.coroutines
 
+import kotlin.time.Duration
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 
-actual fun DbTest.runTest(body: suspend CoroutineScope.(TestDb) -> Unit) = runBlocking {
-  val db = setupDb
+actual fun DbTest.runTest(cleanupAfter: Duration, body: suspend CoroutineScope.(TestDb) -> Unit) = runBlocking {
+  val db = setupDb()
   body(db)
+
+  delay(cleanupAfter)
   db.close()
 }

--- a/extensions/coroutines-extensions/src/nativeTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
+++ b/extensions/coroutines-extensions/src/nativeTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
@@ -16,15 +16,14 @@
 
 package com.squareup.sqldelight.runtime.coroutines
 
-import kotlin.time.Duration
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 
-actual fun DbTest.runTest(cleanupAfter: Duration, body: suspend CoroutineScope.(TestDb) -> Unit) = runBlocking {
+actual fun DbTest.runTest(body: suspend CoroutineScope.(TestDb) -> Unit) = runBlocking {
   val db = setupDb()
   body(db)
 
-  delay(cleanupAfter)
   db.close()
 }
+
+actual typealias AtomicInt = kotlin.native.concurrent.AtomicInt

--- a/extensions/coroutines-extensions/src/nativeTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
+++ b/extensions/coroutines-extensions/src/nativeTest/kotlin/com/squareup/sqldelight/runtime/coroutines/runTest.kt
@@ -19,4 +19,8 @@ package com.squareup.sqldelight.runtime.coroutines
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
 
-actual fun runTest(body: suspend CoroutineScope.() -> Unit) = runBlocking { body() }
+actual fun DbTest.runTest(body: suspend CoroutineScope.(TestDb) -> Unit) = runBlocking {
+  val db = setupDb
+  body(db)
+  db.close()
+}


### PR DESCRIPTION
~Browser tests are currently failing.. but node tests are running fine.~ All js tests are now working!

Restructured the initialization of the `TestDb` since the JS driver needs to be initialized asynchronously. The DB is setup through a suspend function which is part of a `DbTest` interface. `runTest` is now an extension function on that interface and calls that setup function before calling `block` and also handles cleanup afterwards. The DB is passed in to `runTest` which can then be used by the tests.

Not really the prettiest, but it's just how the JS tests need to be since as far as I know `kotlin-test` doesn't support `Promise` setup functions.