### PR TITLE
Improve the first time setup experience so you never have to run the gradle task

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightEnvironment.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightEnvironment.kt
@@ -96,6 +96,8 @@ class SqlDelightEnvironment(
 
   override fun fileIndex(module: Module): SqlDelightFileIndex = FileIndex()
 
+  override fun resetIndex() = throw UnsupportedOperationException()
+
   override var dialectPreset: DialectPreset
     get() = properties.dialectPreset
     set(_) { throw UnsupportedOperationException() }

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightProjectService.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightProjectService.kt
@@ -28,6 +28,8 @@ interface SqlDelightProjectService {
 
   fun fileIndex(module: Module): SqlDelightFileIndex
 
+  fun resetIndex()
+
   companion object {
     fun getInstance(project: Project): SqlDelightProjectService {
       return ServiceManager.getService(project, SqlDelightProjectService::class.java)!!

--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/GradleSystemListener.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/GradleSystemListener.kt
@@ -1,0 +1,17 @@
+package com.squareup.sqldelight.intellij
+
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskId
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskNotificationListenerAdapter
+import com.squareup.sqldelight.core.SqlDelightProjectService
+import org.jetbrains.kotlin.idea.framework.GRADLE_SYSTEM_ID
+
+class GradleSystemListener : ExternalSystemTaskNotificationListenerAdapter() {
+  override fun onSuccess(id: ExternalSystemTaskId) {
+    if (id.projectSystemId == GRADLE_SYSTEM_ID) {
+      // Gradle sync just finished, reset the file index.
+      id.findProject()?.let { project ->
+        SqlDelightProjectService.getInstance(project).resetIndex()
+      }
+    }
+  }
+}

--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/lang/SqlDelightFileViewProviderFactory.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/lang/SqlDelightFileViewProviderFactory.kt
@@ -50,10 +50,7 @@ class SqlDelightFileViewProviderFactory : FileViewProviderFactory {
     eventSystemEnabled: Boolean
   ): FileViewProvider {
     val module = SqlDelightProjectService.getInstance(manager.project).module(file)
-    if (module == null || !SqlDelightFileIndex.getInstance(module).isConfigured ||
-        SqlDelightFileIndex.getInstance(module).sourceFolders(file).isEmpty()) {
-      return SingleRootFileViewProvider(manager, file, eventSystemEnabled)
-    }
+        ?: return SingleRootFileViewProvider(manager, file, eventSystemEnabled)
     return SqlDelightFileViewProvider(manager, file, eventSystemEnabled, language, module)
   }
 }
@@ -80,6 +77,11 @@ private class SqlDelightFileViewProvider(
 
   override fun contentsSynchronized() {
     super.contentsSynchronized()
+
+    if (!SqlDelightFileIndex.getInstance(module).isConfigured ||
+        SqlDelightFileIndex.getInstance(module).sourceFolders(file).isEmpty()) {
+      return
+    }
 
     condition.invalidated.set(true)
 

--- a/sqldelight-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/sqldelight-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -40,6 +40,9 @@
     <internalFileTemplate name="SqlDelight Table"/>
     <internalFileTemplate name="SqlDelight Migration"/>
 
+    <externalSystemTaskNotificationListener
+        implementation="com.squareup.sqldelight.intellij.GradleSystemListener"/>
+
     <defaultLiveTemplatesProvider implementation="com.squareup.sqldelight.intellij.SqlDelightLiveTemplatesProvider"/>
     <liveTemplateContext implementation="com.squareup.sqldelight.intellij.SqlDelightLiveTemplateContextType"/>
 


### PR DESCRIPTION
Anytime you do a gradle sync it will reset the index, which also means when you apply the sqldelight plugin it will properly set the index, and then any time you create/move/delete an SQ file it will regenerate the database wrapper, meaning you never need to rerun the generate gradle task