### PR TITLE
Remove unused parameters

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightEnvironment.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightEnvironment.kt
@@ -161,7 +161,7 @@ class SqlDelightEnvironment(
       if (it !is SqlDelightQueriesFile) return@forSourceFiles
       logger("----- START ${it.name} ms -------")
       val timeTaken = measureTimeMillis {
-        SqlDelightCompiler.writeInterfaces(module, it, moduleName, writer)
+        SqlDelightCompiler.writeInterfaces(module, it, writer)
         sourceFile = it
       }
       logger("----- END ${it.name} in $timeTaken ms ------")
@@ -171,9 +171,7 @@ class SqlDelightEnvironment(
       logger("----- START ${migrationFile.name} ms -------")
       val timeTaken = measureTimeMillis {
         SqlDelightCompiler.writeInterfaces(
-          module = module,
           file = migrationFile,
-          implementationFolder = moduleName,
           output = writer,
           includeAll = true
         )

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/SqlDelightCompiler.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/SqlDelightCompiler.kt
@@ -38,22 +38,19 @@ object SqlDelightCompiler {
   fun writeInterfaces(
     module: Module,
     file: SqlDelightQueriesFile,
-    implementationFolder: String,
     output: FileAppender
   ) {
-    writeTableInterfaces(module, file, implementationFolder, output)
-    writeQueryInterfaces(module, file, implementationFolder, output)
-    writeQueriesInterface(module, file, implementationFolder, output)
+    writeTableInterfaces(file, output)
+    writeQueryInterfaces(file, output)
+    writeQueriesInterface(module, file, output)
   }
 
   fun writeInterfaces(
-    module: Module,
     file: MigrationFile,
-    implementationFolder: String,
     output: FileAppender,
     includeAll: Boolean = false
   ) {
-    writeTableInterfaces(module, file, implementationFolder, output, includeAll)
+    writeTableInterfaces(file, output, includeAll)
   }
 
   fun writeDatabaseInterface(
@@ -118,9 +115,7 @@ object SqlDelightCompiler {
   }
 
   internal fun writeTableInterfaces(
-    module: Module,
     file: SqlDelightFile,
-    implementationFolder: String,
     output: FileAppender,
     includeAll: Boolean = false
   ) {
@@ -147,9 +142,7 @@ object SqlDelightCompiler {
   }
 
   internal fun writeQueryInterfaces(
-    module: Module,
     file: SqlDelightQueriesFile,
-    implementationFolder: String,
     output: FileAppender
   ) {
     file.namedQueries.writeQueryInterfaces(file, output)
@@ -158,7 +151,6 @@ object SqlDelightCompiler {
   internal fun writeQueriesInterface(
     module: Module,
     file: SqlDelightQueriesFile,
-    implementationFolder: String,
     output: FileAppender
   ) {
     val packageName = file.packageName ?: return

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/InterfaceGeneration.kt
@@ -859,7 +859,9 @@ class InterfaceGeneration {
   private fun checkFixtureCompiles(fixtureRoot: String) {
     val result = FixtureCompiler.compileFixture(
       fixtureRoot = "src/test/query-interface-fixtures/$fixtureRoot",
-      compilationMethod = SqlDelightCompiler::writeQueryInterfaces,
+      compilationMethod = { _, file, output ->
+        SqlDelightCompiler.writeQueryInterfaces(file, output)
+      },
       generateDb = false
     )
     for ((expectedFile, actualOutput) in result.compilerOutput) {

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/tables/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/tables/InterfaceGeneration.kt
@@ -491,8 +491,8 @@ class InterfaceGeneration {
   private fun checkFixtureCompiles(fixtureRoot: String) {
     val result = FixtureCompiler.compileFixture(
       fixtureRoot = "src/test/table-interface-fixtures/$fixtureRoot",
-      compilationMethod = { module, sqlDelightQueriesFile, folder, writer ->
-        SqlDelightCompiler.writeTableInterfaces(module, sqlDelightQueriesFile, folder, writer)
+      compilationMethod = { _, sqlDelightQueriesFile, writer ->
+        SqlDelightCompiler.writeTableInterfaces(sqlDelightQueriesFile, writer)
       },
       generateDb = false
     )

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/views/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/views/InterfaceGeneration.kt
@@ -191,8 +191,8 @@ class InterfaceGeneration {
   private fun checkFixtureCompiles(fixtureRoot: String) {
     val result = FixtureCompiler.compileFixture(
       fixtureRoot = "src/test/view-interface-fixtures/$fixtureRoot",
-      compilationMethod = { module, sqlDelightQueriesFile, folder, writer ->
-        SqlDelightCompiler.writeTableInterfaces(module, sqlDelightQueriesFile, folder, writer)
+      compilationMethod = { _, sqlDelightQueriesFile, writer ->
+        SqlDelightCompiler.writeTableInterfaces(sqlDelightQueriesFile, writer)
       },
       generateDb = false
     )

--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/lang/SqlDelightFileViewProviderFactory.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/lang/SqlDelightFileViewProviderFactory.kt
@@ -143,9 +143,9 @@ private class SqlDelightFileViewProvider(
         PrintStream(vFile.getOutputStream(this))
       }
       if (file is SqlDelightQueriesFile) {
-        SqlDelightCompiler.writeInterfaces(module, file, module.name, fileAppender)
+        SqlDelightCompiler.writeInterfaces(module, file, fileAppender)
       } else if (file is MigrationFile) {
-        SqlDelightCompiler.writeInterfaces(module, file, module.name, fileAppender)
+        SqlDelightCompiler.writeInterfaces(file, fileAppender)
       }
       this.filesGenerated = files
     }

--- a/sqldelight-idea-plugin/src/test/kotlin/com/squareup/sqldelight/intellij/SqlDelightProjectTestCase.kt
+++ b/sqldelight-idea-plugin/src/test/kotlin/com/squareup/sqldelight/intellij/SqlDelightProjectTestCase.kt
@@ -97,7 +97,7 @@ abstract class SqlDelightProjectTestCase : LightJavaCodeInsightFixtureTestCase()
       fileToGenerateDb = sqlFile
       return@iterateContentUnderDirectory true
     }
-    SqlDelightCompiler.writeInterfaces(module, fileToGenerateDb!!, module.name, virtualFileWriter)
+    SqlDelightCompiler.writeInterfaces(module, fileToGenerateDb!!, virtualFileWriter)
     SqlDelightCompiler.writeDatabaseInterface(module, fileToGenerateDb!!, module.name, virtualFileWriter)
   }
 }

--- a/test-util/src/main/kotlin/com/squareup/sqldelight/test/util/FixtureCompiler.kt
+++ b/test-util/src/main/kotlin/com/squareup/sqldelight/test/util/FixtureCompiler.kt
@@ -28,7 +28,7 @@ import com.squareup.sqldelight.core.lang.SqlDelightQueriesFile
 import org.junit.rules.TemporaryFolder
 import java.io.File
 
-private typealias CompilationMethod = (Module, SqlDelightQueriesFile, String, (String) -> Appendable) -> Unit
+private typealias CompilationMethod = (Module, SqlDelightQueriesFile, (String) -> Appendable) -> Unit
 
 object FixtureCompiler {
 
@@ -110,7 +110,7 @@ object FixtureCompiler {
     environment.forSourceFiles { psiFile ->
       psiFile.log(sourceFiles)
       if (psiFile is SqlDelightQueriesFile) {
-        compilationMethod(environment.module, psiFile, "testmodule", fileWriter)
+        compilationMethod(environment.module, psiFile, fileWriter)
         file = psiFile
       } else if (psiFile is MigrationFile) {
         if (topMigration == null || psiFile.order > topMigration!!.order) {
@@ -121,9 +121,7 @@ object FixtureCompiler {
 
     if (topMigration != null) {
       SqlDelightCompiler.writeInterfaces(
-        module = environment.module,
         file = topMigration!!,
-        implementationFolder = "testmodule",
         output = fileWriter,
         includeAll = true
       )


### PR DESCRIPTION
The Kotlin compiler warns that many of the parameters used in `SqlDelightCompiler` are unused. Removing them will obviously get rid of the warnings, but it would also be less surprising for callers of the functions if they're not passing in values which are ultimately ignored.