### PR TITLE
Throw when calling SqliteType.ARGUMENT#resultSetGetter(Int)

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
@@ -167,7 +167,8 @@ internal data class IntermediateType(
         INTEGER -> "$CURSOR_NAME.getLong($columnIndex)"
         REAL -> "$CURSOR_NAME.getDouble($columnIndex)"
         TEXT -> "$CURSOR_NAME.getString($columnIndex)"
-        ARGUMENT, BLOB -> "$CURSOR_NAME.getBytes($columnIndex)"
+        BLOB -> "$CURSOR_NAME.getBytes($columnIndex)"
+        ARGUMENT -> throw IllegalArgumentException("Cannot retrieve argument from cursor")
       })
     }
   }


### PR DESCRIPTION
I was a bit stumped as to why `SqliteType#ARGUMENT` is mapped to `cursor.getBytes(Int)`, as to me it doesn't make much sense to get the bytes from an ARGUMENT when we are getting the inferred type of the argument when calling `SqlBindExpr.argumentType()`.

Though if this is a valid use case, could we add some test fixture showcasing its usage?