### PR TITLE
Fix js module qualifier issue

### DIFF
--- a/drivers/sqljs-driver/src/main/kotlin/com/squareup/sqldelight/drivers/sqljs/sqljs.SqlJs.kt
+++ b/drivers/sqljs-driver/src/main/kotlin/com/squareup/sqldelight/drivers/sqljs/sqljs.SqlJs.kt
@@ -1,4 +1,5 @@
-@file:JsQualifier("SqlJs")
+@file:JsModule("sql.js")
+@file:JsNonModule
 @file:Suppress("INTERFACE_WITH_SUPERCLASS", "OVERRIDING_FINAL_MEMBER", "RETURN_TYPE_MISMATCH_ON_OVERRIDE", "CONFLICTING_OVERLOADS", "EXTERNAL_DELEGATION")
 package com.squareup.sqldelight.drivers.sqljs
 


### PR DESCRIPTION
Fixes #2195 

The bundled output from Kotlin/JS now gets the `Database` and `Statement` objects from the `sql.js` module rather than an undefined `SqlJs` qualifier/object.