### PR TITLE
Properly support android variants, and remove support for KMM target-specific sql

### DIFF
--- a/docs/multiplatform_sqlite/index.md
+++ b/docs/multiplatform_sqlite/index.md
@@ -2,7 +2,23 @@
 
 {% include 'common/index_gradle_database.md' %}
 
-{% include 'common/index_schema.md' %}
+Put your SQL statements in a `.sq` file under `src/commonMain/sqldelight`. Typically the first statement in the SQL file creates a table.
+
+```sql
+-- src/commonMain/sqldelight/com/example/sqldelight/hockey/data/Player.sq
+
+CREATE TABLE hockeyPlayer (
+  player_number INTEGER NOT NULL,
+  full_name TEXT NOT NULL
+);
+
+CREATE INDEX hockeyPlayer_full_name ON hockeyPlayer(full_name);
+
+INSERT INTO hockeyPlayer (player_number, full_name)
+VALUES (15, 'Ryan Getzlaf');
+```
+
+From this SQLDelight will generate a `Database` Kotlin class with an associated `Schema` object that can be used to create your database and run your statements on it. Doing this also requires a driver, which SQLDelight provides implementations of:
 
 ```groovy
 kotlin {

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/kotlin/SourceRoots.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/kotlin/SourceRoots.kt
@@ -16,8 +16,8 @@ import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJvmAndroidCompilation
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinMetadataTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 /**
@@ -62,52 +62,40 @@ internal fun SqlDelightDatabase.sources(): List<Source> {
 }
 
 private fun KotlinMultiplatformExtension.sources(project: Project): List<Source> {
-  // TODO: Look at KotlinPlatformType when we get around to module dependencies and compatibility.
-  // We'll probably want to include that in the source so we can tell which source to rely on
-  // during dependency resolution.
-
-  return targets
-    .flatMap { target ->
-      if (target is KotlinAndroidTarget) {
-        val extension = project.extensions.getByType(BaseExtension::class.java)
-        return@flatMap extension.sources(project)
-          .map { source ->
-            val compilation = target.compilations.single { it.name == source.name }
-            return@map source.copy(
-              name = "${target.name}${source.name.capitalize()}",
-              sourceSets = source.sourceSets.map { "${target.name}${it.capitalize()}" } + "commonMain",
-              registerTaskDependency = { task ->
-                compilation.compileKotlinTask.dependsOn(task)
-              }
-            )
-          }
-      }
-      return@flatMap target.compilations.mapNotNull { compilation ->
-        if (compilation.name.endsWith(suffix = "Test", ignoreCase = true)) {
-          // TODO: If we can include these compilations as sqldelight compilation units, we solve
-          //  the testing problem. However there's no api to get the main compilation for a test
-          //  compilation, except for native where KotlinNativeCompilation has a
-          //  "friendCompilationName" which is the main compilation unit. There looks to be
-          //  nothing for the other compilation units, but we should revisit later to see if
-          //  theres a way to accomplish this.
-          return@mapNotNull null
-        }
-        Source(
-          type = target.platformType,
-          nativePresetName = (target as? KotlinNativeTarget)?.preset?.name,
-          name = "${target.name}${compilation.name.capitalize()}",
-          variantName = (compilation as? KotlinJvmAndroidCompilation)?.name,
-          sourceDirectorySet = compilation.defaultSourceSet.kotlin,
-          sourceSets = compilation.allKotlinSourceSets.map { it.name },
-          registerTaskDependency = { task ->
+  // For multiplatform we only support SQLDelight in commonMain - to support other source sets
+  // we would need to generate expect/actual SQLDelight code which at least right now doesn't
+  // seem like there is a use case for. However this code is capable of running on any Target type.
+  val target = targets.single { it is KotlinMetadataTarget }
+  return target.compilations.mapNotNull { compilation ->
+    if (compilation.name.endsWith(suffix = "Test", ignoreCase = true)) {
+      // TODO: If we can include these compilations as sqldelight compilation units, we solve
+      //  the testing problem. However there's no api to get the main compilation for a test
+      //  compilation, except for native where KotlinNativeCompilation has a
+      //  "friendCompilationName" which is the main compilation unit. There looks to be
+      //  nothing for the other compilation units, but we should revisit later to see if
+      //  theres a way to accomplish this.
+      return@mapNotNull null
+    }
+    val targetName = if (target is KotlinMetadataTarget) "common" else target.name
+    Source(
+      type = target.platformType,
+      nativePresetName = (target as? KotlinNativeTarget)?.preset?.name,
+      name = "$targetName${compilation.name.capitalize()}",
+      variantName = (compilation as? KotlinJvmAndroidCompilation)?.name,
+      sourceDirectorySet = compilation.defaultSourceSet.kotlin,
+      sourceSets = compilation.allKotlinSourceSets.map { it.name },
+      registerTaskDependency = { task ->
+        targets.forEach { target ->
+          target.compilations.forEach { compilation ->
             (target as? KotlinNativeTarget)?.binaries?.forEach {
               it.linkTask.dependsOn(task)
             }
             compilation.compileKotlinTask.dependsOn(task)
           }
-        )
+        }
       }
-    }
+    )
+  }
 }
 
 private fun BaseExtension.sources(project: Project): List<Source> {
@@ -165,7 +153,7 @@ internal data class Source(
 ) {
   fun closestMatch(sources: Collection<Source>): Source? {
     var matches = sources.filter {
-      type == it.type || (type == KotlinPlatformType.androidJvm && it.type == KotlinPlatformType.jvm)
+      type == it.type || (type == KotlinPlatformType.androidJvm && it.type == KotlinPlatformType.jvm) || it.type == KotlinPlatformType.common
     }
     if (matches.size <= 1) return matches.singleOrNull()
 

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/integrations/IntegrationTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/integrations/IntegrationTest.kt
@@ -21,7 +21,6 @@ import com.squareup.sqldelight.androidHome
 import com.squareup.sqldelight.assertions.FileSubject.Companion.assertThat
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.experimental.categories.Category
 import java.io.File
@@ -94,6 +93,7 @@ class IntegrationTest {
 
     // Create a clone of the project
     val clonedRoot = File("src/test/integration-clone")
+    clonedRoot.deleteRecursively()
     fixtureRoot.copyRecursively(clonedRoot)
     val settingsFile = File(clonedRoot, "settings.gradle")
     settingsFile.writeText(settingsFile.readText().replace("build-cache", "../integration/build-cache"))
@@ -241,7 +241,6 @@ class IntegrationTest {
 
   @Test
   @Category(Instrumentation::class)
-  @Ignore // https://github.com/cashapp/sqldelight/issues/1039
   fun integrationTestsAndroidVariants() {
     val androidHome = androidHome()
     val integrationRoot = File("src/test/integration-android-variants")

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/CompilationUnitTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/CompilationUnitTests.kt
@@ -168,55 +168,7 @@ class CompilationUnitTests {
         assertThat(database.packageName).isEqualTo("com.sample")
         assertThat(database.compilationUnits).containsExactly(
           SqlDelightCompilationUnitImpl(
-            name = "jvmMain",
-            sourceFolders = listOf(
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/jvmMain/sqldelight"), false)
-            ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb")
-          ),
-          SqlDelightCompilationUnitImpl(
-            name = "jsMain",
-            sourceFolders = listOf(
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/jsMain/sqldelight"), false)
-            ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb")
-          ),
-          SqlDelightCompilationUnitImpl(
-            name = "iosArm32Main",
-            sourceFolders = listOf(
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/iosArm32Main/sqldelight"), false)
-            ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb")
-          ),
-          SqlDelightCompilationUnitImpl(
-            name = "iosArm64Main",
-            sourceFolders = listOf(
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/iosArm64Main/sqldelight"), false)
-            ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb")
-          ),
-          SqlDelightCompilationUnitImpl(
-            name = "iosX64Main",
-            sourceFolders = listOf(
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/iosX64Main/sqldelight"), false)
-            ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb")
-          ),
-          SqlDelightCompilationUnitImpl(
-            name = "macosX64Main",
-            sourceFolders = listOf(
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/macosX64Main/sqldelight"), false)
-            ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb")
-          ),
-          SqlDelightCompilationUnitImpl(
-            name = "metadataMain",
+            name = "commonMain",
             sourceFolders = listOf(SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)),
             outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb")
           )
@@ -295,183 +247,7 @@ class CompilationUnitTests {
         assertThat(database.packageName).isEqualTo("com.sample")
         assertThat(database.compilationUnits).containsExactly(
           SqlDelightCompilationUnitImpl(
-            name = "androidLibMinApi21DemoDebug",
-            sourceFolders = listOf(
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibDebug/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibDemo/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMain/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi21/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi21Demo/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi21DemoDebug/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)
-            ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
-          ),
-          SqlDelightCompilationUnitImpl(
-            name = "androidLibMinApi21DemoRelease",
-            sourceFolders = listOf(
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibDemo/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMain/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi21/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi21Demo/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi21DemoRelease/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibRelease/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)
-            ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
-          ),
-          SqlDelightCompilationUnitImpl(
-            name = "androidLibMinApi21DemoSqldelight",
-            sourceFolders = listOf(
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibDemo/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMain/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi21/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi21Demo/sqldelight"), false),
-              SqlDelightSourceFolderImpl(
-                File(fixtureRoot, "src/androidLibMinApi21DemoSqldelight/sqldelight"),
-                false
-              ),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibSqldelight/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)
-            ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
-          ),
-          SqlDelightCompilationUnitImpl(
-            name = "androidLibMinApi21FullDebug",
-            sourceFolders = listOf(
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibDebug/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibFull/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMain/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi21/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi21Full/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi21FullDebug/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)
-            ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
-          ),
-          SqlDelightCompilationUnitImpl(
-            name = "androidLibMinApi21FullRelease",
-            sourceFolders = listOf(
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibFull/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMain/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi21/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi21Full/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi21FullRelease/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibRelease/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)
-            ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
-          ),
-          SqlDelightCompilationUnitImpl(
-            name = "androidLibMinApi21FullSqldelight",
-            sourceFolders = listOf(
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibFull/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMain/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi21/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi21Full/sqldelight"), false),
-              SqlDelightSourceFolderImpl(
-                File(fixtureRoot, "src/androidLibMinApi21FullSqldelight/sqldelight"),
-                false
-              ),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibSqldelight/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)
-            ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
-          ),
-          SqlDelightCompilationUnitImpl(
-            name = "androidLibMinApi23DemoDebug",
-            sourceFolders = listOf(
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibDebug/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibDemo/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMain/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi23/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi23Demo/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi23DemoDebug/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)
-            ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
-          ),
-          SqlDelightCompilationUnitImpl(
-            name = "androidLibMinApi23DemoRelease",
-            sourceFolders = listOf(
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibDemo/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMain/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi23/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi23Demo/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi23DemoRelease/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibRelease/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)
-            ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
-          ),
-          SqlDelightCompilationUnitImpl(
-            name = "androidLibMinApi23DemoSqldelight",
-            sourceFolders = listOf(
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibDemo/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMain/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi23/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi23Demo/sqldelight"), false),
-              SqlDelightSourceFolderImpl(
-                File(fixtureRoot, "src/androidLibMinApi23DemoSqldelight/sqldelight"),
-                false
-              ),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibSqldelight/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)
-            ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
-          ),
-          SqlDelightCompilationUnitImpl(
-            name = "androidLibMinApi23FullDebug",
-            sourceFolders = listOf(
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibDebug/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibFull/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMain/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi23/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi23Full/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi23FullDebug/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)
-            ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
-          ),
-          SqlDelightCompilationUnitImpl(
-            name = "androidLibMinApi23FullRelease",
-            sourceFolders = listOf(
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibFull/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMain/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi23/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi23Full/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi23FullRelease/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibRelease/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)
-            ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
-          ),
-          SqlDelightCompilationUnitImpl(
-            name = "androidLibMinApi23FullSqldelight",
-            sourceFolders = listOf(
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibFull/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMain/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi23/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMinApi23Full/sqldelight"), false),
-              SqlDelightSourceFolderImpl(
-                File(fixtureRoot, "src/androidLibMinApi23FullSqldelight/sqldelight"),
-                false
-              ),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibSqldelight/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)
-            ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
-          ),
-          SqlDelightCompilationUnitImpl(
-            name = "iosX64Main",
-            sourceFolders = listOf(
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false),
-              SqlDelightSourceFolderImpl(File(fixtureRoot, "src/iosX64Main/sqldelight"), false)
-            ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
-          ),
-          SqlDelightCompilationUnitImpl(
-            name = "metadataMain",
+            name = "commonMain",
             sourceFolders = listOf(SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)),
             outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
           )
@@ -553,7 +329,7 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23Demo/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23DemoDebug/sqldelight"), false)
             ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/minApi23DemoDebug"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "minApi23DemoRelease",
@@ -565,7 +341,7 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23DemoRelease/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/release/sqldelight"), false)
             ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/minApi23DemoRelease"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "minApi23DemoSqldelight",
@@ -577,7 +353,7 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23DemoSqldelight/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/sqldelight/sqldelight"), false)
             ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/minApi23DemoSqldelight"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "minApi23FullDebug",
@@ -589,7 +365,7 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23Full/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23FullDebug/sqldelight"), false)
             ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/minApi23FullDebug"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "minApi23FullRelease",
@@ -601,7 +377,7 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23FullRelease/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/release/sqldelight"), false)
             ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/minApi23FullRelease"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "minApi23FullSqldelight",
@@ -613,7 +389,7 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23FullSqldelight/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/sqldelight/sqldelight"), false)
             ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/minApi23FullSqldelight"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "minApi21DemoDebug",
@@ -625,7 +401,7 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21Demo/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21DemoDebug/sqldelight"), false)
             ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/minApi21DemoDebug"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "minApi21DemoRelease",
@@ -637,7 +413,7 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21DemoRelease/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/release/sqldelight"), false)
             ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/minApi21DemoRelease"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "minApi21DemoSqldelight",
@@ -649,7 +425,7 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21DemoSqldelight/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/sqldelight/sqldelight"), false)
             ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/minApi21DemoSqldelight"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "minApi21FullDebug",
@@ -661,7 +437,7 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21Full/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21FullDebug/sqldelight"), false)
             ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/minApi21FullDebug"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "minApi21FullRelease",
@@ -673,7 +449,7 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21FullRelease/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/release/sqldelight"), false)
             ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/minApi21FullRelease"),
           ),
           SqlDelightCompilationUnitImpl(
             name = "minApi21FullSqldelight",
@@ -685,7 +461,7 @@ class CompilationUnitTests {
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21FullSqldelight/sqldelight"), false),
               SqlDelightSourceFolderImpl(File(fixtureRoot, "src/sqldelight/sqldelight"), false)
             ),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/minApi21FullSqldelight"),
           )
         )
       }

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/MultiModuleTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/MultiModuleTests.kt
@@ -97,92 +97,68 @@ class MultiModuleTests {
       SqlDelightCompilationUnitImpl(
         name = "minApi23Debug",
         sourceFolders = listOf(
-          SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/androidLibDebug/sqldelight"), true),
-          SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/androidLibMain/sqldelight"), true),
-          SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/androidLibMinApi23/sqldelight"), true),
-          SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/androidLibMinApi23Debug/sqldelight"), true),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/commonMain/sqldelight"), true),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/debug/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23Debug/sqldelight"), false)
         ),
-        outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
+        outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/minApi23Debug"),
       ),
       SqlDelightCompilationUnitImpl(
         name = "minApi23Release",
         sourceFolders = listOf(
-          SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/androidLibMain/sqldelight"), true),
-          SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/androidLibMinApi23/sqldelight"), true),
-          SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/androidLibMinApi23Release/sqldelight"), true),
-          SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/androidLibRelease/sqldelight"), true),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/commonMain/sqldelight"), true),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23Release/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/release/sqldelight"), false)
         ),
-        outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
+        outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/minApi23Release"),
       ),
       SqlDelightCompilationUnitImpl(
         name = "minApi23Sqldelight",
         sourceFolders = listOf(
-          SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/androidLibMain/sqldelight"), true),
-          SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/androidLibMinApi23/sqldelight"), true),
-          SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/androidLibMinApi23Sqldelight/sqldelight"), true),
-          SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/androidLibSqldelight/sqldelight"), true),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/commonMain/sqldelight"), true),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi23Sqldelight/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/sqldelight/sqldelight"), false)
         ),
-        outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
+        outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/minApi23Sqldelight"),
       ),
       SqlDelightCompilationUnitImpl(
         name = "minApi21Debug",
         sourceFolders = listOf(
-          SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/androidLibDebug/sqldelight"), true),
-          SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/androidLibMain/sqldelight"), true),
-          SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/androidLibMinApi21/sqldelight"), true),
-          SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/androidLibMinApi21Debug/sqldelight"), true),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/commonMain/sqldelight"), true),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/debug/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21Debug/sqldelight"), false)
         ),
-        outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
+        outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/minApi21Debug"),
       ),
       SqlDelightCompilationUnitImpl(
         name = "minApi21Release",
         sourceFolders = listOf(
-          SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/androidLibMain/sqldelight"), true),
-          SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/androidLibMinApi21/sqldelight"), true),
-          SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/androidLibMinApi21Release/sqldelight"), true),
-          SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/androidLibRelease/sqldelight"), true),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/commonMain/sqldelight"), true),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21Release/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/release/sqldelight"), false)
         ),
-        outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
+        outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/minApi21Release"),
       ),
       SqlDelightCompilationUnitImpl(
         name = "minApi21Sqldelight",
         sourceFolders = listOf(
-          SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/androidLibMain/sqldelight"), true),
-          SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/androidLibMinApi21/sqldelight"), true),
-          SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/androidLibMinApi21Sqldelight/sqldelight"), true),
-          SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/androidLibSqldelight/sqldelight"), true),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "../MultiplatformProject/src/commonMain/sqldelight"), true),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/minApi21Sqldelight/sqldelight"), false),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/sqldelight/sqldelight"), false)
         ),
-        outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
+        outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/minApi21Sqldelight"),
       )
     )
   }

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/PluginTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/PluginTest.kt
@@ -58,7 +58,7 @@ class PluginTest {
       .withProjectDir(fixtureRoot)
 
     val result = runner
-      .withArguments("clean", "generateJvmMainDatabaseInterface", "--stacktrace")
+      .withArguments("clean", "generateCommonMainDatabaseInterface", "--stacktrace")
       .build()
     assertThat(result.output).contains("BUILD SUCCESSFUL")
 
@@ -81,7 +81,7 @@ class PluginTest {
     val result = runner
       .withArguments("clean", "compileKotlinJs", "--stacktrace")
       .build()
-    assertThat(result.output).contains("generateJsMainDatabaseInterface")
+    assertThat(result.output).contains("generateCommonMainDatabaseInterface")
     assertThat(buildDir.exists()).isTrue()
   }
 
@@ -97,7 +97,7 @@ class PluginTest {
     val result = runner
       .withArguments("clean", "compileKotlinJvm", "--stacktrace")
       .build()
-    assertThat(result.output).contains("generateJvmMainDatabaseInterface")
+    assertThat(result.output).contains("generateCommonMainDatabaseInterface")
     assertThat(buildDir.exists()).isTrue()
   }
 
@@ -114,7 +114,7 @@ class PluginTest {
     val result = runner
       .withArguments("clean", "compileKotlinJvm", "--stacktrace")
       .build()
-    assertThat(result.output).contains("generateJvmMainDatabaseInterface")
+    assertThat(result.output).contains("generateCommonMainDatabaseInterface")
     assertThat(buildDir.exists()).isTrue()
   }
 
@@ -131,14 +131,14 @@ class PluginTest {
       .withArguments("clean", "compileKotlinIosArm64", "--stacktrace")
       .forwardOutput()
       .build()
-    assertThat(result.output).contains("generateIosArm64MainDatabaseInterface")
+    assertThat(result.output).contains("generateCommonMainDatabaseInterface")
     assertThat(buildDir.exists()).isTrue()
 
     buildDir.delete()
     result = runner
       .withArguments("clean", "compileKotlinIosX64", "--stacktrace")
       .build()
-    assertThat(result.output).contains("generateIosX64MainDatabaseInterface")
+    assertThat(result.output).contains("generateCommonMainDatabaseInterface")
     assertThat(buildDir.exists()).isTrue()
   }
 
@@ -155,7 +155,7 @@ class PluginTest {
       .withArguments("clean", "compileKotlinIos", "--stacktrace")
       .forwardOutput()
       .build()
-    assertThat(result.output).contains("generateIosMainDatabaseInterface")
+    assertThat(result.output).contains("generateCommonMainDatabaseInterface")
     assertThat(buildDir.exists()).isTrue()
   }
 
@@ -172,14 +172,14 @@ class PluginTest {
       .withArguments("clean", "linkDebugFrameworkIosArm64", "--stacktrace")
       .forwardOutput()
       .build()
-    assertThat(result.output).contains("generateIosArm64MainDatabaseInterface")
+    assertThat(result.output).contains("generateCommonMainDatabaseInterface")
     assertThat(buildDir.exists()).isTrue()
 
     buildDir.delete()
     result = runner
       .withArguments("clean", "linkDebugFrameworkIosX64", "--stacktrace")
       .build()
-    assertThat(result.output).contains("generateIosX64MainDatabaseInterface")
+    assertThat(result.output).contains("generateCommonMainDatabaseInterface")
     assertThat(buildDir.exists()).isTrue()
   }
 

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/PropertiesFileTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/PropertiesFileTest.kt
@@ -86,25 +86,7 @@ class PropertiesFileTest {
       val database = properties().databases.single()
       assertThat(database.compilationUnits).containsExactly(
         SqlDelightCompilationUnitImpl(
-          name = "androidLibDebug",
-          sourceFolders = listOf(
-            SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibDebug/sqldelight"), dependency = false),
-            SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMain/sqldelight"), dependency = false),
-            SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), dependency = false)
-          ),
-          outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CashDatabase"),
-        ),
-        SqlDelightCompilationUnitImpl(
-          name = "androidLibRelease",
-          sourceFolders = listOf(
-            SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibMain/sqldelight"), dependency = false),
-            SqlDelightSourceFolderImpl(File(fixtureRoot, "src/androidLibRelease/sqldelight"), dependency = false),
-            SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), dependency = false)
-          ),
-          outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CashDatabase"),
-        ),
-        SqlDelightCompilationUnitImpl(
-          name = "metadataMain",
+          name = "commonMain",
           sourceFolders = listOf(
             SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), dependency = false)
           ),


### PR DESCRIPTION
Closes #1039

also unignores that test i made

We could also support target-specific sql but that would require using expect/actual. It also STILL wouldn't enable using test-specific sql which I feel like is a more sought-after feature, so i decided to just disable/document that we only support `commonMain` in KMM modules.

It's possible this breaks some folks builds. It was never really documented that you could do target specific sql, it was also terribly broken because of the output directory clobbering thing, so I don't think anyone was using that feature. If someone was, I would prefer a new issue to track and to give an even more thorough rethink of the dependency/sourceset aspects of sqldelight codegen, but at least this sequence of changes has improved the current state by enabling different output directories (and hopefully just straight up fixing android variants)