### PR TITLE
Only download IntelliJ if no local copy exists

### DIFF
--- a/gradle/updateDependencies.gradle
+++ b/gradle/updateDependencies.gradle
@@ -11,6 +11,8 @@ task updateDependencies {
             "${versions.idea}/ideaIC-${versions.idea}.zip"
     dest intellijCoreZip
     onlyIfNewer true
+    overwrite false
+    tempAndMove true
   }
 
   copy {


### PR DESCRIPTION
When working with the SQLDelight project I seemed to end up with IntelliJ downloading every time Gradle ran its configuration phase which is a bit wasteful.

The `overwrite` flag does what you'd expect, while `tempAndMove`: 
> `true` if the file should be downloaded to a temporary location and, upon successful execution, moved to the final location. If `overwrite` is set to false, this flag is useful to avoid partially downloaded files if Gradle is forcefully closed or the system crashes.