### PR TITLE
Confine SqlCursor to the critical section accessing the connection. (API breaking)

### DIFF
--- a/drivers/android-driver/src/test/java/com/squareup/sqldelight/android/AndroidDriverTest.kt
+++ b/drivers/android-driver/src/test/java/com/squareup/sqldelight/android/AndroidDriverTest.kt
@@ -23,9 +23,7 @@ class AndroidDriverTest : DriverTest() {
   fun `cached statement can be reused`() {
     val driver = AndroidSqliteDriver(schema, RuntimeEnvironment.application, cacheSize = 1)
     lateinit var bindable: SqlPreparedStatement
-    driver.executeQuery(1, "SELECT * FROM test", 0) {
-      bindable = this
-    }
+    driver.executeQuery(1, "SELECT * FROM test", 0, { bindable = this }, {})
 
     driver.executeQuery(1, "SELECT * FROM test", 0) {
       assertSame(bindable, this)
@@ -36,15 +34,13 @@ class AndroidDriverTest : DriverTest() {
   fun `cached statement is evicted and closed`() {
     val driver = AndroidSqliteDriver(schema, RuntimeEnvironment.application, cacheSize = 1)
     lateinit var bindable: SqlPreparedStatement
-    driver.executeQuery(1, "SELECT * FROM test", 0) {
-      bindable = this
-    }
+    driver.executeQuery(1, "SELECT * FROM test", 0, { bindable = this }, {})
 
-    driver.executeQuery(2, "SELECT * FROM test", 0)
+    driver.executeQuery(2, "SELECT * FROM test", 0, null, {})
 
-    driver.executeQuery(1, "SELECT * FROM test", 0) {
+    driver.executeQuery(1, "SELECT * FROM test", 0, {
       assertNotSame(bindable, this)
-    }
+    }, {})
   }
 
   @Test

--- a/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/QueryTest.kt
+++ b/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/QueryTest.kt
@@ -168,8 +168,8 @@ abstract class QueryTest {
 
   private fun testDataQuery(): Query<TestData> {
     return object : Query<TestData>(copyOnWriteList(), mapper) {
-      override fun execute(): SqlCursor {
-        return driver.executeQuery(0, "SELECT * FROM test", 0)
+      override fun <R> execute(block: (SqlCursor) -> R): R {
+        return driver.executeQuery(0, "SELECT * FROM test", 0, null, block)
       }
     }
   }

--- a/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/TransacterTest.kt
+++ b/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/TransacterTest.kt
@@ -207,6 +207,8 @@ abstract class TransacterTest {
   fun `we can rollback with value from a transaction`() {
     val result: String = transacter.transactionWithResult {
       rollback("rollback")
+
+      @Suppress("UNREACHABLE_CODE")
       return@transactionWithResult "sup"
     }
 

--- a/drivers/native-driver/src/nativeMain/kotlin/com/squareup/sqldelight/drivers/native/SqliterSqlCursor.kt
+++ b/drivers/native-driver/src/nativeMain/kotlin/com/squareup/sqldelight/drivers/native/SqliterSqlCursor.kt
@@ -12,14 +12,7 @@ import com.squareup.sqldelight.db.SqlCursor
  * them. If dev closes the outer structure, this will get closed as well, which means it could start
  * throwing errors if you're trying to access it.
  */
-internal class SqliterSqlCursor(
-  private val cursor: Cursor,
-  private val recycler: () -> Unit
-) : SqlCursor {
-  override fun close() {
-    recycler()
-  }
-
+internal class SqliterSqlCursor(private val cursor: Cursor) : SqlCursor {
   override fun getBytes(index: Int): ByteArray? = cursor.getBytesOrNull(index)
 
   override fun getDouble(index: Int): Double? = cursor.getDoubleOrNull(index)

--- a/drivers/sqljs-driver/src/test/kotlin/com/squareup/sqldelight/drivers/sqljs/JsDriverTest.kt
+++ b/drivers/sqljs-driver/src/test/kotlin/com/squareup/sqldelight/drivers/sqljs/JsDriverTest.kt
@@ -1,5 +1,6 @@
 package com.squareup.sqldelight.drivers.sqljs
 
+import com.squareup.sqldelight.db.SqlCursor
 import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.db.SqlPreparedStatement
 import com.squareup.sqldelight.db.use
@@ -71,14 +72,14 @@ class JsDriverTest {
     val insert = { binders: SqlPreparedStatement.() -> Unit ->
       driver.execute(2, "INSERT INTO test VALUES (?, ?);", 2, binders)
     }
-    val query = {
-      driver.executeQuery(3, "SELECT * FROM test", 0)
+    fun query(block: (SqlCursor) -> Unit) {
+      driver.executeQuery(3, "SELECT * FROM test", 0, null, block)
     }
-    val changes = {
-      driver.executeQuery(4, "SELECT changes()", 0)
+    fun changes(block: (SqlCursor) -> Unit)  {
+      driver.executeQuery(4, "SELECT changes()", 0, null, block)
     }
 
-    query().use {
+    query {
       assertFalse(it.next())
     }
 
@@ -87,14 +88,14 @@ class JsDriverTest {
       bindString(2, "Alec")
     }
 
-    query().use {
+    query {
       assertTrue(it.next())
       assertFalse(it.next())
     }
 
-    assertEquals(1, changes().apply { next() }.use { it.getLong(0) })
+    assertEquals(1, changes { it.next(); it.getLong(0) })
 
-    query().use {
+    query {
       assertTrue(it.next())
       assertEquals(1, it.getLong(0))
       assertEquals("Alec", it.getString(1))
@@ -104,9 +105,9 @@ class JsDriverTest {
       bindLong(1, 2)
       bindString(2, "Jake")
     }
-    assertEquals(1, changes().apply { next() }.use { it.getLong(0) })
+    assertEquals(1, changes { it.next(); it.getLong(0) })
 
-    query().use {
+    query {
       assertTrue(it.next())
       assertEquals(1, it.getLong(0))
       assertEquals("Alec", it.getString(1))
@@ -116,9 +117,9 @@ class JsDriverTest {
     }
 
     driver.execute(5, "DELETE FROM test", 0)
-    assertEquals(2, changes().apply { next() }.use { it.getLong(0) })
+    assertEquals(2, changes { it.next(); it.getLong(0) })
 
-    query().use {
+    query {
       assertFalse(it.next())
     }
   }
@@ -128,40 +129,46 @@ class JsDriverTest {
     val insert = { binders: SqlPreparedStatement.() -> Unit ->
       driver.execute(2, "INSERT INTO test VALUES (?, ?);", 2, binders)
     }
-    val changes = {
-      driver.executeQuery(4, "SELECT changes()", 0)
+    fun changes(block: (SqlCursor) -> Unit) {
+      driver.executeQuery(4, "SELECT changes()", 0, null, block)
     }
 
     insert {
       bindLong(1, 1)
       bindString(2, "Alec")
     }
-    assertEquals(1, changes().apply { next() }.use { it.getLong(0) })
+    assertEquals(1, changes { it.next(); it.getLong(0) })
     insert {
       bindLong(1, 2)
       bindString(2, "Jake")
     }
-    assertEquals(1, changes().apply { next() }.use { it.getLong(0) })
+    assertEquals(1, changes { it.next(); it.getLong(0) })
 
-    val query = { binders: SqlPreparedStatement.() -> Unit ->
-      driver.executeQuery(6, "SELECT * FROM test WHERE value = ?", 1, binders)
+    fun query(binders: SqlPreparedStatement.() -> Unit, block: (SqlCursor) -> Unit) {
+      driver.executeQuery(6, "SELECT * FROM test WHERE value = ?", 1, binders, block)
     }
-    query {
-      bindString(1, "Jake")
-    }.use {
-      assertTrue(it.next())
-      assertEquals(2, it.getLong(0))
-      assertEquals("Jake", it.getString(1))
-    }
+    query(
+      binders = {
+        bindString(1, "Jake")
+      },
+      block = {
+        assertTrue(it.next())
+        assertEquals(2, it.getLong(0))
+        assertEquals("Jake", it.getString(1))
+      }
+    )
 
     // Second time running the query is fine
-    query {
-      bindString(1, "Jake")
-    }.use {
-      assertTrue(it.next())
-      assertEquals(2, it.getLong(0))
-      assertEquals("Jake", it.getString(1))
-    }
+    query(
+      binders = {
+        bindString(1, "Jake")
+      },
+      block = {
+        assertTrue(it.next())
+        assertEquals(2, it.getLong(0))
+        assertEquals("Jake", it.getString(1))
+      }
+    )
   }
 
   @Test fun sqlResultSet_getters_return_null_if_the_column_values_are_NULL() = driverPromise.then { driver ->
@@ -169,7 +176,10 @@ class JsDriverTest {
     val insert = { binders: SqlPreparedStatement.() -> Unit ->
       driver.execute(7, "INSERT INTO nullability_test VALUES (?, ?, ?, ?, ?);", 5, binders)
     }
-    val changes = { driver.executeQuery(4, "SELECT changes()", 0) }
+    fun changes(block: (SqlCursor) -> Unit) {
+      driver.executeQuery(4, "SELECT changes()", 0, null, block)
+    }
+
     insert {
       bindLong(1, 1)
       bindLong(2, null)
@@ -177,9 +187,9 @@ class JsDriverTest {
       bindBytes(4, null)
       bindDouble(5, null)
     }
-    assertEquals(1, changes().apply { next() }.use { it.getLong(0) })
+    assertEquals(1, changes { it.next(); it.getLong(0) })
 
-    driver.executeQuery(8, "SELECT * FROM nullability_test", 0).use {
+    driver.executeQuery(8, "SELECT * FROM nullability_test", 0) {
       assertTrue(it.next())
       assertEquals(1, it.getLong(0))
       assertNull(it.getLong(1))
@@ -203,7 +213,7 @@ class JsDriverTest {
       bindDouble(5, Float.MAX_VALUE.toDouble())
     }
 
-    driver.executeQuery(8, "SELECT * FROM nullability_test", 0).use {
+    driver.executeQuery(8, "SELECT * FROM nullability_test", 0) {
       assertTrue(it.next())
       assertEquals(1, it.getLong(0))
       assertEquals(Long.MAX_VALUE, it.getLong(1))

--- a/drivers/sqljs-driver/src/test/kotlin/com/squareup/sqldelight/drivers/sqljs/JsQueryTest.kt
+++ b/drivers/sqljs-driver/src/test/kotlin/com/squareup/sqldelight/drivers/sqljs/JsQueryTest.kt
@@ -174,8 +174,8 @@ class JsQueryTest {
 
   private fun SqlDriver.testDataQuery(): Query<TestData> {
     return object : Query<TestData>(copyOnWriteList(), mapper) {
-      override fun execute(): SqlCursor {
-        return executeQuery(0, "SELECT * FROM test", 0)
+      override fun <R> execute(block: (SqlCursor) -> R): R {
+        return executeQuery(0, "SELECT * FROM test", 0, null, block)
       }
     }
   }

--- a/runtime/src/commonMain/kotlin/com/squareup/sqldelight/db/SqlCursor.kt
+++ b/runtime/src/commonMain/kotlin/com/squareup/sqldelight/db/SqlCursor.kt
@@ -19,7 +19,7 @@ package com.squareup.sqldelight.db
  * Represents a SQL result set which can be iterated through with [next]. Initially the cursor will
  * not point to any row, and calling [next] once will iterate to the first row.
  */
-interface SqlCursor : Closeable {
+interface SqlCursor {
   /**
    * Move to the next row in the result set.
    *

--- a/runtime/src/commonMain/kotlin/com/squareup/sqldelight/db/SqlDriver.kt
+++ b/runtime/src/commonMain/kotlin/com/squareup/sqldelight/db/SqlDriver.kt
@@ -23,7 +23,7 @@ import com.squareup.sqldelight.Transacter
  */
 interface SqlDriver : Closeable {
   /**
-   * Execute a SQL statement and return a [SqlCursor] that iterates the result set.
+   * Execute a SQL statement and evaluate its result set using the given block.
    *
    * @param [identifier] An opaque, unique value that can be used to implement any driver-side
    *   caching of prepared statements. If [identifier] is null, a fresh statement is required.
@@ -31,13 +31,18 @@ interface SqlDriver : Closeable {
    * @param [parameters] The number of bindable parameters [sql] contains.
    * @param [binders] A lambda which is called before execution to bind any parameters to the SQL
    *   statement.
+   * @param [block] A lambda which is called with the cursor when the statement is executed
+   *   successfully. The generic result of the lambda is returned to the caller, as soon as the
+   *   mutual exclusion on the database connection ends. The cursor **must not escape** the block
+   *   scope.
    */
-  fun executeQuery(
+  fun <R> executeQuery(
     identifier: Int?,
     sql: String,
     parameters: Int,
-    binders: (SqlPreparedStatement.() -> Unit)? = null
-  ): SqlCursor
+    binders: (SqlPreparedStatement.() -> Unit)? = null,
+    block: (SqlCursor) -> R
+  ): R
 
   /**
    * Execute a SQL statement.

--- a/runtime/src/commonMain/kotlin/com/squareup/sqldelight/logs/LogSqliteDriver.kt
+++ b/runtime/src/commonMain/kotlin/com/squareup/sqldelight/logs/LogSqliteDriver.kt
@@ -40,15 +40,16 @@ class LogSqliteDriver(
     sqlDriver.execute(identifier, sql, parameters, binders)
   }
 
-  override fun executeQuery(
+  override fun <R> executeQuery(
     identifier: Int?,
     sql: String,
     parameters: Int,
-    binders: (SqlPreparedStatement.() -> Unit)?
-  ): SqlCursor {
+    binders: (SqlPreparedStatement.() -> Unit)?,
+    block: (SqlCursor) -> R
+  ): R {
     logger("QUERY\n $sql")
     logParameters(binders)
-    return sqlDriver.executeQuery(identifier, sql, parameters, binders)
+    return sqlDriver.executeQuery(identifier, sql, parameters, binders, block)
   }
 
   override fun newTransaction(): Transacter.Transaction {

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/SelectQueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/SelectQueryGenerator.kt
@@ -36,6 +36,7 @@ import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.joinToCode
 import com.squareup.sqldelight.core.compiler.SqlDelightCompiler.allocateName
 import com.squareup.sqldelight.core.compiler.model.NamedQuery
+import com.squareup.sqldelight.core.lang.*
 import com.squareup.sqldelight.core.lang.ADAPTER_NAME
 import com.squareup.sqldelight.core.lang.CURSOR_NAME
 import com.squareup.sqldelight.core.lang.CURSOR_TYPE
@@ -281,9 +282,12 @@ class SelectQueryGenerator(private val query: NamedQuery) : QueryGenerator(query
     // Query<T>
     queryType.superclass(QUERY_TYPE.parameterizedBy(returnType))
 
+    val genericResultType = TypeVariableName("R")
     val createStatementFunction = FunSpec.builder(EXECUTE_METHOD)
       .addModifiers(OVERRIDE)
-      .returns(CURSOR_TYPE)
+      .addTypeVariable(genericResultType)
+      .addParameter(EXECUTE_BLOCK_NAME, LambdaTypeName.get(parameters = *arrayOf(CURSOR_TYPE), returnType = genericResultType))
+      .returns(genericResultType)
       .addCode(executeBlock())
 
     // For each bind argument the query has.

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/Constants.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/Constants.kt
@@ -22,6 +22,7 @@ internal val QUERY_LIST_TYPE = ClassName("kotlin.collections", "MutableList")
   .parameterizedBy(QUERY_TYPE.parameterizedBy(STAR))
 
 internal const val MAPPER_NAME = "mapper"
+internal const val EXECUTE_BLOCK_NAME = "block"
 
 internal const val EXECUTE_METHOD = "execute"
 


### PR DESCRIPTION
This is a proposed solution to fix the read-your-writes consistency violation as described in the issue:

* [[native + sqlite WAL] Read-your-writes consistency violation under stress, due to SqlCursor escaping mutual exclusion of its parent connection](#2123)

 It is API breaking however, since it changes all method signatures that previously return a `SqlCursor`.

### TL;DR

* `SqlCursor` is no longer returned to the caller.
* Instead, the caller must supply a `(SqlCursor) -> R` lambda that uses the cursor, which the generic lambda result `R` will be passed back to the caller.
* The `SqlCursor` is unconditionally closed after invoking the supplied lambda, but before the SqlDriver exits the critical section on the connection.

   This guarantees that all active select statements are **always** closed, before the connection is reused by another caller/thread. Only when there is no active statement, the connection can then move its end mark forward for future reads to see newly written data.

Note that these changes are applicable to most databases with MVCC. For example, MySQL with InnoDB has a similar default behaviour for read statements as SQLite WAL (autocommit + the `REPEATABLE READ` isolation level).

### Note
This is API breaking in both `SqlDriver` and `Query<T>`. Especially the latter, which exposes to library users a `execute()` returning a `SqlCursor` that can be closed asynchronously (or never).

Though it seems to me that `executeAs*()` are the ones intended to be used, not `execute()`. So the proposal here is to replace `fun execute(): SqlCursor` without deprecation.