### PR TITLE
Fix returning list with size one instead of empty list

### DIFF
--- a/docs/common/custom_column_types.md
+++ b/docs/common/custom_column_types.md
@@ -14,7 +14,12 @@ However, creating the `Database` will require you to provide a `ColumnAdapter` w
 
 ```kotlin
 val listOfStringsAdapter = object : ColumnAdapter<List<String>, String> {
-  override fun decode(databaseValue: String) = databaseValue.split(",")
+  override fun decode(databaseValue: String) =
+    if (databaseValue.isEmpty()) {
+      listOf()
+    } else {
+      databaseValue.split(",")
+    }
   override fun encode(value: List<String>) = value.joinToString(separator = ",")
 }
 


### PR DESCRIPTION
In case an empty list was stored as value before, the `decode` returns a list of size one with one element of empty string.
This behavior seems to come from Kotlin's `.split()`.
Anyhow for the decoding you would expect to get an empty list out if you put one in earlier.

This is a problem since it makes the original object that was inserted into the database not comparable with the one that was read from the database later -> `equals()` becomes `false`.
This cost me a bit of debugging, I guess we should update the docs on this.
