### PR TITLE
Use runPluginVerifier task to verify IntelliJ plugin compatibility

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -46,19 +46,10 @@ jobs:
       - name: Run the IntelliJ plugin
         if: matrix.os == 'ubuntu-latest' && matrix.job == 'instrumentation'
         run: ./gradlew :sqldelight-idea-plugin:build --stacktrace
-      - name: Verify intellij plugin
+      - name: Verify IntelliJ plugin
         if: matrix.os == 'ubuntu-latest' && matrix.job == 'instrumentation'
-        uses: ChrisCarini/intellij-platform-plugin-verifier-action@v1.0.3
-        with:
-          ide-versions: |
-            ideaIC:2019.1.4
-            ideaIU:2019.1.4
-            ideaIC:2019.2.4
-            ideaIU:2019.2.4
-            ideaIC:2019.3.5
-            ideaIU:2019.3.5
-            ideaIC:2020.1.2
-            ideaIU:2020.1.2
+        run: |
+          ./gradlew :sqldelight-idea-plugin:runPluginVerifier
 
       - name: Run windows tests
         if: matrix.os == 'windows-latest'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -22,7 +22,7 @@ ext.deps = [
         kotlin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
         dokka: "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokka}",
         download: "de.undercouch:gradle-download-task:3.4.2",
-        intellij: "gradle.plugin.org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.4.22",
+        intellij: "org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.6.5",
         grammarKitComposer: "com.alecstrong:grammar-kit-composer:0.1.4",
         publish: "com.vanniktech:gradle-maven-publish-plugin:0.11.1",
         spotless: "com.diffplug.spotless:spotless-plugin-gradle:5.8.2",

--- a/sqldelight-idea-plugin/build.gradle
+++ b/sqldelight-idea-plugin/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.intellij.tasks.RunPluginVerifierTask.FailureLevel
+
 apply plugin: 'org.jetbrains.intellij'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: "org.jetbrains.changelog"
@@ -24,6 +26,23 @@ intellij {
   }
   // Uncomment to test against Android Studio
   // alternativeIdePath = '/Applications/Android Studio.app'
+}
+
+runPluginVerifier {
+  ideVersions = [
+      "IC-2019.3.5",
+      "IC-2020.1.4",
+      "IC-2020.2.4",
+      "IC-2020.3.2",
+  ]
+
+  def customFailureLevel = FailureLevel.ALL
+  customFailureLevel.remove(FailureLevel.DEPRECATED_API_USAGES)
+  customFailureLevel.remove(FailureLevel.INTERNAL_API_USAGES)
+  customFailureLevel.remove(FailureLevel.COMPATIBILITY_WARNINGS)
+  customFailureLevel.remove(FailureLevel.NOT_DYNAMIC)
+
+  setFailureLevel(customFailureLevel)
 }
 
 changelog {

--- a/sqldelight-idea-plugin/build.gradle
+++ b/sqldelight-idea-plugin/build.gradle
@@ -11,7 +11,7 @@ intellij {
   plugins = [
       "org.jetbrains.kotlin:${versions.kotlin}-release-IJ2020.1-1",
       "gradle",
-      "java",
+      "com.intellij.java",
       "Groovy",
       "properties",
   ]
@@ -39,7 +39,6 @@ runPluginVerifier {
   def customFailureLevel = FailureLevel.ALL
   customFailureLevel.remove(FailureLevel.DEPRECATED_API_USAGES)
   customFailureLevel.remove(FailureLevel.INTERNAL_API_USAGES)
-  customFailureLevel.remove(FailureLevel.COMPATIBILITY_WARNINGS)
   customFailureLevel.remove(FailureLevel.NOT_DYNAMIC)
 
   setFailureLevel(customFailureLevel)

--- a/sqldelight-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/sqldelight-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -4,7 +4,7 @@
   <category>Custom Languages</category>
   <vendor url="https://github.com/square">Square, Inc.</vendor>
   <idea-version
-      since-build="191"
+      since-build="193"
   />
   <depends>com.intellij.modules.lang</depends>
   <depends>org.jetbrains.kotlin</depends>

--- a/sqldelight-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/sqldelight-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -7,6 +7,7 @@
       since-build="193"
   />
   <depends>com.intellij.modules.lang</depends>
+  <depends>com.intellij.java</depends>
   <depends>org.jetbrains.kotlin</depends>
 
   <description><![CDATA[


### PR DESCRIPTION
Switch to the equivalent Gradle task to verify plugin compatibility.

During testing I found IntelliJ 2019.1 & 2019.2 reported "compatibility problems" that might lead to `NoMethodFoundError`s so bumped the minimum supported version of the plugin.