### PR TITLE
Dont start the sqldelight gradle sync if the module is disposed

### DIFF
--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/gradle/FileIndexMap.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/gradle/FileIndexMap.kt
@@ -27,7 +27,8 @@ internal class FileIndexMap {
     synchronized(this) {
       if (!initializing) {
         initializing = true
-        ProgressManager.getInstance().run(FetchModuleModels(module, projectPath))
+        if (!module.isDisposed)
+          ProgressManager.getInstance().run(FetchModuleModels(module, projectPath))
       }
     }
     return fileIndices[projectPath] ?: defaultIndex


### PR DESCRIPTION
Closes #1981 