### PR TITLE
Fix concurency issue when disabling classLoadIsolation

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/GenerateMigrationOutputTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/GenerateMigrationOutputTask.kt
@@ -5,7 +5,6 @@ import com.squareup.sqldelight.core.SqlDelightDatabaseProperties
 import com.squareup.sqldelight.core.SqlDelightEnvironment
 import com.squareup.sqldelight.core.lang.util.rawSqlText
 import java.io.File
-import javax.inject.Inject
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileTree
 import org.gradle.api.provider.ListProperty
@@ -18,20 +17,15 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
-import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
-import org.gradle.workers.WorkerExecutor
 
 @Suppress("UnstableApiUsage") // Worker API.
 @CacheableTask
-abstract class GenerateMigrationOutputTask : SourceTask(), SqlDelightWorkerTask {
+abstract class GenerateMigrationOutputTask : SqlDelightWorkerTask() {
   @Suppress("unused") // Required to invalidate the task on version updates.
   @Input val pluginVersion = VERSION
-
-  @get:Inject
-  abstract override val workerExecutor: WorkerExecutor
 
   @get:OutputDirectory
   var outputDirectory: File? = null
@@ -39,8 +33,6 @@ abstract class GenerateMigrationOutputTask : SourceTask(), SqlDelightWorkerTask 
   @Internal lateinit var sourceFolders: Iterable<File>
   @Input lateinit var properties: SqlDelightDatabaseProperties
   @Input lateinit var migrationOutputExtension: String
-
-  @Input override var useClassLoaderIsolation = true
 
   @TaskAction
   fun generateSchemaFile() {

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/GenerateSchemaTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/GenerateSchemaTask.kt
@@ -9,7 +9,6 @@ import java.io.File
 import java.sql.Connection
 import java.sql.DriverManager
 import java.sql.SQLException
-import javax.inject.Inject
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileTree
 import org.gradle.api.provider.ListProperty
@@ -22,20 +21,15 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
-import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
-import org.gradle.workers.WorkerExecutor
 
 @Suppress("UnstableApiUsage") // Worker API
 @CacheableTask
-abstract class GenerateSchemaTask : SourceTask(), SqlDelightWorkerTask {
+abstract class GenerateSchemaTask : SqlDelightWorkerTask() {
   @Suppress("unused") // Required to invalidate the task on version updates.
   @Input val pluginVersion = VERSION
-
-  @get:Inject
-  abstract override val workerExecutor: WorkerExecutor
 
   @get:OutputDirectory
   var outputDirectory: File? = null
@@ -44,8 +38,6 @@ abstract class GenerateSchemaTask : SourceTask(), SqlDelightWorkerTask {
   @Input lateinit var properties: SqlDelightDatabaseProperties
 
   @Input var verifyMigrations: Boolean = false
-
-  @Input override var useClassLoaderIsolation = true
 
   @TaskAction
   fun generateSchemaFile() {

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightTask.kt
@@ -21,7 +21,6 @@ import com.squareup.sqldelight.core.SqlDelightEnvironment
 import com.squareup.sqldelight.core.SqlDelightEnvironment.CompilationStatus.Failure
 import com.squareup.sqldelight.core.SqlDelightException
 import java.io.File
-import javax.inject.Inject
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileTree
 import org.gradle.api.logging.LogLevel.ERROR
@@ -37,15 +36,13 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
-import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
-import org.gradle.workers.WorkerExecutor
 
 @Suppress("UnstableApiUsage") // Worker API
 @CacheableTask
-abstract class SqlDelightTask : SourceTask(), SqlDelightWorkerTask {
+abstract class SqlDelightTask : SqlDelightWorkerTask() {
   @Suppress("unused") // Required to invalidate the task on version updates.
   @Input val pluginVersion = VERSION
 
@@ -61,11 +58,6 @@ abstract class SqlDelightTask : SourceTask(), SqlDelightWorkerTask {
   @Input lateinit var properties: SqlDelightDatabaseProperties
 
   @Input var verifyMigrations: Boolean = false
-
-  @get:Inject
-  abstract override val workerExecutor: WorkerExecutor
-
-  @Input override var useClassLoaderIsolation = true
 
   @TaskAction
   fun generateSqlDelightFiles() {

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightWorkerTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightWorkerTask.kt
@@ -1,5 +1,10 @@
 package com.squareup.sqldelight.gradle
 
+import javax.inject.Inject
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.SourceTask
 import org.gradle.workers.WorkQueue
 import org.gradle.workers.WorkerExecutor
 
@@ -7,19 +12,36 @@ import org.gradle.workers.WorkerExecutor
  * Common API for interacting with gradle workers
  * in tasks
  */
-interface SqlDelightWorkerTask {
+abstract class SqlDelightWorkerTask : SourceTask() {
 
-  val workerExecutor: WorkerExecutor
+  @get:Inject
+  internal abstract val workerExecutor: WorkerExecutor
 
   /**
    * If true, [WorkerExecutor.classLoaderIsolation] is used. Otherwise,
    * [WorkerExecutor.noIsolation] is used for running the task's action
    */
-  var useClassLoaderIsolation: Boolean
+  @get:Input
+  internal var useClassLoaderIsolation: Boolean = true
 
-  fun workQueue(): WorkQueue = if (useClassLoaderIsolation) {
+  internal fun workQueue(): WorkQueue = if (useClassLoaderIsolation) {
       workerExecutor.classLoaderIsolation()
     } else {
       workerExecutor.noIsolation()
     }
+
+  /**
+   * Makes the task use [WorkerExecutor.noIsolation]
+   * instead of [WorkerExecutor.classLoaderIsolation]
+   */
+  @Suppress("unused")
+  fun disableClassLoaderIsolation() {
+    useClassLoaderIsolation = false
+    usesService(project.gradle.sharedServices.registerIfAbsent(
+            SqlDelightWorkerTaskSerialService::class.toString(),
+            SqlDelightWorkerTaskSerialService::class.java
+    ) { it.maxParallelUsages.set(1) })
+  }
 }
+
+private abstract class SqlDelightWorkerTaskSerialService : BuildService<BuildServiceParameters.None>

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/VerifyMigrationTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/VerifyMigrationTask.kt
@@ -23,7 +23,6 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
-import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
@@ -31,7 +30,7 @@ import org.gradle.workers.WorkerExecutor
 
 @Suppress("UnstableApiUsage") // Worker API
 @CacheableTask
-abstract class VerifyMigrationTask : SourceTask(), SqlDelightWorkerTask {
+abstract class VerifyMigrationTask : SqlDelightWorkerTask() {
   @Suppress("unused") // Required to invalidate the task on version updates.
   @Input val pluginVersion = VERSION
 
@@ -45,8 +44,6 @@ abstract class VerifyMigrationTask : SourceTask(), SqlDelightWorkerTask {
   @Input lateinit var properties: SqlDelightDatabaseProperties
 
   @Input var verifyMigrations: Boolean = false
-
-  @Input override var useClassLoaderIsolation = true
 
   @TaskAction
   fun verifyMigrations() {

--- a/sqldelight-gradle-plugin/src/test/migration-success-noisolation/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/migration-success-noisolation/build.gradle
@@ -20,17 +20,17 @@ sqldelight {
 }
 
 tasks.withType(com.squareup.sqldelight.gradle.VerifyMigrationTask) {
-  useClassLoaderIsolation = false
+  disableClassLoaderIsolation()
 }
 
 tasks.withType(com.squareup.sqldelight.gradle.GenerateSchemaTask) {
-  useClassLoaderIsolation = false
+  disableClassLoaderIsolation()
 }
 
 tasks.withType(com.squareup.sqldelight.gradle.SqlDelightTask) {
-  useClassLoaderIsolation = false
+  disableClassLoaderIsolation()
 }
 
 tasks.withType(com.squareup.sqldelight.gradle.GenerateMigrationOutputTask) {
-  useClassLoaderIsolation = false
+  disableClassLoaderIsolation()
 }


### PR DESCRIPTION
This ensures that tasks that have this disabled aren't run concurrently.