### PR TITLE
Replace RuntimeEnvironment.application with ApplicationProvider.getApplicationContext()

### DIFF
--- a/drivers/android-driver/build.gradle
+++ b/drivers/android-driver/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 
   testImplementation project(':drivers:driver-test')
   testImplementation deps.junit
+  testImplementation deps.androidx.test.core
   testImplementation deps.robolectric
 }
 

--- a/drivers/android-driver/src/test/java/com/squareup/sqldelight/android/AndroidDriverTest.kt
+++ b/drivers/android-driver/src/test/java/com/squareup/sqldelight/android/AndroidDriverTest.kt
@@ -1,5 +1,6 @@
 package com.squareup.sqldelight.android
 
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.db.SqlDriver.Schema
 import com.squareup.sqldelight.db.SqlPreparedStatement
@@ -11,17 +12,16 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class AndroidDriverTest : DriverTest() {
   override fun setupDatabase(schema: Schema): SqlDriver {
-    return AndroidSqliteDriver(schema, RuntimeEnvironment.application)
+    return AndroidSqliteDriver(schema, getApplicationContext())
   }
 
   @Test
   fun `cached statement can be reused`() {
-    val driver = AndroidSqliteDriver(schema, RuntimeEnvironment.application, cacheSize = 1)
+    val driver = AndroidSqliteDriver(schema, getApplicationContext(), cacheSize = 1)
     lateinit var bindable: SqlPreparedStatement
     driver.executeQuery(1, "SELECT * FROM test", 0) {
       bindable = this
@@ -34,7 +34,7 @@ class AndroidDriverTest : DriverTest() {
 
   @Test
   fun `cached statement is evicted and closed`() {
-    val driver = AndroidSqliteDriver(schema, RuntimeEnvironment.application, cacheSize = 1)
+    val driver = AndroidSqliteDriver(schema, getApplicationContext(), cacheSize = 1)
     lateinit var bindable: SqlPreparedStatement
     driver.executeQuery(1, "SELECT * FROM test", 0) {
       bindable = this
@@ -49,7 +49,7 @@ class AndroidDriverTest : DriverTest() {
 
   @Test
   fun `uncached statement is closed`() {
-    val driver = AndroidSqliteDriver(schema, RuntimeEnvironment.application, cacheSize = 1)
+    val driver = AndroidSqliteDriver(schema, getApplicationContext(), cacheSize = 1)
     lateinit var bindable: AndroidStatement
     driver.execute(null, "SELECT * FROM test", 0) {
       bindable = this as AndroidStatement
@@ -67,7 +67,7 @@ class AndroidDriverTest : DriverTest() {
     val factory = AssertableSupportSQLiteOpenHelperFactory()
     val driver = AndroidSqliteDriver(
       schema = schema,
-      context = RuntimeEnvironment.application,
+      context = getApplicationContext(),
       factory = factory,
       name = "name",
       useNoBackupDirectory = true
@@ -82,7 +82,7 @@ class AndroidDriverTest : DriverTest() {
     val factory = AssertableSupportSQLiteOpenHelperFactory()
     val driver = AndroidSqliteDriver(
       schema = schema,
-      context = RuntimeEnvironment.application,
+      context = getApplicationContext(),
       factory = factory,
       useNoBackupDirectory = false
     )

--- a/drivers/android-driver/src/test/java/com/squareup/sqldelight/android/AndroidQueryTest.kt
+++ b/drivers/android-driver/src/test/java/com/squareup/sqldelight/android/AndroidQueryTest.kt
@@ -1,15 +1,15 @@
 package com.squareup.sqldelight.android
 
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.db.SqlDriver.Schema
 import com.squareup.sqldelight.driver.test.QueryTest
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class AndroidQueryTest : QueryTest() {
   override fun setupDatabase(schema: Schema): SqlDriver {
-    return AndroidSqliteDriver(schema, RuntimeEnvironment.application)
+    return AndroidSqliteDriver(schema, getApplicationContext())
   }
 }

--- a/drivers/android-driver/src/test/java/com/squareup/sqldelight/android/AndroidTransacterTest.kt
+++ b/drivers/android-driver/src/test/java/com/squareup/sqldelight/android/AndroidTransacterTest.kt
@@ -1,15 +1,15 @@
 package com.squareup.sqldelight.android
 
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.db.SqlDriver.Schema
 import com.squareup.sqldelight.driver.test.TransacterTest
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class AndroidTransacterTest : TransacterTest() {
   override fun setupDatabase(schema: Schema): SqlDriver {
-    return AndroidSqliteDriver(schema, RuntimeEnvironment.application)
+    return AndroidSqliteDriver(schema, getApplicationContext())
   }
 }

--- a/extensions/android-paging/build.gradle
+++ b/extensions/android-paging/build.gradle
@@ -33,6 +33,7 @@ dependencies {
   testImplementation project(':drivers:android-driver')
   testImplementation deps.truth
   testImplementation deps.junit
+  testImplementation deps.androidx.test.core
   testImplementation deps.robolectric
 }
 

--- a/extensions/android-paging/src/test/java/com/squareup/sqldelight/android/paging/QueryDataSourceFactoryTest.kt
+++ b/extensions/android-paging/src/test/java/com/squareup/sqldelight/android/paging/QueryDataSourceFactoryTest.kt
@@ -4,6 +4,7 @@ import androidx.paging.PositionalDataSource.LoadInitialCallback
 import androidx.paging.PositionalDataSource.LoadInitialParams
 import androidx.paging.PositionalDataSource.LoadRangeCallback
 import androidx.paging.PositionalDataSource.LoadRangeParams
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import com.google.common.truth.Truth.assertThat
 import com.squareup.sqldelight.Query
 import com.squareup.sqldelight.Transacter
@@ -15,7 +16,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
 class QueryDataSourceFactoryTest {
@@ -44,7 +44,7 @@ class QueryDataSourceFactoryTest {
           throw AssertionError("DB Migration shouldn't occur")
         }
       },
-      RuntimeEnvironment.application
+      getApplicationContext()
     )
     transacter = object : TransacterImpl(driver) {}
   }

--- a/extensions/android-paging3/build.gradle
+++ b/extensions/android-paging3/build.gradle
@@ -33,6 +33,7 @@ dependencies {
   testImplementation project(':drivers:android-driver')
   testImplementation deps.truth
   testImplementation deps.kotlin.test.junit
+  testImplementation deps.androidx.test.core
   testImplementation deps.robolectric
   testImplementation deps.kotlin.coroutines.test
 }

--- a/extensions/android-paging3/src/test/java/com/squareup/sqldelight/android/paging3/OffsetQueryPagingSourceTest.kt
+++ b/extensions/android-paging3/src/test/java/com/squareup/sqldelight/android/paging3/OffsetQueryPagingSourceTest.kt
@@ -17,6 +17,7 @@ package com.squareup.sqldelight.android.paging3
 
 import androidx.paging.PagingSource.LoadParams.Refresh
 import androidx.paging.PagingSource.LoadResult
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import com.squareup.sqldelight.Query
 import com.squareup.sqldelight.Transacter
 import com.squareup.sqldelight.TransacterImpl
@@ -33,7 +34,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import kotlin.test.assertFailsWith
 
 @ExperimentalCoroutinesApi
@@ -64,7 +64,7 @@ class OffsetQueryPagingSourceTest {
           throw AssertionError("DB Migration shouldn't occur")
         }
       },
-      RuntimeEnvironment.application
+      getApplicationContext()
     )
     transacter = object : TransacterImpl(driver) {}
   }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -43,6 +43,9 @@ ext.deps = [
         nativeUtils: "org.jetbrains.kotlin:kotlin-native-utils:${versions.kotlin}"
     ],
     androidx: [
+        test: [
+            core: 'androidx.test:core:1.3.0',
+        ],
         sqlite: "androidx.sqlite:sqlite:${versions.androidxSqlite}",
         sqliteFramework: "androidx.sqlite:sqlite-framework:${versions.androidxSqlite}",
         paging: [


### PR DESCRIPTION
Per http://robolectric.org/androidx_test, `RuntimeEnvironment.application` has been deprecated and should be replaced with `ApplicationProvider.getApplicationContext()` from the AndroidX Test APIs.