### PR TITLE
Retrieve NUMERIC and DECIMAL as Double in PostgreSQL

### DIFF
--- a/docs/jvm_postgresql/types.md
+++ b/docs/jvm_postgresql/types.md
@@ -13,8 +13,8 @@ CREATE TABLE some_types (
   some_int4 INT4,                       -- Retrieved as Int
   some_bigint BIGINT,                   -- Retrieved as Long
   some_int8 INT8,                       -- Retrieved as Long
-  some_numeric NUMERIC,                 -- Retrieved as Long
-  some_decimal DECIMAL,                 -- Retrieved as Long
+  some_numeric NUMERIC,                 -- Retrieved as Double
+  some_decimal DECIMAL,                 -- Retrieved as Double
   some_real REAL,                       -- Retrieved as Double
   some_float4 FLOAT4,                   -- Retrieved as Double
   some_double_prec DOUBLE PRECISION,    -- Retrieved as Double

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/sqlTypeName.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/sqlTypeName.kt
@@ -59,7 +59,7 @@ private fun PostgreSqlTypeName.type(): IntermediateType {
     smallIntDataType != null -> IntermediateType(PostgreSqlType.SMALL_INT)
     intDataType != null -> IntermediateType(PostgreSqlType.INTEGER)
     bigIntDataType != null -> IntermediateType(PostgreSqlType.BIG_INT)
-    numericDataType != null -> IntermediateType(SqliteType.INTEGER)
+    numericDataType != null -> IntermediateType(SqliteType.REAL)
     approximateNumericDataType != null -> IntermediateType(SqliteType.REAL)
     stringDataType != null -> IntermediateType(SqliteType.TEXT)
     smallSerialDataType != null -> IntermediateType(PostgreSqlType.SMALL_INT)


### PR DESCRIPTION
An interim solution to #1882, as even though retrieving `NUMERIC` and `DECIMAL` as `kotlin.Double` fails to fully represent the type (per the issue description), retrieving them as `kotlin.Double` at least allows them to represent floating point numbers compared to the status quo of `kotlin.Long`.