### PR TITLE
Don't throw exception on empty data in AndroidX Paging3 extension

### DIFF
--- a/extensions/android-paging3/src/main/java/com/squareup/sqldelight/android/paging3/OffsetQueryPagingSource.kt
+++ b/extensions/android-paging3/src/main/java/com/squareup/sqldelight/android/paging3/OffsetQueryPagingSource.kt
@@ -37,7 +37,7 @@ internal class OffsetQueryPagingSource<RowType : Any>(
       val key = params.key ?: 0L
       transacter.transactionWithResult {
         val count = countQuery.executeAsOne()
-        if (key >= count) throw IndexOutOfBoundsException()
+        if (count != 0L && key >= count) throw IndexOutOfBoundsException()
 
         val loadSize = if (key < 0) params.loadSize + key else params.loadSize
 

--- a/extensions/android-paging3/src/test/java/com/squareup/sqldelight/android/paging3/OffsetQueryPagingSourceTest.kt
+++ b/extensions/android-paging3/src/test/java/com/squareup/sqldelight/android/paging3/OffsetQueryPagingSourceTest.kt
@@ -69,6 +69,21 @@ class OffsetQueryPagingSourceTest {
     transacter = object : TransacterImpl(driver) {}
   }
 
+  @Test fun `empty page gives correct prevKey and nextKey`() {
+    driver.execute(null, "DELETE FROM testTable", 0)
+    val source = OffsetQueryPagingSource(
+      this::query,
+      countQuery(),
+      transacter,
+      TestCoroutineDispatcher()
+    )
+
+    val results = runBlocking { source.load(Refresh(null, 2, false)) }
+
+    assertNull((results as LoadResult.Page).prevKey)
+    assertNull(results.nextKey)
+  }
+
   @Test fun `aligned first page gives correct prevKey and nextKey`() {
     val source = OffsetQueryPagingSource(
       this::query,


### PR DESCRIPTION
I'm just trying out the new AndroidX Paging3 extension and I'm getting an `IndexOutOfBoundsException` when my table is empty (i.e., `countQuery.executeAsOne() == 0`). I'm new to the Paging3 library, but I'd assume that the table being empty shouldn't throw an exception.