### PR TITLE
Use empty package name for files outside of a gradle project

### DIFF
--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightFileIndexImpl.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightFileIndexImpl.kt
@@ -19,7 +19,7 @@ internal class SqlDelightFileIndexImpl : SqlDelightFileIndex {
     get() = throw UnsupportedOperationException()
   override val deriveSchemaFromMigrations = false
 
-  override fun packageName(file: SqlDelightFile) = throw UnsupportedOperationException()
+  override fun packageName(file: SqlDelightFile) = ""
   override fun sourceFolders(
     file: VirtualFile,
     includeDependencies: Boolean


### PR DESCRIPTION
Closes #1973 