### PR TITLE
Switch to using an output directory per compilation unit

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightFileIndex.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightFileIndex.kt
@@ -27,12 +27,6 @@ interface SqlDelightFileIndex {
   val isConfigured: Boolean
 
   /**
-   * @return the path to the output directory generated code should be placed in, relative to
-   *   [contentRoot]
-   */
-  val outputDirectory: String
-
-  /**
    * @return The package name for the whole source set. This is equivalent to the package name
    * found in the manifest file for the current variant.
    */
@@ -60,6 +54,17 @@ interface SqlDelightFileIndex {
    * fixture's sqldelight directory.
    */
   fun packageName(file: SqlDelightFile): String
+
+  /**
+   * @return A list of output directory paths generated code should be placed in, relative to
+   *   [contentRoot], for the given [file].
+   */
+  fun outputDirectory(file: SqlDelightFile): List<String>
+
+  /**
+   * @return A list of all SQLDelight output directories.
+   */
+  fun outputDirectories(): List<String>
 
   /**
    * @return The source roots of sqldelight files for [file].

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightPropertiesFile.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightPropertiesFile.kt
@@ -30,7 +30,6 @@ interface SqlDelightDatabaseProperties : Serializable {
   val dependencies: List<SqlDelightDatabaseName>
   val dialectPresetName: String
   val deriveSchemaFromMigrations: Boolean
-  val outputDirectoryFile: File
   val rootDirectory: File
 }
 
@@ -48,6 +47,7 @@ val SqlDelightDatabaseProperties.dialectPreset: DialectPreset
 interface SqlDelightCompilationUnit : Serializable {
   val name: String
   val sourceFolders: List<SqlDelightSourceFolder>
+  val outputDirectoryFile: File
 }
 
 interface SqlDelightSourceFolder : Serializable {

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/SqlDelightCompiler.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/SqlDelightCompiler.kt
@@ -70,11 +70,10 @@ object SqlDelightCompiler {
   ) {
     val fileIndex = SqlDelightFileIndex.getInstance(module)
     val packageName = "${fileIndex.packageName}.$implementationFolder"
-    val outputDirectory = "${fileIndex.outputDirectory}/${packageName.replace(".", "/")}"
     val databaseImplementationType = DatabaseGenerator(module, sourceFile).type(packageName)
     val exposer = DatabaseExposerGenerator(databaseImplementationType, fileIndex)
 
-    FileSpec.builder(packageName, databaseImplementationType.name!!)
+    val fileSpec = FileSpec.builder(packageName, databaseImplementationType.name!!)
       .addProperty(exposer.exposedSchema())
       .addFunction(exposer.exposedConstructor())
       .addType(databaseImplementationType)
@@ -87,7 +86,11 @@ object SqlDelightCompiler {
           }
       }
       .build()
-      .writeToAndClose(output("$outputDirectory/${databaseImplementationType.name}.kt"))
+
+    fileIndex.outputDirectory(sourceFile).forEach { outputDirectory ->
+      val packageDirectory = "$outputDirectory/${packageName.replace(".", "/")}"
+      fileSpec.writeToAndClose(output("$packageDirectory/${databaseImplementationType.name}.kt"))
+    }
   }
 
   private fun writeQueryWrapperInterface(
@@ -98,9 +101,8 @@ object SqlDelightCompiler {
   ) {
     val fileIndex = SqlDelightFileIndex.getInstance(module)
     val packageName = fileIndex.packageName
-    val outputDirectory = "${fileIndex.outputDirectory}/${packageName.replace(".", "/")}"
     val queryWrapperType = DatabaseGenerator(module, sourceFile).interfaceType()
-    FileSpec.builder(packageName, queryWrapperType.name!!)
+    val fileSpec = FileSpec.builder(packageName, queryWrapperType.name!!)
       // TODO: Remove these when kotlinpoet supports top level types.
       .addImport("$packageName.$implementationFolder", "newInstance", "schema")
       .apply {
@@ -111,7 +113,11 @@ object SqlDelightCompiler {
       }
       .addType(queryWrapperType)
       .build()
-      .writeToAndClose(output("$outputDirectory/${queryWrapperType.name}.kt"))
+
+    fileIndex.outputDirectory(sourceFile).forEach { outputDirectory ->
+      val packageDirectory = "$outputDirectory/${packageName.replace(".", "/")}"
+      fileSpec.writeToAndClose(output("$packageDirectory/${queryWrapperType.name}.kt"))
+    }
   }
 
   internal fun writeTableInterfaces(
@@ -129,7 +135,7 @@ object SqlDelightCompiler {
         return@forEach
       }
 
-      FileSpec.builder(packageName, allocateName(query.tableName))
+      val fileSpec = FileSpec.builder(packageName, allocateName(query.tableName))
         .apply {
           tryWithElement(statement) {
             val generator = TableInterfaceGenerator(query)
@@ -137,7 +143,10 @@ object SqlDelightCompiler {
           }
         }
         .build()
-        .writeToAndClose(output("${statement.sqFile().generatedDir}/${allocateName(query.tableName).capitalize()}.kt"))
+
+      statement.sqFile().generatedDirectories?.forEach { directory ->
+        fileSpec.writeToAndClose(output("$directory/${allocateName(query.tableName).capitalize()}.kt"))
+      }
     }
   }
 
@@ -155,10 +164,13 @@ object SqlDelightCompiler {
   ) {
     val packageName = file.packageName ?: return
     val queriesType = QueriesTypeGenerator(module, file).interfaceType()
-    FileSpec.builder(packageName, file.queriesName.capitalize())
+    val fileSpec = FileSpec.builder(packageName, file.queriesName.capitalize())
       .addType(queriesType)
       .build()
-      .writeToAndClose(output("${file.generatedDir}/${queriesType.name}.kt"))
+
+    file.generatedDirectories?.forEach { directory ->
+      fileSpec.writeToAndClose(output("$directory/${queriesType.name}.kt"))
+    }
   }
 
   internal fun allocateName(namedElement: NamedElement): String {
@@ -169,7 +181,7 @@ object SqlDelightCompiler {
     val packageName = file.packageName ?: return
     return filter { tryWithElement(it.select) { it.needsInterface() } }
       .forEach { namedQuery ->
-        FileSpec.builder(packageName, namedQuery.name)
+        val fileSpec = FileSpec.builder(packageName, namedQuery.name)
           .apply {
             tryWithElement(namedQuery.select) {
               val generator = QueryInterfaceGenerator(namedQuery)
@@ -177,7 +189,10 @@ object SqlDelightCompiler {
             }
           }
           .build()
-          .writeToAndClose(output("${file.generatedDir}/${namedQuery.name.capitalize()}.kt"))
+
+        file.generatedDirectories?.forEach { directory ->
+          fileSpec.writeToAndClose(output("$directory/${namedQuery.name.capitalize()}.kt"))
+        }
       }
   }
 

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/SqlDelightFile.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/SqlDelightFile.kt
@@ -17,10 +17,12 @@ abstract class SqlDelightFile(
   protected val module: Module?
     get() = SqlDelightProjectService.getInstance(project).module(requireNotNull(virtualFile, { "Null virtualFile" }))
 
-  val generatedDir by lazy {
+  val generatedDirectories by lazy {
     val packageName = packageName ?: return@lazy null
     val module = module ?: return@lazy null
-    "${SqlDelightFileIndex.getInstance(module).outputDirectory}/${packageName.replace('.', '/')}"
+    SqlDelightFileIndex.getInstance(module).outputDirectory(this).map { outputDirectory ->
+      "$outputDirectory/${packageName.replace('.', '/')}"
+    }
   }
 
   internal val dialect

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/GenerateSchemaTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/GenerateSchemaTask.kt
@@ -1,18 +1,18 @@
 package com.squareup.sqldelight.gradle
 
 import com.squareup.sqldelight.VERSION
+import com.squareup.sqldelight.core.SqlDelightCompilationUnit
 import com.squareup.sqldelight.core.SqlDelightDatabaseProperties
 import com.squareup.sqldelight.core.SqlDelightEnvironment
 import com.squareup.sqldelight.core.lang.SqlDelightQueriesFile
 import com.squareup.sqldelight.core.lang.util.forInitializationStatements
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileTree
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -36,19 +36,19 @@ abstract class GenerateSchemaTask : SqlDelightWorkerTask() {
 
   @Input val projectName: Property<String> = project.objects.property(String::class.java)
 
-  @Internal lateinit var sourceFolders: Iterable<File>
-  @Input lateinit var properties: SqlDelightDatabaseProperties
+  @Nested lateinit var properties: SqlDelightDatabasePropertiesImpl
+  @Nested lateinit var compilationUnit: SqlDelightCompilationUnitImpl
 
   @Input var verifyMigrations: Boolean = false
 
   @TaskAction
   fun generateSchemaFile() {
     workQueue().submit(GenerateSchema::class.java) {
-      it.sourceFolders.set(sourceFolders.filter(File::exists))
       it.outputDirectory.set(outputDirectory)
       it.moduleName.set(projectName)
       it.properties.set(properties)
       it.verifyMigrations.set(verifyMigrations)
+      it.compilationUnit.set(compilationUnit)
     }
   }
 
@@ -60,21 +60,26 @@ abstract class GenerateSchemaTask : SqlDelightWorkerTask() {
   }
 
   interface GenerateSchemaWorkParameters : WorkParameters {
-    val sourceFolders: ListProperty<File>
     val outputDirectory: DirectoryProperty
     val moduleName: Property<String>
     val properties: Property<SqlDelightDatabaseProperties>
+    val compilationUnit: Property<SqlDelightCompilationUnit>
     val verifyMigrations: Property<Boolean>
   }
 
   abstract class GenerateSchema : WorkAction<GenerateSchemaWorkParameters> {
+
+    private val sourceFolders: List<File>
+      get() = parameters.compilationUnit.get().sourceFolders.map { it.folder }
+
     override fun execute() {
       val environment = SqlDelightEnvironment(
-        sourceFolders = parameters.sourceFolders.get(),
+        sourceFolders = sourceFolders.filter { it.exists() },
         dependencyFolders = emptyList(),
         moduleName = parameters.moduleName.get(),
         properties = parameters.properties.get(),
-        verifyMigrations = parameters.verifyMigrations.get()
+        verifyMigrations = parameters.verifyMigrations.get(),
+        compilationUnit = parameters.compilationUnit.get(),
       )
 
       var maxVersion = 1

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/PropertiesImpl.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/PropertiesImpl.kt
@@ -22,9 +22,7 @@ data class SqlDelightDatabasePropertiesImpl(
   @Nested override val dependencies: List<SqlDelightDatabaseNameImpl>,
   @Input override val dialectPresetName: String = DialectPreset.SQLITE_3_18.name,
   @Input override val deriveSchemaFromMigrations: Boolean = false,
-  // Output directory is already cached [SqlDelightTask.outputDirectory].
-  @Internal override val outputDirectoryFile: File,
-  // Only useed by intellij plugin to help with resolution.
+  // Only used by intellij plugin to help with resolution.
   @Internal override val rootDirectory: File
 ) : SqlDelightDatabaseProperties
 
@@ -35,7 +33,9 @@ data class SqlDelightDatabaseNameImpl(
 
 data class SqlDelightCompilationUnitImpl(
   @Input override val name: String,
-  @Nested override val sourceFolders: List<SqlDelightSourceFolderImpl>
+  @Nested override val sourceFolders: List<SqlDelightSourceFolderImpl>,
+  // Output directory is already cached [SqlDelightTask.outputDirectory].
+  @Internal override val outputDirectoryFile: File,
 ) : SqlDelightCompilationUnit
 
 data class SqlDelightSourceFolderImpl(

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightDatabase.kt
@@ -71,10 +71,10 @@ class SqlDelightDatabase(
         compilationUnits = sources.map { source ->
           SqlDelightCompilationUnitImpl(
             name = source.name,
-            sourceFolders = sourceFolders(source).sortedBy { it.folder.absolutePath }
+            sourceFolders = sourceFolders(source).sortedBy { it.folder.absolutePath },
+            outputDirectoryFile = generatedSourcesDirectory,
           )
         },
-        outputDirectoryFile = generatedSourcesDirectory,
         rootDirectory = project.projectDir,
         className = name,
         dependencies = dependencies.map { SqlDelightDatabaseNameImpl(it.packageName!!, it.name) },
@@ -134,8 +134,7 @@ class SqlDelightDatabase(
       val task = project.tasks.register("generate${source.name.capitalize()}${name}Interface", SqlDelightTask::class.java) {
         it.projectName.set(project.name)
         it.properties = getProperties()
-        it.sourceFolders = sourceFiles.files
-        it.dependencySourceFolders = dependencyFiles.files
+        it.compilationUnit = getProperties().compilationUnits.single { it.name == source.name }
         it.outputDirectory = generatedSourcesDirectory
         it.source(sourceFiles + dependencyFiles)
         it.include("**${File.separatorChar}*.${SqlDelightFileType.defaultExtension}")
@@ -167,7 +166,7 @@ class SqlDelightDatabase(
     val verifyMigrationTask =
       project.tasks.register("verify${source.name.capitalize()}${name}Migration", VerifyMigrationTask::class.java) {
         it.projectName.set(project.name)
-        it.sourceFolders = sourceSet
+        it.compilationUnit = getProperties().compilationUnits.single { it.name == source.name }
         it.source(sourceSet)
         it.include("**${File.separatorChar}*.${SqlDelightFileType.defaultExtension}")
         it.include("**${File.separatorChar}*.${MigrationFileType.defaultExtension}")
@@ -181,7 +180,7 @@ class SqlDelightDatabase(
     if (schemaOutputDirectory != null) {
       project.tasks.register("generate${source.name.capitalize()}${name}Schema", GenerateSchemaTask::class.java) {
         it.projectName.set(project.name)
-        it.sourceFolders = sourceSet
+        it.compilationUnit = getProperties().compilationUnits.single { it.name == source.name }
         it.outputDirectory = schemaOutputDirectory
         it.source(sourceSet)
         it.include("**${File.separatorChar}*.${SqlDelightFileType.defaultExtension}")
@@ -206,7 +205,7 @@ class SqlDelightDatabase(
   ) {
     project.tasks.register("generate${source.name.capitalize()}${name}Migrations", GenerateMigrationOutputTask::class.java) {
       it.projectName.set(project.name)
-      it.sourceFolders = sourceSet
+      it.compilationUnit = getProperties().compilationUnits.single { it.name == source.name }
       it.source(sourceSet)
       it.include("**${File.separatorChar}*.${MigrationFileType.defaultExtension}")
       it.migrationOutputExtension = migrationOutputFileFormat

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/TemporaryFixture.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/TemporaryFixture.kt
@@ -63,7 +63,8 @@ internal fun properties(fixtureRoot: File): SqlDelightPropertiesFileImpl? {
                 folder = it.folder,
                 dependency = it.dependency
               )
-            }
+            },
+            outputDirectoryFile = it.outputDirectoryFile,
           )
         },
         className = it.className,
@@ -75,7 +76,6 @@ internal fun properties(fixtureRoot: File): SqlDelightPropertiesFileImpl? {
         },
         dialectPresetName = it.dialectPresetName,
         deriveSchemaFromMigrations = it.deriveSchemaFromMigrations,
-        outputDirectoryFile = it.outputDirectoryFile,
         rootDirectory = it.rootDirectory
       )
     }

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/TestUtil.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/TestUtil.kt
@@ -17,8 +17,7 @@ internal fun SqlDelightPropertiesFileImpl.withInvariantPathSeparators(): SqlDeli
 
 internal fun SqlDelightDatabasePropertiesImpl.withInvariantPathSeparators(): SqlDelightDatabasePropertiesImpl {
   return copy(
-    compilationUnits = compilationUnits.map { it.withInvariantPathSeparators() },
-    outputDirectoryFile = File(outputDirectoryFile.path.withInvariantPathSeparators())
+    compilationUnits = compilationUnits.map { it.withInvariantPathSeparators() }
   )
 }
 
@@ -29,7 +28,10 @@ internal fun SqlDelightDatabasePropertiesImpl.withSortedCompilationUnits(): SqlD
 }
 
 private fun SqlDelightCompilationUnitImpl.withInvariantPathSeparators(): SqlDelightCompilationUnitImpl {
-  return copy(sourceFolders = sourceFolders.map { it.withInvariantPathSeparators() })
+  return copy(
+    sourceFolders = sourceFolders.map { it.withInvariantPathSeparators() },
+    outputDirectoryFile = File(outputDirectoryFile.path.withInvariantPathSeparators()),
+  )
 }
 
 private fun SqlDelightCompilationUnitImpl.withSortedSourceFolders(): SqlDelightCompilationUnitImpl {

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/CompilationUnitTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/CompilationUnitTests.kt
@@ -43,13 +43,11 @@ class CompilationUnitTests {
         val database = properties.databases[0]
         assertThat(database.className).isEqualTo("CommonDb")
         assertThat(database.packageName).isEqualTo("com.sample")
-        assertThat(database.outputDirectoryFile).isEqualTo(
-          File(fixtureRoot, "build/generated/sqldelight/code/CommonDb")
-        )
         assertThat(database.compilationUnits).containsExactly(
           SqlDelightCompilationUnitImpl(
             name = "main",
-            sourceFolders = listOf(SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false))
+            sourceFolders = listOf(SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false)),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb")
           )
         )
       }
@@ -93,11 +91,11 @@ class CompilationUnitTests {
           SqlDelightDatabasePropertiesImpl(
             className = "CommonDb",
             packageName = "com.sample",
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
             compilationUnits = listOf(
               SqlDelightCompilationUnitImpl(
                 name = "main",
-                sourceFolders = listOf(SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false))
+                sourceFolders = listOf(SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false)),
+                outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
               )
             ),
             dependencies = emptyList(),
@@ -107,14 +105,14 @@ class CompilationUnitTests {
           SqlDelightDatabasePropertiesImpl(
             className = "OtherDb",
             packageName = "com.sample.otherdb",
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/OtherDb"),
             compilationUnits = listOf(
               SqlDelightCompilationUnitImpl(
                 name = "main",
                 sourceFolders = listOf(
                   SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/otherdb"), false),
-                  SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false)
-                )
+                  SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false),
+                ),
+                outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/OtherDb"),
               )
             ),
             dependencies = emptyList(),
@@ -168,53 +166,59 @@ class CompilationUnitTests {
         val database = properties.databases[0]
         assertThat(database.className).isEqualTo("CommonDb")
         assertThat(database.packageName).isEqualTo("com.sample")
-        assertThat(database.outputDirectoryFile).isEqualTo(File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"))
         assertThat(database.compilationUnits).containsExactly(
           SqlDelightCompilationUnitImpl(
             name = "jvmMain",
             sourceFolders = listOf(
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/jvmMain/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb")
           ),
           SqlDelightCompilationUnitImpl(
             name = "jsMain",
             sourceFolders = listOf(
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/jsMain/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb")
           ),
           SqlDelightCompilationUnitImpl(
             name = "iosArm32Main",
             sourceFolders = listOf(
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/iosArm32Main/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb")
           ),
           SqlDelightCompilationUnitImpl(
             name = "iosArm64Main",
             sourceFolders = listOf(
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/iosArm64Main/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb")
           ),
           SqlDelightCompilationUnitImpl(
             name = "iosX64Main",
             sourceFolders = listOf(
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/iosX64Main/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb")
           ),
           SqlDelightCompilationUnitImpl(
             name = "macosX64Main",
             sourceFolders = listOf(
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/macosX64Main/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb")
           ),
           SqlDelightCompilationUnitImpl(
             name = "metadataMain",
-            sourceFolders = listOf(SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false))
+            sourceFolders = listOf(SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb")
           )
         )
       }
@@ -289,7 +293,6 @@ class CompilationUnitTests {
         val database = properties.databases[0]
         assertThat(database.className).isEqualTo("CommonDb")
         assertThat(database.packageName).isEqualTo("com.sample")
-        assertThat(database.outputDirectoryFile).isEqualTo(File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"))
         assertThat(database.compilationUnits).containsExactly(
           SqlDelightCompilationUnitImpl(
             name = "androidLibMinApi21DemoDebug",
@@ -301,7 +304,8 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi21Demo/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi21DemoDebug/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "androidLibMinApi21DemoRelease",
@@ -313,7 +317,8 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi21DemoRelease/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibRelease/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "androidLibMinApi21DemoSqldelight",
@@ -328,7 +333,8 @@ class CompilationUnitTests {
               ),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibSqldelight/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "androidLibMinApi21FullDebug",
@@ -340,7 +346,8 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi21Full/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi21FullDebug/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "androidLibMinApi21FullRelease",
@@ -352,7 +359,8 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi21FullRelease/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibRelease/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "androidLibMinApi21FullSqldelight",
@@ -367,7 +375,8 @@ class CompilationUnitTests {
               ),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibSqldelight/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "androidLibMinApi23DemoDebug",
@@ -379,7 +388,8 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi23Demo/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi23DemoDebug/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "androidLibMinApi23DemoRelease",
@@ -391,7 +401,8 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi23DemoRelease/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibRelease/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "androidLibMinApi23DemoSqldelight",
@@ -406,7 +417,8 @@ class CompilationUnitTests {
               ),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibSqldelight/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "androidLibMinApi23FullDebug",
@@ -418,7 +430,8 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi23Full/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi23FullDebug/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "androidLibMinApi23FullRelease",
@@ -430,7 +443,8 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi23FullRelease/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibRelease/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "androidLibMinApi23FullSqldelight",
@@ -445,18 +459,21 @@ class CompilationUnitTests {
               ),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibSqldelight/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "iosX64Main",
             sourceFolders = listOf(
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/iosX64Main/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "metadataMain",
-            sourceFolders = listOf(SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false))
+            sourceFolders = listOf(SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           )
         )
       }
@@ -525,7 +542,6 @@ class CompilationUnitTests {
         val database = properties.databases[0]
         assertThat(database.className).isEqualTo("CommonDb")
         assertThat(database.packageName).isEqualTo("com.sample")
-        assertThat(database.outputDirectoryFile).isEqualTo(File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"))
         assertThat(database.compilationUnits).containsExactly(
           SqlDelightCompilationUnitImpl(
             name = "minApi23DemoDebug",
@@ -536,7 +552,8 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23Demo/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23DemoDebug/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "minApi23DemoRelease",
@@ -547,7 +564,8 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23Demo/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23DemoRelease/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/release/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "minApi23DemoSqldelight",
@@ -558,7 +576,8 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23Demo/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23DemoSqldelight/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/sqldelight/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "minApi23FullDebug",
@@ -569,7 +588,8 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23Full/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23FullDebug/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "minApi23FullRelease",
@@ -580,7 +600,8 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23Full/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23FullRelease/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/release/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "minApi23FullSqldelight",
@@ -591,7 +612,8 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23Full/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23FullSqldelight/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/sqldelight/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "minApi21DemoDebug",
@@ -602,7 +624,8 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21Demo/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21DemoDebug/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "minApi21DemoRelease",
@@ -613,7 +636,8 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21Demo/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21DemoRelease/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/release/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "minApi21DemoSqldelight",
@@ -624,7 +648,8 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21Demo/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21DemoSqldelight/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/sqldelight/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "minApi21FullDebug",
@@ -635,7 +660,8 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21Full/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21FullDebug/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "minApi21FullRelease",
@@ -646,7 +672,8 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21Full/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21FullRelease/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/release/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "minApi21FullSqldelight",
@@ -657,7 +684,8 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21Full/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21FullSqldelight/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/sqldelight/sqldelight"), false)
-            )
+            ),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           )
         )
       }

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/MultiModuleTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/MultiModuleTests.kt
@@ -27,10 +27,10 @@ class MultiModuleTests {
     fixtureRoot = File(fixtureRoot, "ProjectA")
     val properties = properties(fixtureRoot)!!.databases.single().withInvariantPathSeparators()
     assertThat(properties.packageName).isEqualTo("com.example")
-    assertThat(properties.outputDirectoryFile).isEqualTo(File(fixtureRoot, "build/generated/sqldelight/code/Database"))
     assertThat(properties.compilationUnits).hasSize(1)
 
     with(properties.compilationUnits[0]) {
+      assertThat(outputDirectoryFile).isEqualTo(File(fixtureRoot, "build/generated/sqldelight/code/Database"))
       assertThat(sourceFolders).containsExactly(
         SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false),
         SqlDelightSourceFolderImpl(File(fixtureRoot, "../ProjectB/src/main/sqldelight"), true)
@@ -93,7 +93,6 @@ class MultiModuleTests {
     val properties = properties(fixtureRoot)!!.databases.single().withInvariantPathSeparators()
       .withSortedCompilationUnits()
     assertThat(properties.packageName).isEqualTo("com.sample.android")
-    assertThat(properties.outputDirectoryFile).isEqualTo(File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"))
     assertThat(properties.compilationUnits).containsExactly(
       SqlDelightCompilationUnitImpl(
         name = "minApi23Debug",
@@ -107,7 +106,8 @@ class MultiModuleTests {
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23Debug/sqldelight"), false)
-        )
+        ),
+        outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
       ),
       SqlDelightCompilationUnitImpl(
         name = "minApi23Release",
@@ -121,7 +121,8 @@ class MultiModuleTests {
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23Release/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/release/sqldelight"), false)
-        )
+        ),
+        outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
       ),
       SqlDelightCompilationUnitImpl(
         name = "minApi23Sqldelight",
@@ -135,7 +136,8 @@ class MultiModuleTests {
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23Sqldelight/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/sqldelight/sqldelight"), false)
-        )
+        ),
+        outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
       ),
       SqlDelightCompilationUnitImpl(
         name = "minApi21Debug",
@@ -149,7 +151,8 @@ class MultiModuleTests {
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21Debug/sqldelight"), false)
-        )
+        ),
+        outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
       ),
       SqlDelightCompilationUnitImpl(
         name = "minApi21Release",
@@ -163,7 +166,8 @@ class MultiModuleTests {
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21Release/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/release/sqldelight"), false)
-        )
+        ),
+        outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
       ),
       SqlDelightCompilationUnitImpl(
         name = "minApi21Sqldelight",
@@ -177,7 +181,8 @@ class MultiModuleTests {
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21Sqldelight/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/sqldelight/sqldelight"), false)
-        )
+        ),
+        outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
       )
     )
   }

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/PropertiesFileTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/PropertiesFileTest.kt
@@ -22,10 +22,10 @@ class PropertiesFileTest {
     // verify
     val properties = properties(fixtureRoot)!!.databases.single().withInvariantPathSeparators()
     assertThat(properties.packageName).isEqualTo("com.example")
-    assertThat(properties.outputDirectoryFile).isEqualTo(File(fixtureRoot, "build/generated/sqldelight/code/Database"))
     assertThat(properties.compilationUnits).hasSize(1)
 
     with(properties.compilationUnits[0]) {
+      assertThat(outputDirectoryFile).isEqualTo(File(fixtureRoot, "build/generated/sqldelight/code/Database"))
       assertThat(sourceFolders).containsExactly(
         SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false)
       )
@@ -91,7 +91,8 @@ class PropertiesFileTest {
             SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibDebug/sqldelight"), dependency = false),
             SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMain/sqldelight"), dependency = false),
             SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), dependency = false)
-          )
+          ),
+          outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CashDatabase"),
         ),
         SqlDelightCompilationUnitImpl(
           name = "androidLibRelease",
@@ -99,13 +100,15 @@ class PropertiesFileTest {
             SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMain/sqldelight"), dependency = false),
             SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibRelease/sqldelight"), dependency = false),
             SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), dependency = false)
-          )
+          ),
+          outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CashDatabase"),
         ),
         SqlDelightCompilationUnitImpl(
           name = "metadataMain",
           sourceFolders = listOf(
             SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), dependency = false)
-          )
+          ),
+          outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CashDatabase"),
         )
       )
     }

--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightFileIndexImpl.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightFileIndexImpl.kt
@@ -8,8 +8,6 @@ import com.squareup.sqldelight.core.lang.SqlDelightFile
 internal class SqlDelightFileIndexImpl : SqlDelightFileIndex {
   override val isConfigured
     get() = false
-  override val outputDirectory
-    get() = throw UnsupportedOperationException()
   override val packageName = ""
   override val className
     get() = throw UnsupportedOperationException()
@@ -18,6 +16,9 @@ internal class SqlDelightFileIndexImpl : SqlDelightFileIndex {
   override val dependencies: List<SqlDelightDatabaseName>
     get() = throw UnsupportedOperationException()
   override val deriveSchemaFromMigrations = false
+
+  override fun outputDirectory(file: SqlDelightFile) = throw UnsupportedOperationException()
+  override fun outputDirectories() = throw UnsupportedOperationException()
 
   override fun packageName(file: SqlDelightFile) = ""
   override fun sourceFolders(

--- a/sqldelight-idea-plugin/src/test/kotlin/com/squareup/sqldelight/intellij/SqlDelightFixtureTestCase.kt
+++ b/sqldelight-idea-plugin/src/test/kotlin/com/squareup/sqldelight/intellij/SqlDelightFixtureTestCase.kt
@@ -47,9 +47,11 @@ abstract class SqlDelightFixtureTestCase : LightJavaCodeInsightFixtureTestCase()
     override val className = "MyDatabase"
     override fun packageName(file: SqlDelightFile) = "com.example"
     override val contentRoot = module.rootManager.contentRoots.single()
-    override val outputDirectory = ""
     override val dependencies = emptyList<SqlDelightDatabaseName>()
     override val deriveSchemaFromMigrations = false
+
+    override fun outputDirectory(file: SqlDelightFile) = outputDirectories()
+    override fun outputDirectories() = listOf("")
 
     override fun sourceFolders(
       file: SqlDelightFile,

--- a/sqldelight-idea-plugin/src/test/kotlin/com/squareup/sqldelight/intellij/SqlDelightProjectTestCase.kt
+++ b/sqldelight-idea-plugin/src/test/kotlin/com/squareup/sqldelight/intellij/SqlDelightProjectTestCase.kt
@@ -43,12 +43,27 @@ abstract class SqlDelightProjectTestCase : LightJavaCodeInsightFixtureTestCase()
       className = "QueryWrapper",
       packageName = "com.example",
       compilationUnits = listOf(
-        SqlDelightCompilationUnitImpl("internalDebug", listOf(SqlDelightSourceFolderImpl(File(tempRoot.path, "src/main/sqldelight"), false), SqlDelightSourceFolderImpl(File(tempRoot.path, "src/internal/sqldelight"), false), SqlDelightSourceFolderImpl(File(tempRoot.path, "src/debug/sqldelight"), false), SqlDelightSourceFolderImpl(File(tempRoot.path, "src/internalDebug/sqldelight"), false))),
-        SqlDelightCompilationUnitImpl("internalRelease", listOf(SqlDelightSourceFolderImpl(File(tempRoot.path, "src/main/sqldelight"), false), SqlDelightSourceFolderImpl(File(tempRoot.path, "src/internal/sqldelight"), false), SqlDelightSourceFolderImpl(File(tempRoot.path, "src/release/sqldelight"), false), SqlDelightSourceFolderImpl(File(tempRoot.path, "src/internalRelease/sqldelight"), false))),
-        SqlDelightCompilationUnitImpl("productionDebug", listOf(SqlDelightSourceFolderImpl(File(tempRoot.path, "src/main/sqldelight"), false), SqlDelightSourceFolderImpl(File(tempRoot.path, "src/production/sqldelight"), false), SqlDelightSourceFolderImpl(File(tempRoot.path, "src/debug/sqldelight"), false), SqlDelightSourceFolderImpl(File(tempRoot.path, "src/productionDebug/sqldelight"), false))),
-        SqlDelightCompilationUnitImpl("productionRelease", listOf(SqlDelightSourceFolderImpl(File(tempRoot.path, "src/main/sqldelight"), false), SqlDelightSourceFolderImpl(File(tempRoot.path, "src/production/sqldelight"), false), SqlDelightSourceFolderImpl(File(tempRoot.path, "src/release/sqldelight"), false), SqlDelightSourceFolderImpl(File(tempRoot.path, "src/productionRelease/sqldelight"), false)))
+        SqlDelightCompilationUnitImpl(
+          name = "internalDebug",
+          outputDirectoryFile = File(tempRoot.path, "build"),
+          sourceFolders = listOf(SqlDelightSourceFolderImpl(File(tempRoot.path, "src/main/sqldelight"), false), SqlDelightSourceFolderImpl(File(tempRoot.path, "src/internal/sqldelight"), false), SqlDelightSourceFolderImpl(File(tempRoot.path, "src/debug/sqldelight"), false), SqlDelightSourceFolderImpl(File(tempRoot.path, "src/internalDebug/sqldelight"), false))
+        ),
+        SqlDelightCompilationUnitImpl(
+          name = "internalRelease",
+          outputDirectoryFile = File(tempRoot.path, "build"),
+          sourceFolders = listOf(SqlDelightSourceFolderImpl(File(tempRoot.path, "src/main/sqldelight"), false), SqlDelightSourceFolderImpl(File(tempRoot.path, "src/internal/sqldelight"), false), SqlDelightSourceFolderImpl(File(tempRoot.path, "src/release/sqldelight"), false), SqlDelightSourceFolderImpl(File(tempRoot.path, "src/internalRelease/sqldelight"), false))
+        ),
+        SqlDelightCompilationUnitImpl(
+          name = "productionDebug",
+          outputDirectoryFile = File(tempRoot.path, "build"),
+          sourceFolders = listOf(SqlDelightSourceFolderImpl(File(tempRoot.path, "src/main/sqldelight"), false), SqlDelightSourceFolderImpl(File(tempRoot.path, "src/production/sqldelight"), false), SqlDelightSourceFolderImpl(File(tempRoot.path, "src/debug/sqldelight"), false), SqlDelightSourceFolderImpl(File(tempRoot.path, "src/productionDebug/sqldelight"), false))
+        ),
+        SqlDelightCompilationUnitImpl(
+          name = "productionRelease",
+          outputDirectoryFile = File(tempRoot.path, "build"),
+          sourceFolders = listOf(SqlDelightSourceFolderImpl(File(tempRoot.path, "src/main/sqldelight"), false), SqlDelightSourceFolderImpl(File(tempRoot.path, "src/production/sqldelight"), false), SqlDelightSourceFolderImpl(File(tempRoot.path, "src/release/sqldelight"), false), SqlDelightSourceFolderImpl(File(tempRoot.path, "src/productionRelease/sqldelight"), false))
+        )
       ),
-      outputDirectoryFile = File(tempRoot.path, "build"),
       dependencies = emptyList(),
       dialectPresetName = DialectPreset.SQLITE_3_18.name,
       rootDirectory = File(tempRoot.path).absoluteFile,
@@ -63,7 +78,6 @@ abstract class SqlDelightProjectTestCase : LightJavaCodeInsightFixtureTestCase()
     override val dependencies: List<SqlDelightDatabaseName>,
     override val dialectPresetName: String,
     override val deriveSchemaFromMigrations: Boolean,
-    override val outputDirectoryFile: File,
     override val rootDirectory: File
   ) : SqlDelightDatabaseProperties
 
@@ -74,7 +88,8 @@ abstract class SqlDelightProjectTestCase : LightJavaCodeInsightFixtureTestCase()
 
   private data class SqlDelightCompilationUnitImpl(
     override val name: String,
-    override val sourceFolders: List<SqlDelightSourceFolder>
+    override val sourceFolders: List<SqlDelightSourceFolder>,
+    override val outputDirectoryFile: File,
   ) : SqlDelightCompilationUnit
 
   protected inline fun <reified T : PsiElement> searchForElement(text: String): Collection<T> {

--- a/test-util/src/main/kotlin/com/squareup/sqldelight/test/util/TestEnvironment.kt
+++ b/test-util/src/main/kotlin/com/squareup/sqldelight/test/util/TestEnvironment.kt
@@ -8,6 +8,7 @@ import com.squareup.sqldelight.core.SqlDelightCompilationUnit
 import com.squareup.sqldelight.core.SqlDelightDatabaseName
 import com.squareup.sqldelight.core.SqlDelightDatabaseProperties
 import com.squareup.sqldelight.core.SqlDelightEnvironment
+import com.squareup.sqldelight.core.SqlDelightSourceFolder
 import java.io.File
 
 internal class TestEnvironment(
@@ -30,6 +31,11 @@ internal class TestEnvironment(
     root: String,
     annotationHolder: SqlAnnotationHolder
   ): SqlDelightEnvironment {
+    val compilationUnit = object : SqlDelightCompilationUnit {
+      override val name = "test"
+      override val outputDirectoryFile = outputDirectory
+      override val sourceFolders = emptyList<SqlDelightSourceFolder>()
+    }
     val environment = SqlDelightEnvironment(
       sourceFolders = listOf(File(root)),
       dependencyFolders = emptyList(),
@@ -37,15 +43,15 @@ internal class TestEnvironment(
         override val packageName = "com.example"
         override val className = "TestDatabase"
         override val dependencies = emptyList<SqlDelightDatabaseName>()
-        override val compilationUnits = emptyList<SqlDelightCompilationUnit>()
-        override val outputDirectoryFile = outputDirectory
+        override val compilationUnits = listOf(compilationUnit)
         override val dialectPresetName = dialectPreset.name
         override val deriveSchemaFromMigrations = this@TestEnvironment.deriveSchemaFromMigrations
         override val rootDirectory = File(root)
       },
       verifyMigrations = true,
       // hyphen in the name tests that our module name sanitizing works correctly
-      moduleName = "test-module"
+      moduleName = "test-module",
+      compilationUnit = compilationUnit,
     )
     environment.annotate(annotationHolder)
     return environment


### PR DESCRIPTION
This does not have any behavior change yet in the codegen, every compilation unit still uses the same output directory, so this should pass all tests and still be broken, but it sets up the API to enable using multiple output directories.