### PR TITLE
Update to Gradle 7-compatible dependency configurations

### DIFF
--- a/sqldelight-gradle-plugin/src/test/integration-android-library/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-android-library/build.gradle
@@ -22,8 +22,8 @@ dependencies {
   implementation "com.squareup.sqldelight:android-driver:${com.squareup.sqldelight.VersionKt.VERSION}"
 
   // TODO why don't these work when specified as androidTestImplementation?
-  compile deps.support.test.runner
-  compile deps.truth
+  implementation deps.support.test.runner
+  implementation deps.truth
 }
 
 sqldelight {

--- a/sqldelight-gradle-plugin/src/test/integration-android/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-android/build.gradle
@@ -21,8 +21,8 @@ dependencies {
   implementation "com.squareup.sqldelight:android-driver:${com.squareup.sqldelight.VersionKt.VERSION}"
 
   // TODO why don't these work when specified as androidTestImplementation?
-  compile deps.support.test.runner
-  compile deps.truth
+  implementation deps.support.test.runner
+  implementation deps.truth
 }
 
 sqldelight {

--- a/sqldelight-idea-plugin/build.gradle
+++ b/sqldelight-idea-plugin/build.gradle
@@ -52,15 +52,15 @@ repositories {
 }
 
 dependencies {
-  compile project(':sqldelight-compiler')
+  implementation project(':sqldelight-compiler')
 
-  compile deps.kotlin.reflect
-  compile(deps.bugsnag) {
+  implementation deps.kotlin.reflect
+  implementation(deps.bugsnag) {
     exclude group: "org.slf4j"
   }
 
-  testCompile deps.truth
-  testCompile project(':test-util')
+  testImplementation deps.truth
+  testImplementation project(':test-util')
 }
 
 def getBugsnagKey() {

--- a/sqlite-migrations/build.gradle
+++ b/sqlite-migrations/build.gradle
@@ -5,7 +5,7 @@ dependencies {
   implementation deps.objectDiff
   implementation deps.schemaCrawler.tools
   implementation deps.schemaCrawler.sqlite
-  compile deps.sqlitePsi
+  implementation deps.sqlitePsi
 
   testImplementation deps.junit
   testImplementation deps.truth


### PR DESCRIPTION
`compile` and `testCompile` are removed in Gradle 7.