### PR TITLE
Fix incompatible types in generated bind* and cursor.get* statements

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/dialect/api/DialectType.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/dialect/api/DialectType.kt
@@ -7,6 +7,10 @@ internal interface DialectType {
 
   val javaType: TypeName
 
+  fun decode(value: CodeBlock): CodeBlock = value
+
+  fun encode(value: CodeBlock): CodeBlock = value
+
   fun prepareStatementBinder(columnIndex: String, value: CodeBlock): CodeBlock
 
   fun cursorGetter(columnIndex: Int): CodeBlock

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/dialect/hsql/HsqlType.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/dialect/hsql/HsqlType.kt
@@ -11,11 +11,27 @@ import com.squareup.sqldelight.core.dialect.api.DialectType
 import com.squareup.sqldelight.core.lang.CURSOR_NAME
 
 internal enum class HsqlType(override val javaType: TypeName) : DialectType {
-  TINY_INT(BYTE),
-  SMALL_INT(SHORT),
-  INTEGER(INT),
+  TINY_INT(BYTE) {
+    override fun decode(value: CodeBlock) = CodeBlock.of("%L.toByte()", value)
+
+    override fun encode(value: CodeBlock) = CodeBlock.of("%L.toLong()", value)
+  },
+  SMALL_INT(SHORT) {
+    override fun decode(value: CodeBlock) = CodeBlock.of("%L.toShort()", value)
+
+    override fun encode(value: CodeBlock) = CodeBlock.of("%L.toLong()", value)
+  },
+  INTEGER(INT) {
+    override fun decode(value: CodeBlock) = CodeBlock.of("%L.toInt()", value)
+
+    override fun encode(value: CodeBlock) = CodeBlock.of("%L.toLong()", value)
+  },
   BIG_INT(LONG),
-  BOOL(BOOLEAN);
+  BOOL(BOOLEAN) {
+    override fun decode(value: CodeBlock) = CodeBlock.of("%L == 1L", value)
+
+    override fun encode(value: CodeBlock) = CodeBlock.of("if (%L) 1L else 0L", value)
+  };
 
   override fun prepareStatementBinder(columnIndex: String, value: CodeBlock): CodeBlock {
     return CodeBlock.builder()

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/dialect/mysql/MySqlType.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/dialect/mysql/MySqlType.kt
@@ -11,12 +11,32 @@ import com.squareup.sqldelight.core.dialect.api.DialectType
 import com.squareup.sqldelight.core.lang.CURSOR_NAME
 
 internal enum class MySqlType(override val javaType: TypeName) : DialectType {
-  TINY_INT(BYTE),
-  TINY_INT_BOOL(BOOLEAN),
-  SMALL_INT(SHORT),
-  INTEGER(INT),
+  TINY_INT(BYTE) {
+    override fun decode(value: CodeBlock) = CodeBlock.of("%L.toByte()", value)
+
+    override fun encode(value: CodeBlock) = CodeBlock.of("%L.toLong()", value)
+  },
+  TINY_INT_BOOL(BOOLEAN) {
+    override fun decode(value: CodeBlock) = CodeBlock.of("%L == 1L", value)
+
+    override fun encode(value: CodeBlock) = CodeBlock.of("if (%L) 1L else 0L", value)
+  },
+  SMALL_INT(SHORT) {
+    override fun decode(value: CodeBlock) = CodeBlock.of("%L.toShort()", value)
+
+    override fun encode(value: CodeBlock) = CodeBlock.of("%L.toLong()", value)
+  },
+  INTEGER(INT) {
+    override fun decode(value: CodeBlock) = CodeBlock.of("%L.toInt()", value)
+
+    override fun encode(value: CodeBlock) = CodeBlock.of("%L.toLong()", value)
+  },
   BIG_INT(LONG),
-  BIT(BOOLEAN);
+  BIT(BOOLEAN) {
+    override fun decode(value: CodeBlock) = CodeBlock.of("%L == 1L", value)
+
+    override fun encode(value: CodeBlock) = CodeBlock.of("if (%L) 1L else 0L", value)
+  };
 
   override fun prepareStatementBinder(columnIndex: String, value: CodeBlock): CodeBlock {
     return CodeBlock.builder()

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/dialect/postgresql/PostgreSqlType.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/dialect/postgresql/PostgreSqlType.kt
@@ -9,8 +9,16 @@ import com.squareup.sqldelight.core.dialect.api.DialectType
 import com.squareup.sqldelight.core.lang.CURSOR_NAME
 
 internal enum class PostgreSqlType(override val javaType: TypeName) : DialectType {
-  SMALL_INT(SHORT),
-  INTEGER(INT),
+  SMALL_INT(SHORT) {
+    override fun decode(value: CodeBlock) = CodeBlock.of("%L.toShort()", value)
+
+    override fun encode(value: CodeBlock) = CodeBlock.of("%L.toLong()", value)
+  },
+  INTEGER(INT) {
+    override fun decode(value: CodeBlock) = CodeBlock.of("%L.toInt()", value)
+
+    override fun encode(value: CodeBlock) = CodeBlock.of("%L.toLong()", value)
+  },
   BIG_INT(LONG);
 
   override fun prepareStatementBinder(columnIndex: String, value: CodeBlock): CodeBlock {

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/QueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/QueriesTypeTest.kt
@@ -98,7 +98,7 @@ class QueriesTypeTest {
       |      Query<T> = SelectForIdQuery(id) { cursor ->
       |    mapper(
       |      cursor.getLong(0)!!,
-      |      cursor.getString(1)?.let(database.data_Adapter.valueAdapter::decode)
+      |      cursor.getString(1)?.let { database.data_Adapter.valueAdapter.decode(it) }
       |    )
       |  }
       |
@@ -227,7 +227,7 @@ class QueriesTypeTest {
       |      Query<T> = SelectForIdQuery(id) { cursor ->
       |    mapper(
       |      cursor.getLong(0)!!,
-      |      cursor.getString(1)?.let(database.data_Adapter.valueAdapter::decode)
+      |      cursor.getString(1)?.let { database.data_Adapter.valueAdapter.decode(it) }
       |    )
       |  }
       |

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/MutatorQueryTypeTest.kt
@@ -1,12 +1,18 @@
 package com.squareup.sqldelight.core.queries
 
+import com.alecstrong.sql.psi.core.DialectPreset
 import com.google.common.truth.Truth.assertThat
+import com.squareup.burst.BurstJUnit4
 import com.squareup.sqldelight.core.compiler.MutatorQueryGenerator
+import com.squareup.sqldelight.core.dialects.intType
 import com.squareup.sqldelight.test.util.FixtureCompiler
+import org.junit.Assume.assumeTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
 
+@RunWith(BurstJUnit4::class)
 class MutatorQueryTypeTest {
   @get:Rule val tempFolder = TemporaryFolder()
 
@@ -346,6 +352,243 @@ class MutatorQueryTypeTest {
       |  |VALUES (?)
       |  ""${'"'}.trimMargin(), 1) {
       |    bindDouble(1, value)
+      |  }
+      |}
+      |""".trimMargin())
+  }
+
+  @Test fun `types bind fine in HSQL`(dialect: DialectPreset) {
+    assumeTrue(dialect == DialectPreset.HSQL)
+
+    val file = FixtureCompiler.parseSql("""
+      |CREATE TABLE data (
+      |  boolean0 BOOLEAN NOT NULL,
+      |  boolean1 BOOLEAN,
+      |  boolean2 BOOLEAN AS kotlin.String NOT NULL,
+      |  boolean3 BOOLEAN AS kotlin.String,
+      |  tinyint0 TINYINT NOT NULL,
+      |  tinyint1 TINYINT,
+      |  tinyint2 TINYINT AS kotlin.String NOT NULL,
+      |  tinyint3 TINYINT AS kotlin.String,
+      |  smallint0 SMALLINT NOT NULL,
+      |  smallint1 SMALLINT,
+      |  smallint2 SMALLINT AS kotlin.String NOT NULL,
+      |  smallint3 SMALLINT AS kotlin.String,
+      |  int0 ${dialect.intType} NOT NULL,
+      |  int1 ${dialect.intType},
+      |  int2 ${dialect.intType} AS kotlin.String NOT NULL,
+      |  int3 ${dialect.intType} AS kotlin.String,
+      |  bigint0 BIGINT NOT NULL,
+      |  bigint1 BIGINT,
+      |  bigint2 BIGINT AS kotlin.String NOT NULL,
+      |  bigint3 BIGINT AS kotlin.String
+      |);
+      |
+      |insertData:
+      |INSERT INTO data
+      |VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+      """.trimMargin(), tempFolder, fileName = "Data.sq", dialect)
+
+    val mutator = file.namedMutators.first()
+    val generator = MutatorQueryGenerator(mutator)
+
+    assertThat(generator.function().toString()).isEqualTo("""
+      |public override fun insertData(
+      |  boolean0: kotlin.Boolean,
+      |  boolean1: kotlin.Boolean?,
+      |  boolean2: kotlin.String,
+      |  boolean3: kotlin.String?,
+      |  tinyint0: kotlin.Byte,
+      |  tinyint1: kotlin.Byte?,
+      |  tinyint2: kotlin.String,
+      |  tinyint3: kotlin.String?,
+      |  smallint0: kotlin.Short,
+      |  smallint1: kotlin.Short?,
+      |  smallint2: kotlin.String,
+      |  smallint3: kotlin.String?,
+      |  int0: kotlin.Int,
+      |  int1: kotlin.Int?,
+      |  int2: kotlin.String,
+      |  int3: kotlin.String?,
+      |  bigint0: kotlin.Long,
+      |  bigint1: kotlin.Long?,
+      |  bigint2: kotlin.String,
+      |  bigint3: kotlin.String?
+      |): kotlin.Unit {
+      |  driver.execute(${mutator.id}, ""${'"'}
+      |  |INSERT INTO data
+      |  |VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      |  ""${'"'}.trimMargin(), 20) {
+      |    bindLong(1, if (boolean0) 1L else 0L)
+      |    bindLong(2, boolean1?.let { if (it) 1L else 0L })
+      |    bindLong(3, if (database.data_Adapter.boolean2Adapter.encode(boolean2)) 1L else 0L)
+      |    bindLong(4, boolean3?.let { if (database.data_Adapter.boolean3Adapter.encode(it)) 1L else 0L })
+      |    bindLong(5, tinyint0.toLong())
+      |    bindLong(6, tinyint1?.let { it.toLong() })
+      |    bindLong(7, database.data_Adapter.tinyint2Adapter.encode(tinyint2).toLong())
+      |    bindLong(8, tinyint3?.let { database.data_Adapter.tinyint3Adapter.encode(it).toLong() })
+      |    bindLong(9, smallint0.toLong())
+      |    bindLong(10, smallint1?.let { it.toLong() })
+      |    bindLong(11, database.data_Adapter.smallint2Adapter.encode(smallint2).toLong())
+      |    bindLong(12, smallint3?.let { database.data_Adapter.smallint3Adapter.encode(it).toLong() })
+      |    bindLong(13, int0.toLong())
+      |    bindLong(14, int1?.let { it.toLong() })
+      |    bindLong(15, database.data_Adapter.int2Adapter.encode(int2).toLong())
+      |    bindLong(16, int3?.let { database.data_Adapter.int3Adapter.encode(it).toLong() })
+      |    bindLong(17, bigint0)
+      |    bindLong(18, bigint1)
+      |    bindLong(19, database.data_Adapter.bigint2Adapter.encode(bigint2))
+      |    bindLong(20, bigint3?.let { database.data_Adapter.bigint3Adapter.encode(it) })
+      |  }
+      |}
+      |""".trimMargin())
+  }
+
+  @Test fun `types bind fine in MySQL`(dialect: DialectPreset) {
+    assumeTrue(dialect == DialectPreset.MYSQL)
+
+    val file = FixtureCompiler.parseSql("""
+      |CREATE TABLE data (
+      |  boolean0 BOOLEAN NOT NULL,
+      |  boolean1 BOOLEAN,
+      |  boolean2 BOOLEAN AS kotlin.String NOT NULL,
+      |  boolean3 BOOLEAN AS kotlin.String,
+      |  bit0 BIT NOT NULL,
+      |  bit1 BIT,
+      |  bit2 BIT AS kotlin.String NOT NULL,
+      |  bit3 BIT AS kotlin.String,
+      |  tinyint0 TINYINT NOT NULL,
+      |  tinyint1 TINYINT,
+      |  tinyint2 TINYINT AS kotlin.String NOT NULL,
+      |  tinyint3 TINYINT AS kotlin.String,
+      |  smallint0 SMALLINT NOT NULL,
+      |  smallint1 SMALLINT,
+      |  smallint2 SMALLINT AS kotlin.String NOT NULL,
+      |  smallint3 SMALLINT AS kotlin.String,
+      |  bigint0 BIGINT NOT NULL,
+      |  bigint1 BIGINT,
+      |  bigint2 BIGINT AS kotlin.String NOT NULL,
+      |  bigint3 BIGINT AS kotlin.String
+      |);
+      |
+      |insertData:
+      |INSERT INTO data
+      |VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+      """.trimMargin(), tempFolder, fileName = "Data.sq", dialect)
+
+    val mutator = file.namedMutators.first()
+    val generator = MutatorQueryGenerator(mutator)
+
+    assertThat(generator.function().toString()).isEqualTo("""
+      |public override fun insertData(
+      |  boolean0: kotlin.Boolean,
+      |  boolean1: kotlin.Boolean?,
+      |  boolean2: kotlin.String,
+      |  boolean3: kotlin.String?,
+      |  bit0: kotlin.Boolean,
+      |  bit1: kotlin.Boolean?,
+      |  bit2: kotlin.String,
+      |  bit3: kotlin.String?,
+      |  tinyint0: kotlin.Byte,
+      |  tinyint1: kotlin.Byte?,
+      |  tinyint2: kotlin.String,
+      |  tinyint3: kotlin.String?,
+      |  smallint0: kotlin.Short,
+      |  smallint1: kotlin.Short?,
+      |  smallint2: kotlin.String,
+      |  smallint3: kotlin.String?,
+      |  bigint0: kotlin.Long,
+      |  bigint1: kotlin.Long?,
+      |  bigint2: kotlin.String,
+      |  bigint3: kotlin.String?
+      |): kotlin.Unit {
+      |  driver.execute(${mutator.id}, ""${'"'}
+      |  |INSERT INTO data
+      |  |VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      |  ""${'"'}.trimMargin(), 20) {
+      |    bindLong(1, if (boolean0) 1L else 0L)
+      |    bindLong(2, boolean1?.let { if (it) 1L else 0L })
+      |    bindLong(3, if (database.data_Adapter.boolean2Adapter.encode(boolean2)) 1L else 0L)
+      |    bindLong(4, boolean3?.let { if (database.data_Adapter.boolean3Adapter.encode(it)) 1L else 0L })
+      |    bindLong(5, if (bit0) 1L else 0L)
+      |    bindLong(6, bit1?.let { if (it) 1L else 0L })
+      |    bindLong(7, if (database.data_Adapter.bit2Adapter.encode(bit2)) 1L else 0L)
+      |    bindLong(8, bit3?.let { if (database.data_Adapter.bit3Adapter.encode(it)) 1L else 0L })
+      |    bindLong(9, tinyint0.toLong())
+      |    bindLong(10, tinyint1?.let { it.toLong() })
+      |    bindLong(11, database.data_Adapter.tinyint2Adapter.encode(tinyint2).toLong())
+      |    bindLong(12, tinyint3?.let { database.data_Adapter.tinyint3Adapter.encode(it).toLong() })
+      |    bindLong(13, smallint0.toLong())
+      |    bindLong(14, smallint1?.let { it.toLong() })
+      |    bindLong(15, database.data_Adapter.smallint2Adapter.encode(smallint2).toLong())
+      |    bindLong(16, smallint3?.let { database.data_Adapter.smallint3Adapter.encode(it).toLong() })
+      |    bindLong(17, bigint0)
+      |    bindLong(18, bigint1)
+      |    bindLong(19, database.data_Adapter.bigint2Adapter.encode(bigint2))
+      |    bindLong(20, bigint3?.let { database.data_Adapter.bigint3Adapter.encode(it) })
+      |  }
+      |}
+      |""".trimMargin())
+  }
+
+  @Test fun `types bind fine in PostgreSQL`(dialect: DialectPreset) {
+    assumeTrue(dialect == DialectPreset.POSTGRESQL)
+
+    val file = FixtureCompiler.parseSql("""
+      |CREATE TABLE data (
+      |  smallint0 SMALLINT NOT NULL,
+      |  smallint1 SMALLINT,
+      |  smallint2 SMALLINT AS kotlin.String NOT NULL,
+      |  smallint3 SMALLINT AS kotlin.String,
+      |  int0 ${dialect.intType} NOT NULL,
+      |  int1 ${dialect.intType},
+      |  int2 ${dialect.intType} AS kotlin.String NOT NULL,
+      |  int3 ${dialect.intType} AS kotlin.String,
+      |  bigint0 BIGINT NOT NULL,
+      |  bigint1 BIGINT,
+      |  bigint2 BIGINT AS kotlin.String NOT NULL,
+      |  bigint3 BIGINT AS kotlin.String
+      |);
+      |
+      |insertData:
+      |INSERT INTO data
+      |VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+      """.trimMargin(), tempFolder, fileName = "Data.sq", dialect)
+
+    val mutator = file.namedMutators.first()
+    val generator = MutatorQueryGenerator(mutator)
+
+    assertThat(generator.function().toString()).isEqualTo("""
+      |public override fun insertData(
+      |  smallint0: kotlin.Short,
+      |  smallint1: kotlin.Short?,
+      |  smallint2: kotlin.String,
+      |  smallint3: kotlin.String?,
+      |  int0: kotlin.Int,
+      |  int1: kotlin.Int?,
+      |  int2: kotlin.String,
+      |  int3: kotlin.String?,
+      |  bigint0: kotlin.Long,
+      |  bigint1: kotlin.Long?,
+      |  bigint2: kotlin.String,
+      |  bigint3: kotlin.String?
+      |): kotlin.Unit {
+      |  driver.execute(${mutator.id}, ""${'"'}
+      |  |INSERT INTO data
+      |  |VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      |  ""${'"'}.trimMargin(), 12) {
+      |    bindLong(1, smallint0.toLong())
+      |    bindLong(2, smallint1?.let { it.toLong() })
+      |    bindLong(3, database.data_Adapter.smallint2Adapter.encode(smallint2).toLong())
+      |    bindLong(4, smallint3?.let { database.data_Adapter.smallint3Adapter.encode(it).toLong() })
+      |    bindLong(5, int0.toLong())
+      |    bindLong(6, int1?.let { it.toLong() })
+      |    bindLong(7, database.data_Adapter.int2Adapter.encode(int2).toLong())
+      |    bindLong(8, int3?.let { database.data_Adapter.int3Adapter.encode(it).toLong() })
+      |    bindLong(9, bigint0)
+      |    bindLong(10, bigint1)
+      |    bindLong(11, database.data_Adapter.bigint2Adapter.encode(bigint2))
+      |    bindLong(12, bigint3?.let { database.data_Adapter.bigint3Adapter.encode(it) })
       |  }
       |}
       |""".trimMargin())


### PR DESCRIPTION
For example, when binding `SMALLINT`, it is (currently) bound with `bindLong(smallint)`, but `SMALLINT` is implicitly `kotlin.Short`. With this PR we'd do `bindLong(smallint.toShort())` for this to compile.

This feels like a pretty major bug as all of the non-SQLite dialects we support will fail unless you only use a specific subset of the supported dialect types (e.g.,  `BIGINT` is implicitly `kotlin.Long`, so there's no type conversion to do there).