### PR TITLE
NBSP before lambdas

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/SelectQueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/SelectQueryGenerator.kt
@@ -73,7 +73,7 @@ class SelectQueryGenerator(private val query: NamedQuery) : QueryGenerator(query
     val ctorParams = columnArgs.joinToString(separator = ",\n", postfix = "\n")
 
     val trailingLambda = CodeBlock.builder()
-        .add(CodeBlock.of(" { $lamdaParams ->\n"))
+        .add(CodeBlock.of("·{ $lamdaParams ->\n"))
         .indent()
         .add("%T(\n", query.interfaceType)
         .indent()
@@ -168,7 +168,7 @@ class SelectQueryGenerator(private val query: NamedQuery) : QueryGenerator(query
     //       queryWrapper.tableAdapter.columnAdapter.decode(resultSet.getString(0))
     //   )
     // }
-    val mapperLambda = CodeBlock.builder().addStatement(" { $CURSOR_NAME ->").indent()
+    val mapperLambda = CodeBlock.builder().addStatement("·{ $CURSOR_NAME ->").indent()
 
     if (query.needsWrapper()) {
       mapperLambda.add("$MAPPER_NAME(\n")

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/integrations/VariantTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/integrations/VariantTest.kt
@@ -1,4 +1,4 @@
-package com.squareup.sqldelight.tests
+package com.squareup.sqldelight.integrations
 
 import com.google.common.truth.Truth.assertThat
 import com.squareup.sqldelight.androidHome


### PR DESCRIPTION
Couldn't find a way to test those.

We found a case where the generated code would not compile because of that.

```kotlin
  override fun testMultipleCustomers(): Query<TestMultipleCustomers> = testMultipleCustomers
      { lookup_key, display_name, hashed_alias, sms, email, has_multiple_customers ->
    TestMultipleCustomers(
      lookup_key,
      display_name,
      hashed_alias,
      sms,
      email,
      has_multiple_customers
    )
  }
```