### PR TITLE
Stop enabling GRADLE_METADATA feature preview

### DIFF
--- a/docs/common/multiplatform.md
+++ b/docs/common/multiplatform.md
@@ -14,9 +14,3 @@ sqldelight {
 ```
 
 Put `.sq` files in the `src/commonMain/sqldelight` directory, and then `expect` a `SqlDriver` to be provided by individual platforms when creating the `Database`. Migration files should also be in the same `src/commonMain/sqldelight` directory.
-
-Multiplatform **requires the gradle metadata feature**, which you need to enable via the `settings.gradle` file in the project root:
-
-```groovy
-enableFeaturePreview('GRADLE_METADATA')
-```

--- a/sqldelight-gradle-plugin/src/test/integration-multiplatform/settings.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-multiplatform/settings.gradle
@@ -1,1 +1,0 @@
-enableFeaturePreview('GRADLE_METADATA')

--- a/sqldelight-gradle-plugin/src/test/kotlin-mpp-1.3.20/settings.gradle
+++ b/sqldelight-gradle-plugin/src/test/kotlin-mpp-1.3.20/settings.gradle
@@ -1,1 +1,0 @@
-enableFeaturePreview('GRADLE_METADATA')

--- a/sqldelight-gradle-plugin/src/test/kotlin-mpp-configure-on-demand/settings.gradle
+++ b/sqldelight-gradle-plugin/src/test/kotlin-mpp-configure-on-demand/settings.gradle
@@ -1,1 +1,0 @@
-enableFeaturePreview('GRADLE_METADATA')

--- a/sqldelight-gradle-plugin/src/test/kotlin-mpp/settings.gradle
+++ b/sqldelight-gradle-plugin/src/test/kotlin-mpp/settings.gradle
@@ -1,1 +1,0 @@
-enableFeaturePreview('GRADLE_METADATA')

--- a/sqldelight-gradle-plugin/src/test/multi-module/settings.gradle
+++ b/sqldelight-gradle-plugin/src/test/multi-module/settings.gradle
@@ -1,5 +1,3 @@
-enableFeaturePreview('GRADLE_METADATA')
-
 include ':AndroidProject'
 include ':MultiplatformProject'
 include ':ProjectA'


### PR DESCRIPTION
It's a no-op since Gradle 6 and removed in Gradle 7.

The instructions can be removed from the multiplatform docs since it's enabled from Gradle 6 onwards and Gradle 6 is required for MPP since Kotlin 1.4.