### PR TITLE
Remove redundant check whether connection is closed

### DIFF
--- a/drivers/jdbc-driver/src/main/kotlin/com/squareup/sqldelight/sqlite/driver/JdbcDriver.kt
+++ b/drivers/jdbc-driver/src/main/kotlin/com/squareup/sqldelight/sqlite/driver/JdbcDriver.kt
@@ -18,9 +18,7 @@ fun DataSource.asJdbcDriver() = object : JdbcDriver() {
   }
 
   override fun closeConnection(connection: Connection) {
-    if (!connection.isClosed) {
-      connection.close()
-    }
+    connection.close()
   }
 }
 


### PR DESCRIPTION
Per the [documentation](https://docs.oracle.com/javase/7/docs/api/java/sql/Connection.html#close()) of `java.sql.Connection#close()`:

> Calling the method `close` on a `Connection` object that is already closed is a no-op.