### PR TITLE
update maven publish plugin to 0.14.2

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -33,15 +33,15 @@ jobs:
       - name: Publish the macOS artifacts
         if: matrix.os == 'macOS-latest'
         env:
-          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralRepositoryUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralRepositoryPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
-        run: ./gradlew uploadArchives --no-daemon
+        run: ./gradlew publishAllPublicationsToMavenRepository --no-daemon
       - name: Publish the windows artifact
         if: matrix.os == 'windows-latest'
         env:
-          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralRepositoryUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralRepositoryPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
         run: ./gradlew publishMingwPublicationToMavenRepository
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -24,7 +24,7 @@ ext.deps = [
         download: "de.undercouch:gradle-download-task:3.4.2",
         intellij: "gradle.plugin.org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.4.22",
         grammarKitComposer: "com.alecstrong:grammar-kit-composer:0.1.4",
-        publish: "com.vanniktech:gradle-maven-publish-plugin:0.11.1",
+        publish: "com.vanniktech:gradle-maven-publish-plugin:0.14.2",
         spotless: "com.diffplug.spotless:spotless-plugin-gradle:5.8.2",
         changelog: "org.jetbrains.intellij.plugins:gradle-changelog-plugin:0.4.0",
     ],

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -8,13 +8,15 @@ dokka {
 
 mavenPublish {
   releaseSigningEnabled = !getGpgKey().isEmpty()
+}
 
-  targets {
-    installLocally {
-      releaseRepositoryUrl = file("${rootProject.buildDir}/localMaven").toURI().toString()
-      snapshotRepositoryUrl = file("${rootProject.buildDir}/localMaven").toURI().toString()
+publishing {
+    repositories {
+        maven {
+            name = "installLocally"
+            url = "${rootProject.buildDir}/localMaven"
+        }
     }
-  }
 }
 
 if (project.plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")) {


### PR DESCRIPTION
Updates the plugin to the latest version which fixes a compatibility issue with Kotlin 1.4.30. I've also replaced some deprecated bits:
- the old targets API is replaced by Gradle's native API to declare publishing repositories
- new property syntax for credentials so that we can use Gradle's credentials APIs
- replace custom `uploadArchives` with the standard Gradle task