### PR TITLE
Enable sqljs-driver publication

### DIFF
--- a/drivers/sqljs-driver/build.gradle
+++ b/drivers/sqljs-driver/build.gradle
@@ -28,4 +28,4 @@ kotlin {
   }
 }
 
-// TODO publishing artifacts
+apply from: "$rootDir/gradle/gradle-mvn-push.gradle"


### PR DESCRIPTION
This fixes #1667 now that the project is using the newest version of the publish plugin.