### PR TITLE
Fix deprecation warnings on IntelliJ platform 193

### DIFF
--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightRenameProcessor.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightRenameProcessor.kt
@@ -6,6 +6,8 @@ import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiReference
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.SearchScope
 import com.intellij.refactoring.listeners.RefactoringElementListener
 import com.intellij.refactoring.rename.RenamePsiElementProcessor
 import com.intellij.usageView.UsageInfo
@@ -53,14 +55,18 @@ class SqlDelightRenameProcessor : RenamePsiElementProcessor() {
     super.renameElement(element, newName, usages, listener)
   }
 
-  override fun findReferences(element: PsiElement): Collection<PsiReference> {
-    if (element !is StmtIdentifierMixin) return super.findReferences(element)
+  override fun findReferences(
+    element: PsiElement,
+    searchScope: SearchScope,
+    searchInCommentsAndStrings: Boolean
+  ): Collection<PsiReference> {
+    if (element !is StmtIdentifierMixin) return super.findReferences(element, searchScope, searchInCommentsAndStrings)
     return element.generatedMethods().flatMap { element.references(it) }
   }
 
   private fun PsiElement.references(element: PsiElement): Collection<PsiReference> {
     val processor = RenamePsiElementProcessor.forElement(element)
-    return processor.findReferences(element)
+    return processor.findReferences(element, GlobalSearchScope.projectScope(element.project), false)
       .filter { it.element.containingFile.virtualFile != generatedFile() }
   }
 

--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/intentions/ExpandColumnNamesWildcardQuickFix.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/intentions/ExpandColumnNamesWildcardQuickFix.kt
@@ -4,6 +4,7 @@ import com.alecstrong.sql.psi.core.psi.SqlSelectStmt
 import com.intellij.codeInsight.intention.impl.BaseIntentionAction
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.ReadOnlyModificationException
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
 import com.squareup.sqldelight.core.lang.SqlDelightFile
@@ -35,17 +36,15 @@ class ExpandColumnNamesWildcardQuickFix : BaseIntentionAction() {
   }
 
   override fun invoke(project: Project, editor: Editor, file: PsiFile) {
-    object : WriteCommandAction.Simple<Project>(project) {
-      override fun run() {
-        val caret = editor.caretModel.offset
-        selectStatementAtCaretWithColumnNamesWildcard(file as SqlDelightFile, caret)?.run {
-          val wildcard = resultColumnList.first()
-          val allColumns = queryExposed()
-            .flatMap { it.columns }
-            .joinToString(separator = ", ") { it.element.text }
-          editor.document.replaceString(wildcard.startOffset, wildcard.endOffset, allColumns)
-        }
+    WriteCommandAction.writeCommandAction(project).run<ReadOnlyModificationException> {
+      val caret = editor.caretModel.offset
+      selectStatementAtCaretWithColumnNamesWildcard(file as SqlDelightFile, caret)?.run {
+        val wildcard = resultColumnList.first()
+        val allColumns = queryExposed()
+          .flatMap { it.columns }
+          .joinToString(separator = ", ") { it.element.text }
+        editor.document.replaceString(wildcard.startOffset, wildcard.endOffset, allColumns)
       }
-    }.execute()
+    }
   }
 }

--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/lang/SqlDelightFoldingBuilder.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/lang/SqlDelightFoldingBuilder.kt
@@ -23,7 +23,6 @@ import com.alecstrong.sql.psi.core.psi.SqlTypes
 import com.intellij.lang.ASTNode
 import com.intellij.lang.folding.FoldingBuilder
 import com.intellij.lang.folding.FoldingDescriptor
-import com.intellij.lang.folding.NamedFoldingDescriptor
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.project.DumbAware
 import com.intellij.psi.PsiElement
@@ -79,7 +78,7 @@ class SqlDelightFoldingBuilder : FoldingBuilder, DumbAware {
     val start = openingBraceElement.startOffset
     val end = nextSibling.endOffset
     if (start >= end) return null
-    return NamedFoldingDescriptor(this, start, end, null, "(...);")
+    return FoldingDescriptor(this, start, end, null, "(...);")
   }
 
   private fun PsiElement.toCreateViewDescriptor(createViewStmt: PsiElement?): FoldingDescriptor? {
@@ -106,7 +105,7 @@ class SqlDelightFoldingBuilder : FoldingBuilder, DumbAware {
     val start = stmtIdentifier.endOffset
     val end = nextSibling.endOffset
     if (start >= end) return null
-    return NamedFoldingDescriptor(this, start, end, null, "...")
+    return FoldingDescriptor(this, start, end, null, "...")
   }
 
   private fun PsiElement.toImportListDescriptor(): FoldingDescriptor? {
@@ -115,7 +114,7 @@ class SqlDelightFoldingBuilder : FoldingBuilder, DumbAware {
     val start = whitespaceElement.endOffset
     val end = lastChild.endOffset
     if (start >= end) return null
-    return NamedFoldingDescriptor(this, start, end, null, "...")
+    return FoldingDescriptor(this, start, end, null, "...")
   }
 
   override fun getPlaceholderText(node: ASTNode) = "..."


### PR DESCRIPTION
Only the quick fix code is not just a direct replacement with an updated API, but I'm assuming good test coverage exists for that.

This will address all deprecated usages on platform 193 once https://github.com/AlecStrong/sql-psi/pull/237 makes its way to the plugin.