### PR TITLE
Attempt to tune the jvm size for testkit spawned processes

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -71,4 +71,4 @@ jobs:
           path: build-reports.zip
 
 env:
-  GRADLE_OPTS: -Dorg.gradle.configureondemand=true -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx4g -XX:MaxPermSize=4096m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=1024m"
+  GRADLE_OPTS: -Dorg.gradle.configureondemand=true -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx4g -Xms128m -XX:MaxPermSize=4096m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=1024m"

--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -44,6 +44,10 @@ dependencies {
 }
 
 test {
+  // TestKit spawns individual daemons for each test so set things up to be less memory intensive.
+  maxParallelForks = 2
+  minHeapSize = '128m'
+
   // The integration tests require local installations of artifacts.
   dependsOn(
           ":runtime:publishAllPublicationsToInstallLocallyRepository",


### PR DESCRIPTION
Going off of these issues for ideas of fixing:

https://discuss.gradle.org/t/testkit-how-to-turn-off-daemon/17843
https://discuss.gradle.org/t/travis-ci-org-gradle-launcher-daemon-client-daemondisappearedexception-gradle-build-daemon-disappeared-unexpectedly-it-may-have-been-killed-or-may-have-crashed/13106