### PR TITLE
Replace text equality checks with textMatches

### DIFF
--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightClassCompletionContributor.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightClassCompletionContributor.kt
@@ -56,7 +56,7 @@ private class AutoImportInsertionHandler : InsertHandler<JavaPsiClassReferenceEl
     val qname = item.qualifiedName
     val imports = (context.file as SqlDelightFile).sqlStmtList
       ?.findChildrenOfType<SqlDelightImportStmt>().orEmpty()
-    val ref = imports.map { it.javaType }.find { it.text == qname }
+    val ref = imports.map { it.javaType }.find { it.textMatches(qname) }
     val refEnd = context.trackOffset(context.tailOffset, false)
 
     if (ref == null) {

--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightGotoDeclarationHandler.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightGotoDeclarationHandler.kt
@@ -69,7 +69,7 @@ class SqlDelightGotoDeclarationHandler : GotoDeclarationHandler {
       result = file.sqlStmtList!!
         .findChildrenOfType<SqlDelightStmtIdentifier>()
         .mapNotNull { it.identifier() }
-        .filter { it.text == sourceElement.text }
+        .filter { it.textMatches(sourceElement) }
         .toTypedArray()
       return@iterateContent false
     }

--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/intentions/ExpandColumnNamesWildcardQuickFix.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/intentions/ExpandColumnNamesWildcardQuickFix.kt
@@ -32,7 +32,7 @@ class ExpandColumnNamesWildcardQuickFix : BaseIntentionAction() {
   ): SqlSelectStmt? {
     val selectStatement = file.findElementOfTypeAtOffset<SqlSelectStmt>(caret) ?: return null
     val resultColumns = selectStatement.resultColumnList
-    return if (resultColumns.size == 1 && resultColumns[0].text == "*") selectStatement else null
+    return if (resultColumns.size == 1 && resultColumns[0].textMatches("*")) selectStatement else null
   }
 
   override fun invoke(project: Project, editor: Editor, file: PsiFile) {


### PR DESCRIPTION
https://plugins.jetbrains.com/docs/intellij/performance.html#avoid-expensive-methods-in-psielement

> getText() traverses the whole tree under the given element and concatenates strings, consider textMatches() instead.