### PR TITLE
Fix incorrect requested types to marshal in ColumnAdapter's

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/BindableQuery.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/BindableQuery.kt
@@ -23,9 +23,9 @@ import com.alecstrong.sql.psi.core.psi.SqlInsertStmt
 import com.alecstrong.sql.psi.core.psi.SqlTypes
 import com.intellij.psi.PsiElement
 import com.squareup.sqldelight.core.compiler.SqlDelightCompiler.allocateName
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType.ARGUMENT
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType.NULL
 import com.squareup.sqldelight.core.lang.IntermediateType
-import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.ARGUMENT
-import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.NULL
 import com.squareup.sqldelight.core.lang.acceptsTableInterface
 import com.squareup.sqldelight.core.lang.util.argumentType
 import com.squareup.sqldelight.core.lang.util.childOfType

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/BindableQuery.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/BindableQuery.kt
@@ -141,11 +141,11 @@ abstract class BindableQuery(
       // If we currently have a NULL type for this argument but encounter a different type later,
       // then the new type must be nullable.
       // i.e. WHERE (:foo IS NULL OR data = :foo)
-      current.type.sqliteType == NULL -> bindArg.argumentType()
+      current.type.dialectType == NULL -> bindArg.argumentType()
       // If we'd previously assigned a type to this argument other than NULL, and later encounter NULL,
       // we should update the existing type to be nullable.
       // i.e. WHERE (data = :foo OR :foo IS NULL)
-      bindArg.argumentType().sqliteType == NULL && current.type.sqliteType != NULL -> current.type
+      bindArg.argumentType().dialectType == NULL && current.type.dialectType != NULL -> current.type
       // Nothing to update
       else -> null
     }

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/NamedQuery.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/NamedQuery.kt
@@ -129,34 +129,34 @@ data class NamedQuery(
 
   private fun superType(typeOne: IntermediateType, typeTwo: IntermediateType): IntermediateType {
     // Arguments types always take the other type.
-    if (typeOne.sqliteType == ARGUMENT) {
+    if (typeOne.dialectType == ARGUMENT) {
       return typeTwo.copy(name = typeOne.name)
-    } else if (typeTwo.sqliteType == ARGUMENT) {
+    } else if (typeTwo.dialectType == ARGUMENT) {
       return typeOne
     }
 
     // Nullable types take nullable version of the other type.
-    if (typeOne.sqliteType == NULL) {
+    if (typeOne.dialectType == NULL) {
       return typeTwo.asNullable().copy(name = typeOne.name)
-    } else if (typeTwo.sqliteType == NULL) {
+    } else if (typeTwo.dialectType == NULL) {
       return typeOne.asNullable()
     }
 
     val nullable = typeOne.javaType.isNullable || typeTwo.javaType.isNullable
 
-    if (typeOne.sqliteType != typeTwo.sqliteType) {
+    if (typeOne.dialectType != typeTwo.dialectType) {
       // Incompatible sqlite types. Prefer the type which can contain the other.
       // NULL < INTEGER < REAL < TEXT < BLOB
       val type = listOf(NULL, INTEGER, REAL, TEXT, BLOB)
-          .last { it == typeOne.sqliteType || it == typeTwo.sqliteType }
-      return IntermediateType(sqliteType = type, name = typeOne.name).nullableIf(nullable)
+          .last { it == typeOne.dialectType || it == typeTwo.dialectType }
+      return IntermediateType(dialectType = type, name = typeOne.name).nullableIf(nullable)
     }
 
     if (typeOne.column !== typeTwo.column &&
         typeOne.cursorGetter(0) != typeTwo.cursorGetter(0) &&
         typeOne.column != null && typeTwo.column != null) {
       // Incompatible adapters. Revert to unadapted java type.
-      return IntermediateType(sqliteType = typeOne.sqliteType, name = typeOne.name).nullableIf(nullable)
+      return IntermediateType(dialectType = typeOne.dialectType, name = typeOne.name).nullableIf(nullable)
     }
 
     return typeOne.nullableIf(nullable)

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/NamedQuery.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/NamedQuery.kt
@@ -25,20 +25,19 @@ import com.intellij.psi.PsiElement
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.sqldelight.core.compiler.SqlDelightCompiler.allocateName
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType.ARGUMENT
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType.BLOB
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType.INTEGER
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType.NULL
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType.REAL
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType.TEXT
 import com.squareup.sqldelight.core.lang.CUSTOM_DATABASE_NAME
 import com.squareup.sqldelight.core.lang.IntermediateType
-import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.ARGUMENT
-import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.BLOB
-import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.INTEGER
-import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.NULL
-import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.REAL
-import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.TEXT
 import com.squareup.sqldelight.core.lang.queriesName
 import com.squareup.sqldelight.core.lang.util.name
 import com.squareup.sqldelight.core.lang.util.sqFile
 import com.squareup.sqldelight.core.lang.util.tablesObserved
 import com.squareup.sqldelight.core.lang.util.type
-import java.util.LinkedHashSet
 
 data class NamedQuery(
   val name: String,

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/dialect/api/DialectType.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/dialect/api/DialectType.kt
@@ -1,0 +1,13 @@
+package com.squareup.sqldelight.core.dialect.api
+
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.TypeName
+
+internal interface DialectType {
+
+  val javaType: TypeName
+
+  fun prepareStatementBinder(columnIndex: String, value: CodeBlock): CodeBlock
+
+  fun cursorGetter(columnIndex: Int): CodeBlock
+}

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/dialect/hsql/HsqlType.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/dialect/hsql/HsqlType.kt
@@ -1,0 +1,34 @@
+package com.squareup.sqldelight.core.dialect.hsql
+
+import com.squareup.kotlinpoet.BOOLEAN
+import com.squareup.kotlinpoet.BYTE
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.INT
+import com.squareup.kotlinpoet.LONG
+import com.squareup.kotlinpoet.SHORT
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.sqldelight.core.dialect.api.DialectType
+import com.squareup.sqldelight.core.lang.CURSOR_NAME
+
+internal enum class HsqlType(override val javaType: TypeName) : DialectType {
+  TINY_INT(BYTE),
+  SMALL_INT(SHORT),
+  INTEGER(INT),
+  BIG_INT(LONG),
+  BOOL(BOOLEAN);
+
+  override fun prepareStatementBinder(columnIndex: String, value: CodeBlock): CodeBlock {
+    return CodeBlock.builder()
+      .add(when (this) {
+        TINY_INT, SMALL_INT, INTEGER, BIG_INT, BOOL -> "bindLong"
+      })
+      .add("($columnIndex, %L)\n", value)
+      .build()
+  }
+
+  override fun cursorGetter(columnIndex: Int): CodeBlock {
+    return CodeBlock.of(when (this) {
+      TINY_INT, SMALL_INT, INTEGER, BIG_INT, BOOL -> "$CURSOR_NAME.getLong($columnIndex)"
+    })
+  }
+}

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/dialect/mysql/MySqlType.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/dialect/mysql/MySqlType.kt
@@ -1,0 +1,35 @@
+package com.squareup.sqldelight.core.dialect.mysql
+
+import com.squareup.kotlinpoet.BOOLEAN
+import com.squareup.kotlinpoet.BYTE
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.INT
+import com.squareup.kotlinpoet.LONG
+import com.squareup.kotlinpoet.SHORT
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.sqldelight.core.dialect.api.DialectType
+import com.squareup.sqldelight.core.lang.CURSOR_NAME
+
+internal enum class MySqlType(override val javaType: TypeName) : DialectType {
+  TINY_INT(BYTE),
+  TINY_INT_BOOL(BOOLEAN),
+  SMALL_INT(SHORT),
+  INTEGER(INT),
+  BIG_INT(LONG),
+  BIT(BOOLEAN);
+
+  override fun prepareStatementBinder(columnIndex: String, value: CodeBlock): CodeBlock {
+    return CodeBlock.builder()
+      .add(when (this) {
+        TINY_INT, TINY_INT_BOOL, SMALL_INT, INTEGER, BIG_INT, BIT -> "bindLong"
+      })
+      .add("($columnIndex, %L)\n", value)
+      .build()
+  }
+
+  override fun cursorGetter(columnIndex: Int): CodeBlock {
+    return CodeBlock.of(when (this) {
+      TINY_INT, TINY_INT_BOOL, SMALL_INT, INTEGER, BIG_INT, BIT -> "$CURSOR_NAME.getLong($columnIndex)"
+    })
+  }
+}

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/dialect/postgresql/PostgreSqlType.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/dialect/postgresql/PostgreSqlType.kt
@@ -1,0 +1,30 @@
+package com.squareup.sqldelight.core.dialect.postgresql
+
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.INT
+import com.squareup.kotlinpoet.LONG
+import com.squareup.kotlinpoet.SHORT
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.sqldelight.core.dialect.api.DialectType
+import com.squareup.sqldelight.core.lang.CURSOR_NAME
+
+internal enum class PostgreSqlType(override val javaType: TypeName) : DialectType {
+  SMALL_INT(SHORT),
+  INTEGER(INT),
+  BIG_INT(LONG);
+
+  override fun prepareStatementBinder(columnIndex: String, value: CodeBlock): CodeBlock {
+    return CodeBlock.builder()
+      .add(when (this) {
+        SMALL_INT, INTEGER, BIG_INT -> "bindLong"
+      })
+      .add("($columnIndex, %L)\n", value)
+      .build()
+  }
+
+  override fun cursorGetter(columnIndex: Int): CodeBlock {
+    return CodeBlock.of(when (this) {
+      SMALL_INT, INTEGER, BIG_INT -> "$CURSOR_NAME.getLong($columnIndex)"
+    })
+  }
+}

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/dialect/sqlite/SqliteType.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/dialect/sqlite/SqliteType.kt
@@ -1,0 +1,44 @@
+package com.squareup.sqldelight.core.dialect.sqlite
+
+import com.squareup.kotlinpoet.ANY
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.DOUBLE
+import com.squareup.kotlinpoet.LONG
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.asClassName
+import com.squareup.kotlinpoet.asTypeName
+import com.squareup.sqldelight.core.dialect.api.DialectType
+import com.squareup.sqldelight.core.lang.CURSOR_NAME
+
+internal enum class SqliteType(override val javaType: TypeName) : DialectType {
+  ARGUMENT(ANY.copy(nullable = true)),
+  NULL(Nothing::class.asClassName().copy(nullable = true)),
+  INTEGER(LONG),
+  REAL(DOUBLE),
+  TEXT(String::class.asTypeName()),
+  BLOB(ByteArray::class.asTypeName());
+
+  override fun prepareStatementBinder(columnIndex: String, value: CodeBlock): CodeBlock {
+    return CodeBlock.builder()
+      .add(when (this) {
+        INTEGER -> "bindLong"
+        REAL -> "bindDouble"
+        TEXT -> "bindString"
+        BLOB -> "bindBytes"
+        else -> throw IllegalArgumentException("Cannot bind unknown types or null")
+      })
+      .add("($columnIndex, %L)\n", value)
+      .build()
+  }
+
+  override fun cursorGetter(columnIndex: Int): CodeBlock {
+    return CodeBlock.of(when (this) {
+      NULL -> "null"
+      INTEGER -> "$CURSOR_NAME.getLong($columnIndex)"
+      REAL -> "$CURSOR_NAME.getDouble($columnIndex)"
+      TEXT -> "$CURSOR_NAME.getString($columnIndex)"
+      BLOB -> "$CURSOR_NAME.getBytes($columnIndex)"
+      ARGUMENT -> throw IllegalArgumentException("Cannot retrieve argument from cursor")
+    })
+  }
+}

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
@@ -40,8 +40,8 @@ import com.squareup.sqldelight.core.lang.util.isArrayParameter
  * type.
  */
 internal data class IntermediateType(
-  val sqliteType: SqliteType,
-  val javaType: TypeName = sqliteType.javaType,
+  val dialectType: DialectType,
+  val javaType: TypeName = dialectType.javaType,
   /**
    * The column definition this type is sourced from, or null if there is none.
    */
@@ -92,23 +92,23 @@ internal data class IntermediateType(
       INT -> CodeBlock.of("$name.toLong()")
       BOOLEAN -> CodeBlock.of("if ($name) 1L else 0L")
       else -> {
-        return sqliteType.prepareStatementBinder(columnIndex, CodeBlock.of(this.name))
+        return dialectType.prepareStatementBinder(columnIndex, CodeBlock.of(this.name))
       }
     }
 
     if (javaType.isNullable) {
-      return sqliteType.prepareStatementBinder(columnIndex, CodeBlock.builder()
+      return dialectType.prepareStatementBinder(columnIndex, CodeBlock.builder()
           .add("${this.name}?.let { ")
           .add(value)
           .add(" }")
           .build())
     }
 
-    return sqliteType.prepareStatementBinder(columnIndex, value)
+    return dialectType.prepareStatementBinder(columnIndex, value)
   }
 
   fun cursorGetter(columnIndex: Int): CodeBlock {
-    var cursorGetter = sqliteType.cursorGetter(columnIndex)
+    var cursorGetter = dialectType.cursorGetter(columnIndex)
 
     if (!javaType.isNullable) {
       cursorGetter = CodeBlock.of("$cursorGetter!!")
@@ -140,7 +140,16 @@ internal data class IntermediateType(
     return cursorGetter
   }
 
-  enum class SqliteType(val javaType: TypeName) {
+  interface DialectType {
+
+    val javaType: TypeName
+
+    fun prepareStatementBinder(columnIndex: String, value: CodeBlock): CodeBlock
+
+    fun cursorGetter(columnIndex: Int): CodeBlock
+  }
+
+  enum class SqliteType(override val javaType: TypeName) : DialectType {
     ARGUMENT(ANY.copy(nullable = true)),
     NULL(Nothing::class.asClassName().copy(nullable = true)),
     INTEGER(LONG),
@@ -148,7 +157,7 @@ internal data class IntermediateType(
     TEXT(String::class.asTypeName()),
     BLOB(ByteArray::class.asTypeName());
 
-    fun prepareStatementBinder(columnIndex: String, value: CodeBlock): CodeBlock {
+    override fun prepareStatementBinder(columnIndex: String, value: CodeBlock): CodeBlock {
       return CodeBlock.builder()
           .add(when (this) {
             INTEGER -> "bindLong"
@@ -161,7 +170,7 @@ internal data class IntermediateType(
           .build()
     }
 
-    fun cursorGetter(columnIndex: Int): CodeBlock {
+    override fun cursorGetter(columnIndex: Int): CodeBlock {
       return CodeBlock.of(when (this) {
         NULL -> "null"
         INTEGER -> "$CURSOR_NAME.getLong($columnIndex)"
@@ -169,6 +178,74 @@ internal data class IntermediateType(
         TEXT -> "$CURSOR_NAME.getString($columnIndex)"
         BLOB -> "$CURSOR_NAME.getBytes($columnIndex)"
         ARGUMENT -> throw IllegalArgumentException("Cannot retrieve argument from cursor")
+      })
+    }
+  }
+
+  enum class MySqlType(override val javaType: TypeName) : DialectType {
+    TINY_INT(BYTE),
+    TINY_INT_BOOL(BOOLEAN),
+    SMALL_INT(SHORT),
+    INTEGER(INT),
+    BIG_INT(LONG),
+    BIT(BOOLEAN);
+
+    override fun prepareStatementBinder(columnIndex: String, value: CodeBlock): CodeBlock {
+      return CodeBlock.builder()
+        .add(when (this) {
+          TINY_INT, TINY_INT_BOOL, SMALL_INT, INTEGER, BIG_INT, BIT -> "bindLong"
+        })
+        .add("($columnIndex, %L)\n", value)
+        .build()
+    }
+
+    override fun cursorGetter(columnIndex: Int): CodeBlock {
+      return CodeBlock.of(when (this) {
+        TINY_INT, TINY_INT_BOOL, SMALL_INT, INTEGER, BIG_INT, BIT -> "$CURSOR_NAME.getLong($columnIndex)"
+      })
+    }
+  }
+
+  enum class PostgreSqlType(override val javaType: TypeName) : DialectType {
+    SMALL_INT(SHORT),
+    INTEGER(INT),
+    BIG_INT(LONG);
+
+    override fun prepareStatementBinder(columnIndex: String, value: CodeBlock): CodeBlock {
+      return CodeBlock.builder()
+          .add(when (this) {
+            SMALL_INT, INTEGER, BIG_INT -> "bindLong"
+          })
+          .add("($columnIndex, %L)\n", value)
+          .build()
+    }
+
+    override fun cursorGetter(columnIndex: Int): CodeBlock {
+      return CodeBlock.of(when (this) {
+        SMALL_INT, INTEGER, BIG_INT -> "$CURSOR_NAME.getLong($columnIndex)"
+      })
+    }
+  }
+
+  enum class HsqlType(override val javaType: TypeName) : DialectType {
+    TINY_INT(BYTE),
+    SMALL_INT(SHORT),
+    INTEGER(INT),
+    BIG_INT(LONG),
+    BOOL(BOOLEAN);
+
+    override fun prepareStatementBinder(columnIndex: String, value: CodeBlock): CodeBlock {
+      return CodeBlock.builder()
+        .add(when (this) {
+          TINY_INT, SMALL_INT, INTEGER, BIG_INT, BOOL -> "bindLong"
+        })
+        .add("($columnIndex, %L)\n", value)
+        .build()
+    }
+
+    override fun cursorGetter(columnIndex: Int): CodeBlock {
+      return CodeBlock.of(when (this) {
+        TINY_INT, SMALL_INT, INTEGER, BIG_INT, BOOL -> "$CURSOR_NAME.getLong($columnIndex)"
       })
     }
   }

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/ColumnDefMixin.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/ColumnDefMixin.kt
@@ -74,7 +74,7 @@ internal abstract class ColumnDefMixin(
       return PropertySpec
           .builder(
               name = "${allocateName(columnName)}Adapter",
-              type = columnAdapterType.parameterizedBy(customType, typeName.type().sqliteType.javaType)
+              type = columnAdapterType.parameterizedBy(customType, typeName.type().dialectType.javaType)
           )
           .build()
     }

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/FunctionExprMixin.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/FunctionExprMixin.kt
@@ -6,6 +6,7 @@ import com.alecstrong.sql.psi.core.psi.SqlExpr
 import com.alecstrong.sql.psi.core.psi.SqlResultColumn
 import com.alecstrong.sql.psi.core.psi.impl.SqlFunctionExprImpl
 import com.intellij.lang.ASTNode
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType
 import com.squareup.sqldelight.core.lang.IntermediateType
 import com.squareup.sqldelight.core.lang.SqlDelightFile
 import com.squareup.sqldelight.core.lang.util.encapsulatingType
@@ -14,7 +15,7 @@ import com.squareup.sqldelight.core.lang.util.type
 internal class FunctionExprMixin(node: ASTNode?) : SqlFunctionExprImpl(node) {
   fun argumentType(expr: SqlExpr) = when (functionName.text.toLowerCase()) {
     "instr" -> when (expr) {
-      exprList.getOrNull(1) -> IntermediateType(IntermediateType.SqliteType.TEXT)
+      exprList.getOrNull(1) -> IntermediateType(SqliteType.TEXT)
       else -> functionType()
     }
     else -> functionType()
@@ -24,9 +25,9 @@ internal class FunctionExprMixin(node: ASTNode?) : SqlFunctionExprImpl(node) {
     "round" -> {
       // Single arg round function returns an int. Otherwise real.
       if (exprList.size == 1) {
-        IntermediateType(IntermediateType.SqliteType.INTEGER).nullableIf(exprList[0].type().javaType.isNullable)
+        IntermediateType(SqliteType.INTEGER).nullableIf(exprList[0].type().javaType.isNullable)
       } else {
-        IntermediateType(IntermediateType.SqliteType.REAL).nullableIf(exprList.any { it.type().javaType.isNullable })
+        IntermediateType(SqliteType.REAL).nullableIf(exprList.any { it.type().javaType.isNullable })
       }
     }
 
@@ -40,35 +41,35 @@ internal class FunctionExprMixin(node: ASTNode?) : SqlFunctionExprImpl(node) {
      */
     "sum" -> {
       val type = exprList[0].type()
-      if (type.dialectType == IntermediateType.SqliteType.INTEGER && !type.javaType.isNullable) {
+      if (type.dialectType == SqliteType.INTEGER && !type.javaType.isNullable) {
         type.asNullable()
       } else {
-        IntermediateType(IntermediateType.SqliteType.REAL).asNullable()
+        IntermediateType(SqliteType.REAL).asNullable()
       }
     }
 
     "lower", "ltrim", "replace", "rtrim", "substr", "trim", "upper", "group_concat" -> {
-      IntermediateType(IntermediateType.SqliteType.TEXT).nullableIf(exprList[0].type().javaType.isNullable)
+      IntermediateType(SqliteType.TEXT).nullableIf(exprList[0].type().javaType.isNullable)
     }
 
     "date", "time", "char", "hex", "quote", "soundex", "typeof" -> {
-      IntermediateType(IntermediateType.SqliteType.TEXT)
+      IntermediateType(SqliteType.TEXT)
     }
 
     "random", "count" -> {
-      IntermediateType(IntermediateType.SqliteType.INTEGER)
+      IntermediateType(SqliteType.INTEGER)
     }
 
     "instr", "length" -> {
-      IntermediateType(IntermediateType.SqliteType.INTEGER).nullableIf(exprList.any { it.type().javaType.isNullable })
+      IntermediateType(SqliteType.INTEGER).nullableIf(exprList.any { it.type().javaType.isNullable })
     }
 
-    "avg" -> IntermediateType(IntermediateType.SqliteType.REAL).asNullable()
+    "avg" -> IntermediateType(SqliteType.REAL).asNullable()
     "abs" -> exprList[0].type()
-    "coalesce", "ifnull" -> encapsulatingType(exprList, IntermediateType.SqliteType.INTEGER, IntermediateType.SqliteType.REAL, IntermediateType.SqliteType.TEXT, IntermediateType.SqliteType.BLOB)
+    "coalesce", "ifnull" -> encapsulatingType(exprList, SqliteType.INTEGER, SqliteType.REAL, SqliteType.TEXT, SqliteType.BLOB)
     "nullif" -> exprList[0].type().asNullable()
-    "max" -> encapsulatingType(exprList, IntermediateType.SqliteType.INTEGER, IntermediateType.SqliteType.REAL, IntermediateType.SqliteType.TEXT, IntermediateType.SqliteType.BLOB).asNullable()
-    "min" -> encapsulatingType(exprList, IntermediateType.SqliteType.BLOB, IntermediateType.SqliteType.TEXT, IntermediateType.SqliteType.INTEGER, IntermediateType.SqliteType.REAL).asNullable()
+    "max" -> encapsulatingType(exprList, SqliteType.INTEGER, SqliteType.REAL, SqliteType.TEXT, SqliteType.BLOB).asNullable()
+    "min" -> encapsulatingType(exprList, SqliteType.BLOB, SqliteType.TEXT, SqliteType.INTEGER, SqliteType.REAL).asNullable()
     else -> when ((containingFile as SqlDelightFile).dialect) {
       DialectPreset.SQLITE_3_18, DialectPreset.SQLITE_3_24, DialectPreset.SQLITE_3_25 -> sqliteFunctionType()
       DialectPreset.MYSQL -> mySqlFunctionType()
@@ -78,40 +79,36 @@ internal class FunctionExprMixin(node: ASTNode?) : SqlFunctionExprImpl(node) {
   }
 
   private fun sqliteFunctionType() = when (functionName.text.toLowerCase()) {
-    "printf" -> IntermediateType(IntermediateType.SqliteType.TEXT).nullableIf(exprList[0].type().javaType.isNullable)
+    "printf" -> IntermediateType(SqliteType.TEXT).nullableIf(exprList[0].type().javaType.isNullable)
     "datetime", "julianday", "strftime", "sqlite_compileoption_get", "sqlite_source_id", "sqlite_version" -> {
-      IntermediateType(IntermediateType.SqliteType.TEXT)
+      IntermediateType(SqliteType.TEXT)
     }
     "changes", "last_insert_rowid", "sqlite_compileoption_used", "total_changes" -> {
-      IntermediateType(IntermediateType.SqliteType.INTEGER)
+      IntermediateType(SqliteType.INTEGER)
     }
     "unicode" -> {
-      IntermediateType(IntermediateType.SqliteType.INTEGER).nullableIf(exprList.any { it.type().javaType.isNullable })
+      IntermediateType(SqliteType.INTEGER).nullableIf(exprList.any { it.type().javaType.isNullable })
     }
-    "randomblob", "zeroblob" -> IntermediateType(IntermediateType.SqliteType.BLOB)
-    "total", "bm25" -> IntermediateType(IntermediateType.SqliteType.REAL)
+    "randomblob", "zeroblob" -> IntermediateType(SqliteType.BLOB)
+    "total", "bm25" -> IntermediateType(SqliteType.REAL)
     "likelihood", "likely", "unlikely" -> exprList[0].type()
-    "highlight", "snippet" -> IntermediateType(IntermediateType.SqliteType.TEXT).asNullable()
+    "highlight", "snippet" -> IntermediateType(SqliteType.TEXT).asNullable()
     else -> null
   }
 
   private fun mySqlFunctionType() = when (functionName.text.toLowerCase()) {
-    "greatest" -> encapsulatingType(exprList, IntermediateType.SqliteType.INTEGER,
-        IntermediateType.SqliteType.REAL, IntermediateType.SqliteType.TEXT,
-        IntermediateType.SqliteType.BLOB)
-    "concat" -> encapsulatingType(exprList, IntermediateType.SqliteType.TEXT)
-    "last_insert_id" -> IntermediateType(IntermediateType.SqliteType.INTEGER)
-    "month", "year", "minute" -> IntermediateType(IntermediateType.SqliteType.INTEGER)
-    "sin", "cos", "tan" -> IntermediateType(IntermediateType.SqliteType.REAL)
+    "greatest" -> encapsulatingType(exprList, SqliteType.INTEGER, SqliteType.REAL, SqliteType.TEXT, SqliteType.BLOB)
+    "concat" -> encapsulatingType(exprList, SqliteType.TEXT)
+    "last_insert_id" -> IntermediateType(SqliteType.INTEGER)
+    "month", "year", "minute" -> IntermediateType(SqliteType.INTEGER)
+    "sin", "cos", "tan" -> IntermediateType(SqliteType.REAL)
     else -> null
   }
 
   private fun postgreSqlFunctionType() = when (functionName.text.toLowerCase()) {
-    "greatest" -> encapsulatingType(exprList, IntermediateType.SqliteType.INTEGER,
-        IntermediateType.SqliteType.REAL, IntermediateType.SqliteType.TEXT,
-        IntermediateType.SqliteType.BLOB)
-    "concat" -> encapsulatingType(exprList, IntermediateType.SqliteType.TEXT)
-    "substring" -> IntermediateType(IntermediateType.SqliteType.TEXT).nullableIf(exprList[0].type().javaType.isNullable)
+    "greatest" -> encapsulatingType(exprList, SqliteType.INTEGER, SqliteType.REAL, SqliteType.TEXT, SqliteType.BLOB)
+    "concat" -> encapsulatingType(exprList, SqliteType.TEXT)
+    "substring" -> IntermediateType(SqliteType.TEXT).nullableIf(exprList[0].type().javaType.isNullable)
     else -> null
   }
 

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/FunctionExprMixin.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/FunctionExprMixin.kt
@@ -40,7 +40,7 @@ internal class FunctionExprMixin(node: ASTNode?) : SqlFunctionExprImpl(node) {
      */
     "sum" -> {
       val type = exprList[0].type()
-      if (type.sqliteType == IntermediateType.SqliteType.INTEGER && !type.javaType.isNullable) {
+      if (type.dialectType == IntermediateType.SqliteType.INTEGER && !type.javaType.isNullable) {
         type.asNullable()
       } else {
         IntermediateType(IntermediateType.SqliteType.REAL).asNullable()

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/sqlTypeName.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/sqlTypeName.kt
@@ -5,11 +5,6 @@ import com.alecstrong.sql.psi.core.mysql.psi.MySqlTypeName
 import com.alecstrong.sql.psi.core.postgresql.psi.PostgreSqlTypeName
 import com.alecstrong.sql.psi.core.psi.SqlTypeName
 import com.alecstrong.sql.psi.core.sqlite_3_18.psi.TypeName as SqliteTypeName
-import com.squareup.kotlinpoet.BOOLEAN
-import com.squareup.kotlinpoet.BYTE
-import com.squareup.kotlinpoet.INT
-import com.squareup.kotlinpoet.LONG
-import com.squareup.kotlinpoet.SHORT
 import com.squareup.sqldelight.core.lang.IntermediateType
 
 internal fun SqlTypeName.type(): IntermediateType {
@@ -38,34 +33,34 @@ private fun MySqlTypeName.type(): IntermediateType {
     binaryDataType != null -> IntermediateType(IntermediateType.SqliteType.BLOB)
     dateDataType != null -> IntermediateType(IntermediateType.SqliteType.TEXT)
     tinyIntDataType != null -> if (tinyIntDataType!!.text == "BOOLEAN") {
-      IntermediateType(IntermediateType.SqliteType.INTEGER, BOOLEAN)
+      IntermediateType(IntermediateType.MySqlType.TINY_INT_BOOL)
     } else {
-      IntermediateType(IntermediateType.SqliteType.INTEGER, BYTE)
+      IntermediateType(IntermediateType.MySqlType.TINY_INT)
     }
-    smallIntDataType != null -> IntermediateType(IntermediateType.SqliteType.INTEGER, SHORT)
-    mediumIntDataType != null -> IntermediateType(IntermediateType.SqliteType.INTEGER, INT)
-    intDataType != null -> IntermediateType(IntermediateType.SqliteType.INTEGER, INT)
-    bigIntDataType != null -> IntermediateType(IntermediateType.SqliteType.INTEGER, LONG)
+    smallIntDataType != null -> IntermediateType(IntermediateType.MySqlType.SMALL_INT)
+    mediumIntDataType != null -> IntermediateType(IntermediateType.MySqlType.INTEGER)
+    intDataType != null -> IntermediateType(IntermediateType.MySqlType.INTEGER)
+    bigIntDataType != null -> IntermediateType(IntermediateType.MySqlType.BIG_INT)
     fixedPointDataType != null -> IntermediateType(IntermediateType.SqliteType.INTEGER)
     jsonDataType != null -> IntermediateType(IntermediateType.SqliteType.TEXT)
     enumSetType != null -> IntermediateType(IntermediateType.SqliteType.TEXT)
     characterType != null -> IntermediateType(IntermediateType.SqliteType.TEXT)
-    bitDataType != null -> IntermediateType(IntermediateType.SqliteType.INTEGER, BOOLEAN)
+    bitDataType != null -> IntermediateType(IntermediateType.MySqlType.BIT)
     else -> throw IllegalArgumentException("Unknown kotlin type for sql type ${this.text}")
   }
 }
 
 private fun PostgreSqlTypeName.type(): IntermediateType {
   return when {
-    smallIntDataType != null -> IntermediateType(IntermediateType.SqliteType.INTEGER, SHORT)
-    intDataType != null -> IntermediateType(IntermediateType.SqliteType.INTEGER, INT)
-    bigIntDataType != null -> IntermediateType(IntermediateType.SqliteType.INTEGER, LONG)
+    smallIntDataType != null -> IntermediateType(IntermediateType.PostgreSqlType.SMALL_INT)
+    intDataType != null -> IntermediateType(IntermediateType.PostgreSqlType.INTEGER)
+    bigIntDataType != null -> IntermediateType(IntermediateType.PostgreSqlType.BIG_INT)
     numericDataType != null -> IntermediateType(IntermediateType.SqliteType.INTEGER)
     approximateNumericDataType != null -> IntermediateType(IntermediateType.SqliteType.REAL)
     stringDataType != null -> IntermediateType(IntermediateType.SqliteType.TEXT)
-    smallSerialDataType != null -> IntermediateType(IntermediateType.SqliteType.INTEGER, SHORT)
-    serialDataType != null -> IntermediateType(IntermediateType.SqliteType.INTEGER, INT)
-    bigSerialDataType != null -> IntermediateType(IntermediateType.SqliteType.INTEGER, LONG)
+    smallSerialDataType != null -> IntermediateType(IntermediateType.PostgreSqlType.SMALL_INT)
+    serialDataType != null -> IntermediateType(IntermediateType.PostgreSqlType.INTEGER)
+    bigSerialDataType != null -> IntermediateType(IntermediateType.PostgreSqlType.BIG_INT)
     dateDataType != null -> IntermediateType(IntermediateType.SqliteType.TEXT)
     jsonDataType != null -> IntermediateType(IntermediateType.SqliteType.TEXT)
     else -> throw IllegalArgumentException("Unknown kotlin type for sql type ${this.text}")
@@ -77,13 +72,13 @@ private fun HsqlTypeName.type(): IntermediateType {
     approximateNumericDataType != null -> IntermediateType(IntermediateType.SqliteType.REAL)
     binaryStringDataType != null -> IntermediateType(IntermediateType.SqliteType.BLOB)
     dateDataType != null -> IntermediateType(IntermediateType.SqliteType.TEXT)
-    tinyIntDataType != null -> IntermediateType(IntermediateType.SqliteType.INTEGER, BYTE)
-    smallIntDataType != null -> IntermediateType(IntermediateType.SqliteType.INTEGER, SHORT)
-    intDataType != null -> IntermediateType(IntermediateType.SqliteType.INTEGER, INT)
-    bigIntDataType != null -> IntermediateType(IntermediateType.SqliteType.INTEGER, LONG)
+    tinyIntDataType != null -> IntermediateType(IntermediateType.HsqlType.TINY_INT)
+    smallIntDataType != null -> IntermediateType(IntermediateType.HsqlType.SMALL_INT)
+    intDataType != null -> IntermediateType(IntermediateType.HsqlType.INTEGER)
+    bigIntDataType != null -> IntermediateType(IntermediateType.HsqlType.BIG_INT)
     fixedPointDataType != null -> IntermediateType(IntermediateType.SqliteType.INTEGER)
     characterStringDataType != null -> IntermediateType(IntermediateType.SqliteType.TEXT)
-    booleanDataType != null -> IntermediateType(IntermediateType.SqliteType.INTEGER, BOOLEAN)
+    booleanDataType != null -> IntermediateType(IntermediateType.HsqlType.BOOL)
     bitStringDataType != null -> IntermediateType(IntermediateType.SqliteType.BLOB)
     intervalDataType != null -> IntermediateType(IntermediateType.SqliteType.BLOB)
     else -> throw IllegalArgumentException("Unknown kotlin type for sql type ${this.text}")

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/sqlTypeName.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/sqlTypeName.kt
@@ -5,6 +5,10 @@ import com.alecstrong.sql.psi.core.mysql.psi.MySqlTypeName
 import com.alecstrong.sql.psi.core.postgresql.psi.PostgreSqlTypeName
 import com.alecstrong.sql.psi.core.psi.SqlTypeName
 import com.alecstrong.sql.psi.core.sqlite_3_18.psi.TypeName as SqliteTypeName
+import com.squareup.sqldelight.core.dialect.hsql.HsqlType
+import com.squareup.sqldelight.core.dialect.mysql.MySqlType
+import com.squareup.sqldelight.core.dialect.postgresql.PostgreSqlType
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType
 import com.squareup.sqldelight.core.lang.IntermediateType
 
 internal fun SqlTypeName.type(): IntermediateType {
@@ -19,68 +23,68 @@ internal fun SqlTypeName.type(): IntermediateType {
 
 private fun SqliteTypeName.type(): IntermediateType {
   return when (text) {
-    "TEXT" -> IntermediateType(IntermediateType.SqliteType.TEXT)
-    "BLOB" -> IntermediateType(IntermediateType.SqliteType.BLOB)
-    "INTEGER" -> IntermediateType(IntermediateType.SqliteType.INTEGER)
-    "REAL" -> IntermediateType(IntermediateType.SqliteType.REAL)
+    "TEXT" -> IntermediateType(SqliteType.TEXT)
+    "BLOB" -> IntermediateType(SqliteType.BLOB)
+    "INTEGER" -> IntermediateType(SqliteType.INTEGER)
+    "REAL" -> IntermediateType(SqliteType.REAL)
     else -> throw IllegalArgumentException("Unknown sql type $text")
   }
 }
 
 private fun MySqlTypeName.type(): IntermediateType {
   return when {
-    approximateNumericDataType != null -> IntermediateType(IntermediateType.SqliteType.REAL)
-    binaryDataType != null -> IntermediateType(IntermediateType.SqliteType.BLOB)
-    dateDataType != null -> IntermediateType(IntermediateType.SqliteType.TEXT)
+    approximateNumericDataType != null -> IntermediateType(SqliteType.REAL)
+    binaryDataType != null -> IntermediateType(SqliteType.BLOB)
+    dateDataType != null -> IntermediateType(SqliteType.TEXT)
     tinyIntDataType != null -> if (tinyIntDataType!!.text == "BOOLEAN") {
-      IntermediateType(IntermediateType.MySqlType.TINY_INT_BOOL)
+      IntermediateType(MySqlType.TINY_INT_BOOL)
     } else {
-      IntermediateType(IntermediateType.MySqlType.TINY_INT)
+      IntermediateType(MySqlType.TINY_INT)
     }
-    smallIntDataType != null -> IntermediateType(IntermediateType.MySqlType.SMALL_INT)
-    mediumIntDataType != null -> IntermediateType(IntermediateType.MySqlType.INTEGER)
-    intDataType != null -> IntermediateType(IntermediateType.MySqlType.INTEGER)
-    bigIntDataType != null -> IntermediateType(IntermediateType.MySqlType.BIG_INT)
-    fixedPointDataType != null -> IntermediateType(IntermediateType.SqliteType.INTEGER)
-    jsonDataType != null -> IntermediateType(IntermediateType.SqliteType.TEXT)
-    enumSetType != null -> IntermediateType(IntermediateType.SqliteType.TEXT)
-    characterType != null -> IntermediateType(IntermediateType.SqliteType.TEXT)
-    bitDataType != null -> IntermediateType(IntermediateType.MySqlType.BIT)
+    smallIntDataType != null -> IntermediateType(MySqlType.SMALL_INT)
+    mediumIntDataType != null -> IntermediateType(MySqlType.INTEGER)
+    intDataType != null -> IntermediateType(MySqlType.INTEGER)
+    bigIntDataType != null -> IntermediateType(MySqlType.BIG_INT)
+    fixedPointDataType != null -> IntermediateType(SqliteType.INTEGER)
+    jsonDataType != null -> IntermediateType(SqliteType.TEXT)
+    enumSetType != null -> IntermediateType(SqliteType.TEXT)
+    characterType != null -> IntermediateType(SqliteType.TEXT)
+    bitDataType != null -> IntermediateType(MySqlType.BIT)
     else -> throw IllegalArgumentException("Unknown kotlin type for sql type ${this.text}")
   }
 }
 
 private fun PostgreSqlTypeName.type(): IntermediateType {
   return when {
-    smallIntDataType != null -> IntermediateType(IntermediateType.PostgreSqlType.SMALL_INT)
-    intDataType != null -> IntermediateType(IntermediateType.PostgreSqlType.INTEGER)
-    bigIntDataType != null -> IntermediateType(IntermediateType.PostgreSqlType.BIG_INT)
-    numericDataType != null -> IntermediateType(IntermediateType.SqliteType.INTEGER)
-    approximateNumericDataType != null -> IntermediateType(IntermediateType.SqliteType.REAL)
-    stringDataType != null -> IntermediateType(IntermediateType.SqliteType.TEXT)
-    smallSerialDataType != null -> IntermediateType(IntermediateType.PostgreSqlType.SMALL_INT)
-    serialDataType != null -> IntermediateType(IntermediateType.PostgreSqlType.INTEGER)
-    bigSerialDataType != null -> IntermediateType(IntermediateType.PostgreSqlType.BIG_INT)
-    dateDataType != null -> IntermediateType(IntermediateType.SqliteType.TEXT)
-    jsonDataType != null -> IntermediateType(IntermediateType.SqliteType.TEXT)
+    smallIntDataType != null -> IntermediateType(PostgreSqlType.SMALL_INT)
+    intDataType != null -> IntermediateType(PostgreSqlType.INTEGER)
+    bigIntDataType != null -> IntermediateType(PostgreSqlType.BIG_INT)
+    numericDataType != null -> IntermediateType(SqliteType.INTEGER)
+    approximateNumericDataType != null -> IntermediateType(SqliteType.REAL)
+    stringDataType != null -> IntermediateType(SqliteType.TEXT)
+    smallSerialDataType != null -> IntermediateType(PostgreSqlType.SMALL_INT)
+    serialDataType != null -> IntermediateType(PostgreSqlType.INTEGER)
+    bigSerialDataType != null -> IntermediateType(PostgreSqlType.BIG_INT)
+    dateDataType != null -> IntermediateType(SqliteType.TEXT)
+    jsonDataType != null -> IntermediateType(SqliteType.TEXT)
     else -> throw IllegalArgumentException("Unknown kotlin type for sql type ${this.text}")
   }
 }
 
 private fun HsqlTypeName.type(): IntermediateType {
   return when {
-    approximateNumericDataType != null -> IntermediateType(IntermediateType.SqliteType.REAL)
-    binaryStringDataType != null -> IntermediateType(IntermediateType.SqliteType.BLOB)
-    dateDataType != null -> IntermediateType(IntermediateType.SqliteType.TEXT)
-    tinyIntDataType != null -> IntermediateType(IntermediateType.HsqlType.TINY_INT)
-    smallIntDataType != null -> IntermediateType(IntermediateType.HsqlType.SMALL_INT)
-    intDataType != null -> IntermediateType(IntermediateType.HsqlType.INTEGER)
-    bigIntDataType != null -> IntermediateType(IntermediateType.HsqlType.BIG_INT)
-    fixedPointDataType != null -> IntermediateType(IntermediateType.SqliteType.INTEGER)
-    characterStringDataType != null -> IntermediateType(IntermediateType.SqliteType.TEXT)
-    booleanDataType != null -> IntermediateType(IntermediateType.HsqlType.BOOL)
-    bitStringDataType != null -> IntermediateType(IntermediateType.SqliteType.BLOB)
-    intervalDataType != null -> IntermediateType(IntermediateType.SqliteType.BLOB)
+    approximateNumericDataType != null -> IntermediateType(SqliteType.REAL)
+    binaryStringDataType != null -> IntermediateType(SqliteType.BLOB)
+    dateDataType != null -> IntermediateType(SqliteType.TEXT)
+    tinyIntDataType != null -> IntermediateType(HsqlType.TINY_INT)
+    smallIntDataType != null -> IntermediateType(HsqlType.SMALL_INT)
+    intDataType != null -> IntermediateType(HsqlType.INTEGER)
+    bigIntDataType != null -> IntermediateType(HsqlType.BIG_INT)
+    fixedPointDataType != null -> IntermediateType(SqliteType.INTEGER)
+    characterStringDataType != null -> IntermediateType(SqliteType.TEXT)
+    booleanDataType != null -> IntermediateType(HsqlType.BOOL)
+    bitStringDataType != null -> IntermediateType(SqliteType.BLOB)
+    intervalDataType != null -> IntermediateType(SqliteType.BLOB)
     else -> throw IllegalArgumentException("Unknown kotlin type for sql type ${this.text}")
   }
 }

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/util/Arguments.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/util/Arguments.kt
@@ -45,11 +45,11 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.squareup.kotlinpoet.BOOLEAN
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.sqldelight.core.compiler.model.NamedQuery
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType.ARGUMENT
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType.INTEGER
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType.NULL
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType.TEXT
 import com.squareup.sqldelight.core.lang.IntermediateType
-import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.ARGUMENT
-import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.INTEGER
-import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.NULL
-import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.TEXT
 import com.squareup.sqldelight.core.lang.psi.FunctionExprMixin
 
 /**

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/util/Arguments.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/util/Arguments.kt
@@ -68,7 +68,7 @@ private fun SqlExpr.inferredType(): IntermediateType {
   return when (val parentRule = parent!!) {
     is SqlExpr -> {
       val result = parentRule.argumentType(this)
-      if (result.sqliteType == ARGUMENT) {
+      if (result.dialectType == ARGUMENT) {
         parentRule.inferredType()
       } else {
         result

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/util/ExprUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/util/ExprUtil.kt
@@ -37,14 +37,14 @@ import com.alecstrong.sql.psi.core.psi.SqlUnaryExpr
 import com.intellij.psi.tree.TokenSet
 import com.squareup.kotlinpoet.BOOLEAN
 import com.squareup.sqldelight.core.compiler.SqlDelightCompiler.allocateName
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType.ARGUMENT
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType.BLOB
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType.INTEGER
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType.NULL
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType.REAL
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType.TEXT
 import com.squareup.sqldelight.core.lang.IntermediateType
-import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType
-import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.ARGUMENT
-import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.BLOB
-import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.INTEGER
-import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.NULL
-import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.REAL
-import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.TEXT
 import com.squareup.sqldelight.core.lang.psi.FunctionExprMixin
 import com.squareup.sqldelight.core.lang.psi.type
 

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/util/ExprUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/util/ExprUtil.kt
@@ -143,7 +143,7 @@ internal fun encapsulatingType(
   vararg typeOrder: SqliteType
 ): IntermediateType {
   val types = exprList.map { it.type() }
-  val sqlTypes = types.map { it.sqliteType }
+  val sqlTypes = types.map { it.dialectType }
 
   val type = typeOrder.last { it in sqlTypes }
   if (types.all { it.javaType.isNullable }) {

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/util/TreeUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/util/TreeUtil.kt
@@ -29,9 +29,9 @@ import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.tree.IElementType
 import com.intellij.psi.tree.TokenSet
 import com.intellij.psi.util.PsiTreeUtil
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType.INTEGER
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType.TEXT
 import com.squareup.sqldelight.core.lang.IntermediateType
-import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.INTEGER
-import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.TEXT
 import com.squareup.sqldelight.core.lang.SqlDelightFile
 import com.squareup.sqldelight.core.lang.SqlDelightQueriesFile
 import com.squareup.sqldelight.core.lang.acceptsTableInterface

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/BindArgsTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/BindArgsTest.kt
@@ -5,8 +5,7 @@ import com.alecstrong.sql.psi.core.psi.SqlBindExpr
 import com.alecstrong.sql.psi.core.psi.SqlColumnDef
 import com.google.common.truth.Truth.assertThat
 import com.squareup.kotlinpoet.asClassName
-import com.squareup.sqldelight.core.lang.IntermediateType
-import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType
 import com.squareup.sqldelight.core.lang.util.argumentType
 import com.squareup.sqldelight.core.lang.util.findChildrenOfType
 import com.squareup.sqldelight.core.lang.util.isArrayParameter
@@ -32,7 +31,7 @@ class BindArgsTest {
 
     val column = file.findChildrenOfType<SqlColumnDef>().first()
     val bindArgType = file.findChildrenOfType<SqlBindExpr>().first().argumentType()
-    assertThat(bindArgType.dialectType).isEqualTo(IntermediateType.SqliteType.INTEGER)
+    assertThat(bindArgType.dialectType).isEqualTo(SqliteType.INTEGER)
     assertThat(bindArgType.javaType).isEqualTo(List::class.asClassName())
     assertThat(bindArgType.name).isEqualTo("id")
     assertThat(bindArgType.column).isSameAs(column)
@@ -56,7 +55,7 @@ class BindArgsTest {
 
     val column = file.findChildrenOfType<SqlColumnDef>().first()
     val bindArgType = file.findChildrenOfType<SqlBindExpr>().first().argumentType()
-    assertThat(bindArgType.dialectType).isEqualTo(IntermediateType.SqliteType.INTEGER)
+    assertThat(bindArgType.dialectType).isEqualTo(SqliteType.INTEGER)
     assertThat(bindArgType.javaType).isEqualTo(List::class.asClassName())
     assertThat(bindArgType.name).isEqualTo("data_id")
     assertThat(bindArgType.column).isSameAs(column)
@@ -75,7 +74,7 @@ class BindArgsTest {
 
     val column = file.findChildrenOfType<SqlColumnDef>().first()
     file.findChildrenOfType<SqlBindExpr>().map { it.argumentType() }.forEach {
-      assertThat(it.dialectType).isEqualTo(IntermediateType.SqliteType.INTEGER)
+      assertThat(it.dialectType).isEqualTo(SqliteType.INTEGER)
       assertThat(it.javaType).isEqualTo(List::class.asClassName())
       assertThat(it.name).isEqualTo("id")
       assertThat(it.column).isSameAs(column)
@@ -95,7 +94,7 @@ class BindArgsTest {
 
     val column = file.findChildrenOfType<SqlColumnDef>().first()
     file.findChildrenOfType<SqlBindExpr>().map { it.argumentType() }.forEach {
-      assertThat(it.dialectType).isEqualTo(IntermediateType.SqliteType.INTEGER)
+      assertThat(it.dialectType).isEqualTo(SqliteType.INTEGER)
       assertThat(it.javaType).isEqualTo(List::class.asClassName())
       assertThat(it.name).isEqualTo("id")
       assertThat(it.column).isSameAs(column)
@@ -117,7 +116,7 @@ class BindArgsTest {
 
     val column = file.findChildrenOfType<SqlColumnDef>().first()
     file.findChildrenOfType<SqlBindExpr>().map { it.argumentType() }.forEach {
-      assertThat(it.dialectType).isEqualTo(IntermediateType.SqliteType.INTEGER)
+      assertThat(it.dialectType).isEqualTo(SqliteType.INTEGER)
       assertThat(it.javaType).isEqualTo(List::class.asClassName())
       assertThat(it.name).isEqualTo("id")
       assertThat(it.column).isSameAs(column)
@@ -159,7 +158,7 @@ class BindArgsTest {
 
     val column = file.findChildrenOfType<SqlColumnDef>().first()
     file.findChildrenOfType<SqlBindExpr>().map { it.argumentType() }.forEach {
-      assertThat(it.dialectType).isEqualTo(IntermediateType.SqliteType.INTEGER)
+      assertThat(it.dialectType).isEqualTo(SqliteType.INTEGER)
       assertThat(it.javaType).isEqualTo(List::class.asClassName())
       assertThat(it.name).isEqualTo("id")
       assertThat(it.column).isSameAs(column)
@@ -191,14 +190,14 @@ class BindArgsTest {
     file.findChildrenOfType<SqlBindExpr>().map { it.argumentType() }.forEach {
       when (it.name) {
         "id" -> {
-          assertThat(it.dialectType).isEqualTo(IntermediateType.SqliteType.INTEGER)
+          assertThat(it.dialectType).isEqualTo(SqliteType.INTEGER)
           assertThat(it.javaType).isEqualTo(Long::class.asClassName())
           assertThat(it.name).isEqualTo("id")
           assertThat(it.column).isSameAs(idColumn)
         }
 
         "list" -> {
-          assertThat(it.dialectType).isEqualTo(IntermediateType.SqliteType.INTEGER)
+          assertThat(it.dialectType).isEqualTo(SqliteType.INTEGER)
           assertThat(it.javaType).isEqualTo(List::class.asClassName())
           assertThat(it.name).isEqualTo("list")
           assertThat(it.column).isSameAs(listColumn)
@@ -224,7 +223,7 @@ class BindArgsTest {
 
     val column = file.findChildrenOfType<SqlColumnDef>().first()
     file.findChildrenOfType<SqlBindExpr>().map { it.argumentType() }.forEach {
-      assertThat(it.dialectType).isEqualTo(IntermediateType.SqliteType.INTEGER)
+      assertThat(it.dialectType).isEqualTo(SqliteType.INTEGER)
       assertThat(it.javaType).isEqualTo(List::class.asClassName())
       assertThat(it.name).isEqualTo("some_alias")
       assertThat(it.column).isSameAs(column)
@@ -245,7 +244,7 @@ class BindArgsTest {
 
     val column = file.findChildrenOfType<SqlColumnDef>().first()
     file.findChildrenOfType<SqlBindExpr>().map { it.argumentType() }.forEach {
-      assertThat(it.dialectType).isEqualTo(IntermediateType.SqliteType.INTEGER)
+      assertThat(it.dialectType).isEqualTo(SqliteType.INTEGER)
       assertThat(it.javaType).isEqualTo(List::class.asClassName())
       assertThat(it.name).isEqualTo("id")
       assertThat(it.column).isSameAs(column)

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/BindArgsTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/BindArgsTest.kt
@@ -32,7 +32,7 @@ class BindArgsTest {
 
     val column = file.findChildrenOfType<SqlColumnDef>().first()
     val bindArgType = file.findChildrenOfType<SqlBindExpr>().first().argumentType()
-    assertThat(bindArgType.sqliteType).isEqualTo(IntermediateType.SqliteType.INTEGER)
+    assertThat(bindArgType.dialectType).isEqualTo(IntermediateType.SqliteType.INTEGER)
     assertThat(bindArgType.javaType).isEqualTo(List::class.asClassName())
     assertThat(bindArgType.name).isEqualTo("id")
     assertThat(bindArgType.column).isSameAs(column)
@@ -56,7 +56,7 @@ class BindArgsTest {
 
     val column = file.findChildrenOfType<SqlColumnDef>().first()
     val bindArgType = file.findChildrenOfType<SqlBindExpr>().first().argumentType()
-    assertThat(bindArgType.sqliteType).isEqualTo(IntermediateType.SqliteType.INTEGER)
+    assertThat(bindArgType.dialectType).isEqualTo(IntermediateType.SqliteType.INTEGER)
     assertThat(bindArgType.javaType).isEqualTo(List::class.asClassName())
     assertThat(bindArgType.name).isEqualTo("data_id")
     assertThat(bindArgType.column).isSameAs(column)
@@ -75,7 +75,7 @@ class BindArgsTest {
 
     val column = file.findChildrenOfType<SqlColumnDef>().first()
     file.findChildrenOfType<SqlBindExpr>().map { it.argumentType() }.forEach {
-      assertThat(it.sqliteType).isEqualTo(IntermediateType.SqliteType.INTEGER)
+      assertThat(it.dialectType).isEqualTo(IntermediateType.SqliteType.INTEGER)
       assertThat(it.javaType).isEqualTo(List::class.asClassName())
       assertThat(it.name).isEqualTo("id")
       assertThat(it.column).isSameAs(column)
@@ -95,7 +95,7 @@ class BindArgsTest {
 
     val column = file.findChildrenOfType<SqlColumnDef>().first()
     file.findChildrenOfType<SqlBindExpr>().map { it.argumentType() }.forEach {
-      assertThat(it.sqliteType).isEqualTo(IntermediateType.SqliteType.INTEGER)
+      assertThat(it.dialectType).isEqualTo(IntermediateType.SqliteType.INTEGER)
       assertThat(it.javaType).isEqualTo(List::class.asClassName())
       assertThat(it.name).isEqualTo("id")
       assertThat(it.column).isSameAs(column)
@@ -117,7 +117,7 @@ class BindArgsTest {
 
     val column = file.findChildrenOfType<SqlColumnDef>().first()
     file.findChildrenOfType<SqlBindExpr>().map { it.argumentType() }.forEach {
-      assertThat(it.sqliteType).isEqualTo(IntermediateType.SqliteType.INTEGER)
+      assertThat(it.dialectType).isEqualTo(IntermediateType.SqliteType.INTEGER)
       assertThat(it.javaType).isEqualTo(List::class.asClassName())
       assertThat(it.name).isEqualTo("id")
       assertThat(it.column).isSameAs(column)
@@ -138,7 +138,7 @@ class BindArgsTest {
       """.trimMargin(), tempFolder)
 
     file.findChildrenOfType<SqlBindExpr>().map { it.argumentType() }.forEach {
-      assertThat(it.sqliteType).isEqualTo(SqliteType.INTEGER)
+      assertThat(it.dialectType).isEqualTo(SqliteType.INTEGER)
       assertThat(it.javaType).isEqualTo(List::class.asClassName())
       assertThat(it.name).isEqualTo("id")
       assertThat(it.column).isNotNull()
@@ -159,7 +159,7 @@ class BindArgsTest {
 
     val column = file.findChildrenOfType<SqlColumnDef>().first()
     file.findChildrenOfType<SqlBindExpr>().map { it.argumentType() }.forEach {
-      assertThat(it.sqliteType).isEqualTo(IntermediateType.SqliteType.INTEGER)
+      assertThat(it.dialectType).isEqualTo(IntermediateType.SqliteType.INTEGER)
       assertThat(it.javaType).isEqualTo(List::class.asClassName())
       assertThat(it.name).isEqualTo("id")
       assertThat(it.column).isSameAs(column)
@@ -191,14 +191,14 @@ class BindArgsTest {
     file.findChildrenOfType<SqlBindExpr>().map { it.argumentType() }.forEach {
       when (it.name) {
         "id" -> {
-          assertThat(it.sqliteType).isEqualTo(IntermediateType.SqliteType.INTEGER)
+          assertThat(it.dialectType).isEqualTo(IntermediateType.SqliteType.INTEGER)
           assertThat(it.javaType).isEqualTo(Long::class.asClassName())
           assertThat(it.name).isEqualTo("id")
           assertThat(it.column).isSameAs(idColumn)
         }
 
         "list" -> {
-          assertThat(it.sqliteType).isEqualTo(IntermediateType.SqliteType.INTEGER)
+          assertThat(it.dialectType).isEqualTo(IntermediateType.SqliteType.INTEGER)
           assertThat(it.javaType).isEqualTo(List::class.asClassName())
           assertThat(it.name).isEqualTo("list")
           assertThat(it.column).isSameAs(listColumn)
@@ -224,7 +224,7 @@ class BindArgsTest {
 
     val column = file.findChildrenOfType<SqlColumnDef>().first()
     file.findChildrenOfType<SqlBindExpr>().map { it.argumentType() }.forEach {
-      assertThat(it.sqliteType).isEqualTo(IntermediateType.SqliteType.INTEGER)
+      assertThat(it.dialectType).isEqualTo(IntermediateType.SqliteType.INTEGER)
       assertThat(it.javaType).isEqualTo(List::class.asClassName())
       assertThat(it.name).isEqualTo("some_alias")
       assertThat(it.column).isSameAs(column)
@@ -245,7 +245,7 @@ class BindArgsTest {
 
     val column = file.findChildrenOfType<SqlColumnDef>().first()
     file.findChildrenOfType<SqlBindExpr>().map { it.argumentType() }.forEach {
-      assertThat(it.sqliteType).isEqualTo(IntermediateType.SqliteType.INTEGER)
+      assertThat(it.dialectType).isEqualTo(IntermediateType.SqliteType.INTEGER)
       assertThat(it.javaType).isEqualTo(List::class.asClassName())
       assertThat(it.name).isEqualTo("id")
       assertThat(it.column).isSameAs(column)
@@ -271,16 +271,16 @@ class BindArgsTest {
 
     val columns = file.findChildrenOfType<SqlColumnDef>().toTypedArray()
     file.findChildrenOfType<SqlBindExpr>().map { it.argumentType() }.let { args ->
-      assertThat(args[0].sqliteType).isEqualTo(SqliteType.TEXT)
+      assertThat(args[0].dialectType).isEqualTo(SqliteType.TEXT)
       assertThat(args[0].javaType).isEqualTo(String::class.asClassName().copy(nullable = true))
       assertThat(args[0].name).isEqualTo("type")
       assertThat(args[0].column).isEqualTo(columns[0])
 
-      assertThat(args[1].sqliteType).isEqualTo(SqliteType.TEXT)
+      assertThat(args[1].dialectType).isEqualTo(SqliteType.TEXT)
       assertThat(args[1].javaType).isEqualTo(String::class.asClassName())
       assertThat(args[1].name).isEqualTo("first_name")
 
-      assertThat(args[2].sqliteType).isEqualTo(SqliteType.TEXT)
+      assertThat(args[2].dialectType).isEqualTo(SqliteType.TEXT)
       assertThat(args[2].javaType).isEqualTo(String::class.asClassName())
       assertThat(args[2].name).isEqualTo("last_name")
     }

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/BindableQueryTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/BindableQueryTest.kt
@@ -6,9 +6,9 @@ import com.google.common.truth.Truth.assertThat
 import com.intellij.psi.util.PsiTreeUtil
 import com.squareup.kotlinpoet.LONG
 import com.squareup.kotlinpoet.asClassName
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType.INTEGER
+import com.squareup.sqldelight.core.dialect.sqlite.SqliteType.TEXT
 import com.squareup.sqldelight.core.lang.IntermediateType
-import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.INTEGER
-import com.squareup.sqldelight.core.lang.IntermediateType.SqliteType.TEXT
 import com.squareup.sqldelight.core.lang.psi.ColumnDefMixin
 import com.squareup.sqldelight.test.util.FixtureCompiler
 import org.junit.Rule


### PR DESCRIPTION
Resolves #2012 

I was trying to make some first steps towards making https://github.com/AlecStrong/sql-psi/issues/155 a bit easier to implement, because we can now easily pull out `PostgreSqlType`, `MySqlType`, etc. into their own dialect specific modules.

We can also now move the SQLite specific type information to the `SqliteType` enum, for example: https://github.com/cashapp/sqldelight/blob/638cf97d5036bcaa9bb7b0c15f286e1041d339c7/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/NamedQuery.kt#L147-L153

This is a proposal PR more than anything, and I just wanted to fix a small subset of the dialect type problem for demonstration. LMK your thoughts, or if you had another interim API in mind.