### PR TITLE
Fix GoToDeclaration/FindUsages being broken on Windows due to path separator bug

### DIFF
--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/gradle/FetchProjectModelsBuildAction.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/gradle/FetchProjectModelsBuildAction.kt
@@ -9,10 +9,12 @@ object FetchProjectModelsBuildAction : BuildAction<Map<String, SqlDelightPropert
   override fun execute(controller: BuildController): Map<String, SqlDelightPropertiesFile?> {
     val models = mutableMapOf<String, SqlDelightPropertiesFile?>()
     for (project in controller.buildModel.projects) {
+      // Make sure the keys of our map always use '/' as path separator
+      val path = project.projectDirectory.absoluteFile.invariantSeparatorsPath
       try {
-        models[project.projectDirectory.absolutePath] = controller.getModel(project, SqlDelightPropertiesFile::class.java)
+        models[path] = controller.getModel(project, SqlDelightPropertiesFile::class.java)
       } catch (e: UnknownModelException) {
-        models[project.projectDirectory.absolutePath] = null
+        models[path] = null
       }
     }
     return models


### PR DESCRIPTION
This code was making a map where the keys were system-specific path strings, but the map was being looked-up using unix path strings, so the lookup always failed on systems with non-unix paths (ie Windows)

Fixes #2052 

I'm not sure why GoToDeclarationHandlerTest wasn't failing before, but I haven't been able [to start the tests on my machine](https://github.com/cashapp/sqldelight/issues/2052#issuecomment-711041884)