### PR TITLE
Add compiler support for SQLite offsets()

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/FunctionExprMixin.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/FunctionExprMixin.kt
@@ -93,6 +93,7 @@ internal class FunctionExprMixin(node: ASTNode?) : SqlFunctionExprImpl(node) {
     "total", "bm25" -> IntermediateType(SqliteType.REAL)
     "likelihood", "likely", "unlikely" -> exprList[0].type()
     "highlight", "snippet" -> IntermediateType(SqliteType.TEXT).asNullable()
+    "offsets" -> IntermediateType(SqliteType.TEXT).asNullable()
     else -> null
   }
 


### PR DESCRIPTION
Hello! I recently ran into a compiler issue while trying to use `offsets()` queries for an FTS3 table. The fix seemed straightforward, and seems to work for my usage. I wasn't quite sure which tests would be helpful to update, but tried to add a unit test for now. Let me know if there's additional context or testing needed!

**Issue**

SQLDelight supports FTS3/4 tables, but the compiler does not understand the `offsets()` function ([SQLite documentation](https://sqlite.org/fts3.html#offsets)). The result of `offsets()` is a string, which can be parsed as sets of 4 integers. For simplicity, this PR only models the result as a single string, and leaves further parsing up to the caller.

When used in queries where no rows match, the result may return `null`, which is why I chose to mark it `asNullable()`.

**Change**
- Add `offsets` as a valid function  to `FunctionExprMixin.kt`
- Add unit test to verify codegen output is correct

**Testing**
- [x] Run new test locally
- I ran into (unrelated) issues trying to run a full `./gradlew test` locally, but would be happy to run this if they could be solved!