### PR TITLE
Use a shaded jar for intellij

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -10,11 +10,19 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macOS-latest, windows-latest, ubuntu-latest]
-        job: [instrumentation, test]
+        os: [ macOS-latest, windows-latest, ubuntu-latest ]
+        job: [ instrumentation, test, gradle-plugin-tests, gradle-plugin-integrations ]
         exclude:
           - os: windows-latest
             job: instrumentation
+          - os: windows-latest
+            job: gradle-plugin-tests
+          - os: windows-latest
+            job: gradle-plugin-integrations
+          - os: macOS-latest
+            job: gradle-plugin-tests
+          - os: macOS-latest
+            job: gradle-plugin-integrations
 
     runs-on: ${{matrix.os}}
 
@@ -31,11 +39,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Run ubuntu tests
+      - name: Run gradle tests
         if: matrix.os == 'ubuntu-latest' && matrix.job == 'test'
         run: |
           ./gradlew build -x :sqldelight-idea-plugin:build -x :sqldelight-gradle-plugin:test --stacktrace
+      - name: Run gradle plugin tests
+        if: matrix.os == 'ubuntu-latest' && matrix.job == 'gradle-plugin-tests'
+        run: |
           ./gradlew :sqldelight-gradle-plugin:test --tests="com.squareup.sqldelight.tests.*"
+      - name: Run gradle plugin integrations
+        if: matrix.os == 'ubuntu-latest' && matrix.job == 'gradle-plugin-integrations'
+        run: |
           ./gradlew :sqldelight-gradle-plugin:test --tests="com.squareup.sqldelight.integrations.*"
 
       - name: Run the IntelliJ plugin
@@ -71,4 +85,4 @@ jobs:
           path: build-reports.zip
 
 env:
-  GRADLE_OPTS: -Dorg.gradle.configureondemand=true -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx4g -Xms128m -XX:MaxPermSize=4096m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=1024m"
+  GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.configureondemand=true -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx4g -Xms128m -XX:MaxPermSize=4096m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=1024m"

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ buildscript {
     classpath deps.plugins.publish
     classpath deps.plugins.spotless
     classpath deps.plugins.changelog
+    classpath deps.plugins.shadow
 
     // Used for the sample
 //    classpath "com.squareup.sqldelight:gradle-plugin:${versions.sqldelight}"

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -27,6 +27,7 @@ ext.deps = [
         publish: "com.vanniktech:gradle-maven-publish-plugin:0.14.2",
         spotless: "com.diffplug.spotless:spotless-plugin-gradle:5.8.2",
         changelog: "org.jetbrains.intellij.plugins:gradle-changelog-plugin:0.4.0",
+        shadow: "com.github.jengelman.gradle.plugins:shadow:6.1.0"
     ],
     kotlin: [
         test: [

--- a/sqldelight-compiler/build.gradle
+++ b/sqldelight-compiler/build.gradle
@@ -19,14 +19,15 @@ dependencies {
   api deps.sqlitePsi
 
   implementation deps.kotlinPoet
-  implementation deps.sqliteJdbc
 
+  compileOnly deps.sqliteJdbc
   compileOnly deps.intellij.core
   compileOnly deps.intellij.lang
   compileOnly deps.intellij.java
   compileOnly deps.intellij.testFramework
 
   testImplementation deps.burst
+  testImplementation deps.sqliteJdbc
   testImplementation deps.intellij.core
   testImplementation deps.intellij.lang
   testImplementation deps.intellij.java

--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -83,7 +83,8 @@ test {
 }
 
 tasks.register("relocateShadowJar", ConfigureShadowRelocation.class) {
-    target = tasks.shadowJar
+  target = tasks.shadowJar
+  prefix = "sqldelight"
 }
 
 tasks.getByName("shadowJar").configure {

--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -1,3 +1,5 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
+
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'java-gradle-plugin'
@@ -28,6 +30,10 @@ tasks.named('pluginUnderTestMetadata').configure {
 
 dependencies {
   implementation deps.kotlin.nativeUtils
+  implementation deps.sqliteJdbc
+  implementation deps.objectDiff
+  implementation deps.schemaCrawler.tools
+  implementation deps.schemaCrawler.sqlite
 
   shade deps.sqlitePsi
   shade project(':sqlite-migrations')
@@ -76,14 +82,30 @@ test {
   }
 }
 
-tasks.getByName("shadowJar").configure {
-  archiveClassifier.set("")
-  configurations = [project.configurations.shade]
-  minimize()
-  relocate "com.intellij", "com.squareup.sqldelight.com.intellij"
+tasks.register("relocateShadowJar", ConfigureShadowRelocation.class) {
+    target = tasks.shadowJar
+}
 
-  exclude '*.properties'
-  exclude 'META-INF/services/*'
+tasks.getByName("shadowJar").configure {
+  dependsOn("relocateShadowJar")
+  archiveClassifier.set("")
+  minimize()
+  configurations = [project.configurations.shade]
+
+  doFirst {
+    relocators = relocators.grep {
+      !it.getPattern().startsWith("com.squareup.sqldelight") &&
+      !it.getPattern().startsWith("groovy") &&
+      !it.getPattern().startsWith("kotlin")
+    }
+  }
+
+  include '*.jar'
+  include '**/*.class'
+  include 'META-INF/gradle-plugins/*'
+
+  exclude '/groovy**'
+  exclude '/kotlin/**'
 }
 
 artifacts {

--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -1,3 +1,4 @@
+apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'java-gradle-plugin'
 
@@ -13,7 +14,10 @@ gradlePlugin {
 configurations {
   fixtureClasspath
   bundled
+  shade
 }
+
+configurations.compileOnly.extendsFrom(configurations.shade)
 
 // Append any extra dependencies to the test fixtures via a custom configuration classpath. This
 // allows us to apply additional plugins in a fixture while still leveraging dependency resolution
@@ -23,19 +27,23 @@ tasks.named('pluginUnderTestMetadata').configure {
 }
 
 dependencies {
-  implementation project(':sqldelight-compiler')
-  implementation project(':sqlite-migrations')
   implementation deps.kotlin.nativeUtils
-  implementation deps.sqlitePsi
-  implementation deps.intellij.core
-  implementation deps.intellij.java
-  implementation deps.intellij.lang
-  implementation deps.intellij.testFramework
+
+  shade deps.sqlitePsi
+  shade project(':sqlite-migrations')
+  shade project(':sqldelight-compiler')
+  shade deps.intellij.core
+  shade deps.intellij.java
+  shade deps.intellij.lang
+  shade deps.intellij.testFramework
 
   compileOnly gradleApi()
   implementation deps.plugins.kotlin
   compileOnly deps.plugins.android
 
+  testImplementation deps.sqlitePsi
+  testImplementation project(':sqlite-migrations')
+  testImplementation project(':sqldelight-compiler')
   testImplementation deps.junit
   testImplementation deps.truth
 
@@ -66,6 +74,21 @@ test {
       excludeCategories 'com.squareup.sqldelight.Instrumentation'
     }
   }
+}
+
+tasks.getByName("shadowJar").configure {
+  archiveClassifier.set("")
+  configurations = [project.configurations.shade]
+  minimize()
+  relocate "com.intellij", "com.squareup.sqldelight.com.intellij"
+
+  exclude '*.properties'
+  exclude 'META-INF/services/*'
+}
+
+artifacts {
+  runtime(shadowJar)
+  archives(shadowJar)
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/sqldelight-idea-plugin/build.gradle
+++ b/sqldelight-idea-plugin/build.gradle
@@ -73,6 +73,7 @@ dependencies {
   implementation project(':sqldelight-compiler')
 
   implementation deps.kotlin.reflect
+  implementation deps.sqliteJdbc
   implementation(deps.bugsnag) {
     exclude group: "org.slf4j"
   }

--- a/sqlite-migrations/build.gradle
+++ b/sqlite-migrations/build.gradle
@@ -1,12 +1,18 @@
 apply plugin: 'org.jetbrains.kotlin.jvm'
 
 dependencies {
-  implementation deps.sqliteJdbc
-  implementation deps.objectDiff
-  implementation deps.schemaCrawler.tools
-  implementation deps.schemaCrawler.sqlite
+  // These dependencies will not be shadowed by sqldelight-gradle-plugin
+  compileOnly deps.sqliteJdbc
+  compileOnly deps.objectDiff
+  compileOnly deps.schemaCrawler.tools
+  compileOnly deps.schemaCrawler.sqlite
+
   implementation deps.sqlitePsi
 
+  testImplementation deps.sqliteJdbc
+  testImplementation deps.objectDiff
+  testImplementation deps.schemaCrawler.tools
+  testImplementation deps.schemaCrawler.sqlite
   testImplementation deps.junit
   testImplementation deps.truth
 }


### PR DESCRIPTION
well, its back to 50mb but im pretty sure it is a lot bigger than it needs to be. If I just inspect the jar manually its bloated as hell presumably with stuff we dont need.

BUT now the intellij dependency is in a different package, which is good, and our local setup is way more sane since we dont download it every time. So I think this is still the best option. Ideally we follow up by trying to prune more - im not sure how shadow works entirely but it looks like its also shading things like guava so maybe theres a way to avoid shadowing some transitive dependencies and have them show up in the pom...regardless this is a good first step