### PR TITLE
Sqliter 1.0.1 to make db ptr visible

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,7 +7,7 @@ ext.versions = [
     minSdk: 14,
     schemaCrawler: '14.16.04.01-java7',
     stately: '1.1.1',
-    sqliter: '1.0.0',
+    sqliter: '1.0.1',
     testhelp: '0.4.0',
     sqljs: '1.0.0',
     paging: '2.1.2',


### PR DESCRIPTION
Minor version bump that makes the native db connection pointer available for configuration on create.