### PR TITLE
Rename resultSetGetter to cursorGetter

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/SelectQueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/SelectQueryGenerator.kt
@@ -181,13 +181,13 @@ class SelectQueryGenerator(private val query: NamedQuery) : QueryGenerator(query
       mapperLambda
           .indent()
           .apply {
-            val decoders = query.resultColumns.mapIndexed { index, column -> column.resultSetGetter(index) }
+            val decoders = query.resultColumns.mapIndexed { index, column -> column.cursorGetter(index) }
             add(decoders.joinToCode(separator = ",\n", suffix = "\n"))
           }
           .unindent()
           .add(")\n")
     } else {
-      mapperLambda.add(query.resultColumns.single().resultSetGetter(0)).add("\n")
+      mapperLambda.add(query.resultColumns.single().cursorGetter(0)).add("\n")
     }
     mapperLambda.unindent().add("}\n")
 

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/NamedQuery.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/NamedQuery.kt
@@ -153,7 +153,7 @@ data class NamedQuery(
     }
 
     if (typeOne.column !== typeTwo.column &&
-        typeOne.resultSetGetter(0) != typeTwo.resultSetGetter(0) &&
+        typeOne.cursorGetter(0) != typeTwo.cursorGetter(0) &&
         typeOne.column != null && typeTwo.column != null) {
       // Incompatible adapters. Revert to unadapted java type.
       return IntermediateType(sqliteType = typeOne.sqliteType, name = typeOne.name).nullableIf(nullable)

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
@@ -107,37 +107,37 @@ internal data class IntermediateType(
     return sqliteType.prepareStatementBinder(columnIndex, value)
   }
 
-  fun resultSetGetter(columnIndex: Int): CodeBlock {
-    var resultSetGetter = sqliteType.resultSetGetter(columnIndex)
+  fun cursorGetter(columnIndex: Int): CodeBlock {
+    var cursorGetter = sqliteType.cursorGetter(columnIndex)
 
     if (!javaType.isNullable) {
-      resultSetGetter = CodeBlock.of("$resultSetGetter!!")
+      cursorGetter = CodeBlock.of("$cursorGetter!!")
     }
 
-    resultSetGetter = when (javaType) {
-      FLOAT -> CodeBlock.of("$resultSetGetter.toFloat()")
-      FLOAT.copy(nullable = true) -> CodeBlock.of("$resultSetGetter?.toFloat()")
-      BYTE -> CodeBlock.of("$resultSetGetter.toByte()")
-      BYTE.copy(nullable = true) -> CodeBlock.of("$resultSetGetter?.toByte()")
-      SHORT -> CodeBlock.of("$resultSetGetter.toShort()")
-      SHORT.copy(nullable = true) -> CodeBlock.of("$resultSetGetter?.toShort()")
-      INT -> CodeBlock.of("$resultSetGetter.toInt()")
-      INT.copy(nullable = true) -> CodeBlock.of("$resultSetGetter?.toInt()")
-      BOOLEAN -> CodeBlock.of("$resultSetGetter == 1L")
-      BOOLEAN.copy(nullable = true) -> CodeBlock.of("$resultSetGetter?.let { it == 1L }")
-      else -> resultSetGetter
+    cursorGetter = when (javaType) {
+      FLOAT -> CodeBlock.of("$cursorGetter.toFloat()")
+      FLOAT.copy(nullable = true) -> CodeBlock.of("$cursorGetter?.toFloat()")
+      BYTE -> CodeBlock.of("$cursorGetter.toByte()")
+      BYTE.copy(nullable = true) -> CodeBlock.of("$cursorGetter?.toByte()")
+      SHORT -> CodeBlock.of("$cursorGetter.toShort()")
+      SHORT.copy(nullable = true) -> CodeBlock.of("$cursorGetter?.toShort()")
+      INT -> CodeBlock.of("$cursorGetter.toInt()")
+      INT.copy(nullable = true) -> CodeBlock.of("$cursorGetter?.toInt()")
+      BOOLEAN -> CodeBlock.of("$cursorGetter == 1L")
+      BOOLEAN.copy(nullable = true) -> CodeBlock.of("$cursorGetter?.let { it == 1L }")
+      else -> cursorGetter
     }
 
     column?.adapter()?.let { adapter ->
       val adapterName = PsiTreeUtil.getParentOfType(column, Queryable::class.java)!!.tableExposed().adapterName
-      resultSetGetter = if (javaType.isNullable) {
-        CodeBlock.of("%L?.let($CUSTOM_DATABASE_NAME.$adapterName.%N::decode)", resultSetGetter, adapter)
+      cursorGetter = if (javaType.isNullable) {
+        CodeBlock.of("%L?.let($CUSTOM_DATABASE_NAME.$adapterName.%N::decode)", cursorGetter, adapter)
       } else {
-        CodeBlock.of("$CUSTOM_DATABASE_NAME.$adapterName.%N.decode(%L)", adapter, resultSetGetter)
+        CodeBlock.of("$CUSTOM_DATABASE_NAME.$adapterName.%N.decode(%L)", adapter, cursorGetter)
       }
     }
 
-    return resultSetGetter
+    return cursorGetter
   }
 
   enum class SqliteType(val javaType: TypeName) {
@@ -161,7 +161,7 @@ internal data class IntermediateType(
           .build()
     }
 
-    fun resultSetGetter(columnIndex: Int): CodeBlock {
+    fun cursorGetter(columnIndex: Int): CodeBlock {
       return CodeBlock.of(when (this) {
         NULL -> "null"
         INTEGER -> "$CURSOR_NAME.getLong($columnIndex)"


### PR DESCRIPTION
`resultSet` is a bit misleading as the function generates code for `cursor` getters, those of which may or may not be backed by a `ResultSet`.