### PR TITLE
Remove redundant CMSClassUnloadingEnabled flag

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=square
 POM_DEVELOPER_NAME=Square, Inc.
 
-org.gradle.jvmargs=-Xms128m -Xmx2048m -XX:+CMSClassUnloadingEnabled
+org.gradle.jvmargs=-Xms128m -Xmx2048m
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 android.useAndroidX=true


### PR DESCRIPTION
As far back as Java 8 the CMSClassUnloadingEnabled option was set true by default, making this flag redundant, while in later versions the CMS GC has been removed along with the CMS command line flags which stops the Gradle daemon from starting on recent Java versions.