### PR TITLE
[Docs] Android: Add Kotlin plugin for Implementation

### DIFF
--- a/docs/android_sqlite/index.md
+++ b/docs/android_sqlite/index.md
@@ -13,6 +13,7 @@ buildscript {
   }
 }
 
+apply plugin: 'kotlin'
 apply plugin: 'com.squareup.sqldelight'
 ```
 


### PR DESCRIPTION
I was moving my KMP module's SqlDelight setup to native Android and realised this issue. If you are missing 
`apply plugin: 'kotlin'` in root build.gradle, you get an error which says:

> SQL Delight Gradle plugin applied in project ':' but no supported Kotlin plugin was found
 Took me a while to understand what was missing. 

