### PR TITLE
Fix erroneous cursor equality check

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/NamedQuery.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/NamedQuery.kt
@@ -158,7 +158,7 @@ data class NamedQuery(
     }
 
     if (typeOne.column !== typeTwo.column &&
-      typeOne.cursorGetter(0) != typeTwo.cursorGetter(0) &&
+      typeOne.asNonNullable().cursorGetter(0) != typeTwo.asNonNullable().cursorGetter(0) &&
       typeOne.column != null && typeTwo.column != null
     ) {
       // Incompatible adapters. Revert to unadapted java type.


### PR DESCRIPTION
Fix bug introduced in #2116 where an invalid cursor equality check (`check(setOf(…).size == 1) {  "…" }`) was being generated for columns being merged with different nullabilities, but neither of them had a column adapter.