### PR TITLE
Set source & target compatibility for Kotlin JVM subprojects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,9 +58,9 @@ allprojects {
     }
   }
 
-  if (plugins.hasPlugin("org.jetbrains.kotlin.jvm")) {
-    sourceCompatibility JavaVersion.VERSION_1_8
-    targetCompatibility JavaVersion.VERSION_1_8
+  plugins.withId("org.jetbrains.kotlin.jvm") {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
   }
 
   plugins.withId("com.android.library") {


### PR DESCRIPTION
Fixes application of source & target compatibility so it works as intended. See https://github.com/cashapp/sqldelight/issues/2079#issuecomment-782794215