### PR TITLE
Fix no version displaying for Gradle dependency in docs

### DIFF
--- a/docs/common/index_server.md
+++ b/docs/common/index_server.md
@@ -47,7 +47,7 @@ connection managers.
 
 ```groovy
 dependencies {
-  implementation "com.squareup.sqldelight:jdbc-driver:{{ versions.driver }}"
+  implementation "com.squareup.sqldelight:jdbc-driver:{{ versions.sqldelight }}"
 }
 ```
 ```kotlin


### PR DESCRIPTION
In the [docs](https://cashapp.github.io/sqldelight/jvm_postgresql/#typesafe-sql), no version is showing up for the driver dependency.

<img width="1298" alt="Screenshot 2020-12-19 at 15 33 47" src="https://user-images.githubusercontent.com/6900601/102691860-e478d980-420f-11eb-8da1-36274e85ffe3.png">
