### PR TITLE
Improve native transaction performance by avoiding freezing and shareable data structures when possible.

### DIFF
--- a/drivers/android-driver/src/test/java/com/squareup/sqldelight/android/AndroidTransacterTest.kt
+++ b/drivers/android-driver/src/test/java/com/squareup/sqldelight/android/AndroidTransacterTest.kt
@@ -1,15 +1,89 @@
 package com.squareup.sqldelight.android
 
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
+import com.squareup.sqldelight.Transacter
+import com.squareup.sqldelight.TransactionWithReturn
+import com.squareup.sqldelight.TransactionWithoutReturn
 import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.db.SqlDriver.Schema
 import com.squareup.sqldelight.driver.test.TransacterTest
+import org.junit.Assert.assertThrows
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.Semaphore
+import kotlin.concurrent.thread
 
 @RunWith(RobolectricTestRunner::class)
 class AndroidTransacterTest : TransacterTest() {
   override fun setupDatabase(schema: Schema): SqlDriver {
     return AndroidSqliteDriver(schema, getApplicationContext())
+  }
+
+  @Test fun `detect the afterRollback call has escaped the original transaction thread in transaction()`() {
+    assertChecksThreadConfinement<TransactionWithoutReturn>(
+      scope = { transaction(false, it) },
+      block = { afterRollback {} }
+    )
+  }
+
+  @Test fun `detect the afterCommit call has escaped the original transaction thread in transaction()`() {
+    assertChecksThreadConfinement<TransactionWithoutReturn>(
+      scope = { transaction(false, it) },
+      block = { afterCommit {} }
+    )
+  }
+
+  @Test fun `detect the rollback call has escaped the original transaction thread in transaction()`() {
+    assertChecksThreadConfinement<TransactionWithoutReturn>(
+      scope = { transaction(false, it) },
+      block = { rollback() }
+    )
+  }
+
+  @Test fun `detect the afterRollback call has escaped the original transaction thread in transactionWithReturn()`() {
+    assertChecksThreadConfinement<TransactionWithReturn<Unit>>(
+      scope = { transactionWithResult(false, it) },
+      block = { afterRollback {} }
+    )
+  }
+
+  @Test fun `detect the afterCommit call has escaped the original transaction thread in transactionWithReturn()`() {
+    assertChecksThreadConfinement<TransactionWithReturn<Unit>>(
+      scope = { transactionWithResult(false, it) },
+      block = { afterCommit {} }
+    )
+  }
+
+  @Test fun `detect the rollback call has escaped the original transaction thread in transactionWithReturn()`() {
+    assertChecksThreadConfinement<TransactionWithReturn<Unit>>(
+      scope = { transactionWithResult<Unit>(false, it) },
+      block = { rollback(Unit) }
+    )
+  }
+
+  private inline fun <T> assertChecksThreadConfinement(
+    crossinline scope: Transacter.(T.() -> Unit) -> Unit,
+    crossinline block: T.() -> Unit
+  ) {
+    lateinit var thread: Thread
+    var result: Result<Unit>? = null
+    val semaphore = Semaphore(0)
+
+    transacter.scope {
+      thread = thread {
+        result = runCatching {
+          this@scope.block()
+        }
+
+        semaphore.release()
+      }
+    }
+
+    semaphore.acquire()
+    thread.interrupt()
+    assertThrows(IllegalStateException::class.java) {
+      result!!.getOrThrow()
+    }
   }
 }

--- a/drivers/native-driver/src/nativeMain/kotlin/com/squareup/sqldelight/drivers/native/NativeSqlDatabase.kt
+++ b/drivers/native-driver/src/nativeMain/kotlin/com/squareup/sqldelight/drivers/native/NativeSqlDatabase.kt
@@ -17,10 +17,7 @@ import com.squareup.sqldelight.db.SqlPreparedStatement
 import com.squareup.sqldelight.drivers.native.util.PoolLock
 import com.squareup.sqldelight.drivers.native.util.nativeCache
 import kotlin.native.concurrent.AtomicInt
-import kotlin.native.concurrent.AtomicReference
-import kotlin.native.concurrent.WorkerBoundReference
 import kotlin.native.concurrent.ensureNeverFrozen
-import kotlin.native.concurrent.freeze
 
 sealed class ConnectionWrapper : SqlDriver {
   internal abstract fun <R> accessConnection(

--- a/drivers/native-driver/src/nativeMain/kotlin/com/squareup/sqldelight/drivers/native/NativeSqlDatabase.kt
+++ b/drivers/native-driver/src/nativeMain/kotlin/com/squareup/sqldelight/drivers/native/NativeSqlDatabase.kt
@@ -18,10 +18,8 @@ import com.squareup.sqldelight.drivers.native.util.PoolLock
 import com.squareup.sqldelight.drivers.native.util.nativeCache
 import kotlin.native.concurrent.AtomicInt
 import kotlin.native.concurrent.AtomicReference
-import kotlin.native.concurrent.Worker
 import kotlin.native.concurrent.WorkerBoundReference
 import kotlin.native.concurrent.ensureNeverFrozen
-import kotlin.native.concurrent.freeze
 
 sealed class ConnectionWrapper : SqlDriver {
   internal abstract fun <R> accessConnection(

--- a/runtime/src/commonMain/kotlin/com/squareup/sqldelight/Query.kt
+++ b/runtime/src/commonMain/kotlin/com/squareup/sqldelight/Query.kt
@@ -19,6 +19,7 @@ import com.squareup.sqldelight.db.SqlCursor
 import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.db.use
 import com.squareup.sqldelight.internal.QueryLock
+import com.squareup.sqldelight.internal.copyOnWriteList
 import com.squareup.sqldelight.internal.sharedSet
 import com.squareup.sqldelight.internal.withLock
 
@@ -85,7 +86,7 @@ abstract class Query<out RowType : Any>(
   val mapper: (SqlCursor) -> RowType
 ) {
   private val listenerLock = QueryLock()
-  private val listeners = sharedSet<Listener>()
+  private val listeners = copyOnWriteList<Listener>()
 
   /**
    * Notify listeners that their current result set is staled.

--- a/runtime/src/commonMain/kotlin/com/squareup/sqldelight/Query.kt
+++ b/runtime/src/commonMain/kotlin/com/squareup/sqldelight/Query.kt
@@ -20,7 +20,6 @@ import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.db.use
 import com.squareup.sqldelight.internal.QueryLock
 import com.squareup.sqldelight.internal.copyOnWriteList
-import com.squareup.sqldelight.internal.sharedSet
 import com.squareup.sqldelight.internal.withLock
 
 /**

--- a/runtime/src/commonMain/kotlin/com/squareup/sqldelight/Transacter.kt
+++ b/runtime/src/commonMain/kotlin/com/squareup/sqldelight/Transacter.kt
@@ -17,9 +17,6 @@ package com.squareup.sqldelight
 
 import com.squareup.sqldelight.Transacter.Transaction
 import com.squareup.sqldelight.db.SqlDriver
-import com.squareup.sqldelight.internal.Supplier
-
-private fun <T> Supplier<() -> T>.run() = invoke().invoke()
 
 interface TransactionCallbacks {
   fun afterCommit(function: () -> Unit)

--- a/runtime/src/commonMain/kotlin/com/squareup/sqldelight/Transacter.kt
+++ b/runtime/src/commonMain/kotlin/com/squareup/sqldelight/Transacter.kt
@@ -17,14 +17,7 @@ package com.squareup.sqldelight
 
 import com.squareup.sqldelight.Transacter.Transaction
 import com.squareup.sqldelight.db.SqlDriver
-import com.squareup.sqldelight.internal.Atomic
-import com.squareup.sqldelight.internal.AtomicBoolean
 import com.squareup.sqldelight.internal.Supplier
-import com.squareup.sqldelight.internal.getValue
-import com.squareup.sqldelight.internal.setValue
-import com.squareup.sqldelight.internal.sharedMap
-import com.squareup.sqldelight.internal.sharedSet
-import com.squareup.sqldelight.internal.threadLocalRef
 
 private fun <T> Supplier<() -> T>.run() = invoke().invoke()
 

--- a/runtime/src/commonMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
+++ b/runtime/src/commonMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
@@ -9,3 +9,5 @@ internal expect fun <T> copyOnWriteList(): MutableList<T>
 internal expect class QueryLock()
 
 internal expect inline fun <T> QueryLock.withLock(block: () -> T): T
+
+internal expect fun currentThreadId(): Long

--- a/runtime/src/commonMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
+++ b/runtime/src/commonMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
@@ -2,8 +2,6 @@ package com.squareup.sqldelight.internal
 
 import com.squareup.sqldelight.Query
 
-internal typealias Supplier<T> = () -> T
-
 expect fun copyOnWriteList(): MutableList<Query<*>>
 
 internal expect fun <T> copyOnWriteList(): MutableList<T>

--- a/runtime/src/commonMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
+++ b/runtime/src/commonMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
@@ -8,12 +8,6 @@ expect fun copyOnWriteList(): MutableList<Query<*>>
 
 internal expect fun <T> copyOnWriteList(): MutableList<T>
 
-internal expect fun <T> threadLocalRef(value: T): Supplier<T>
-
 internal expect class QueryLock()
 
 internal expect inline fun <T> QueryLock.withLock(block: () -> T): T
-
-internal expect fun <T> sharedSet(): MutableSet<T>
-
-internal expect fun <T, R> sharedMap(): MutableMap<T, R>

--- a/runtime/src/commonMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
+++ b/runtime/src/commonMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
@@ -6,6 +6,8 @@ internal typealias Supplier<T> = () -> T
 
 expect fun copyOnWriteList(): MutableList<Query<*>>
 
+internal expect fun <T> copyOnWriteList(): MutableList<T>
+
 internal expect fun <T> threadLocalRef(value: T): Supplier<T>
 
 internal expect class QueryLock()

--- a/runtime/src/jsMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
+++ b/runtime/src/jsMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
@@ -6,6 +6,10 @@ actual fun copyOnWriteList(): MutableList<Query<*>> {
   return mutableListOf()
 }
 
+internal actual fun <T> copyOnWriteList(): MutableList<T> {
+  return mutableListOf()
+}
+
 internal actual class QueryLock
 
 internal actual inline fun <T> QueryLock.withLock(block: () -> T): T {

--- a/runtime/src/jsMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
+++ b/runtime/src/jsMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
@@ -15,3 +15,5 @@ internal actual class QueryLock
 internal actual inline fun <T> QueryLock.withLock(block: () -> T): T {
   return block()
 }
+
+internal actual fun currentThreadId(): Long = 0

--- a/runtime/src/jsMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
+++ b/runtime/src/jsMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
@@ -15,11 +15,3 @@ internal actual class QueryLock
 internal actual inline fun <T> QueryLock.withLock(block: () -> T): T {
   return block()
 }
-
-internal actual fun <T> threadLocalRef(value: T): () -> T {
-  return { value }
-}
-
-internal actual fun <T> sharedSet(): MutableSet<T> = mutableSetOf()
-
-internal actual fun <T, R> sharedMap(): MutableMap<T, R> = mutableMapOf()

--- a/runtime/src/jvmMain/kotlin/com/squareup/sqldelight/internal/FunctionsJvm.kt
+++ b/runtime/src/jvmMain/kotlin/com/squareup/sqldelight/internal/FunctionsJvm.kt
@@ -7,6 +7,11 @@ actual fun copyOnWriteList(): MutableList<Query<*>> {
   return CopyOnWriteArrayList()
 }
 
+@JvmName("copyOnWriteListGeneric")
+internal actual fun <T> copyOnWriteList(): MutableList<T> {
+  return CopyOnWriteArrayList()
+}
+
 internal actual class QueryLock
 
 internal actual inline fun <T> QueryLock.withLock(block: () -> T): T {

--- a/runtime/src/jvmMain/kotlin/com/squareup/sqldelight/internal/FunctionsJvm.kt
+++ b/runtime/src/jvmMain/kotlin/com/squareup/sqldelight/internal/FunctionsJvm.kt
@@ -19,13 +19,3 @@ internal actual inline fun <T> QueryLock.withLock(block: () -> T): T {
     return block()
   }
 }
-
-internal actual fun <T> threadLocalRef(value: T): () -> T {
-  val threadLocal = ThreadLocal<T>()
-  threadLocal.set(value)
-  return { threadLocal.get() }
-}
-
-internal actual fun <T> sharedSet(): MutableSet<T> = mutableSetOf()
-
-internal actual fun <T, R> sharedMap(): MutableMap<T, R> = mutableMapOf()

--- a/runtime/src/jvmMain/kotlin/com/squareup/sqldelight/internal/FunctionsJvm.kt
+++ b/runtime/src/jvmMain/kotlin/com/squareup/sqldelight/internal/FunctionsJvm.kt
@@ -19,3 +19,5 @@ internal actual inline fun <T> QueryLock.withLock(block: () -> T): T {
     return block()
   }
 }
+
+internal actual fun currentThreadId(): Long = Thread.currentThread().id

--- a/runtime/src/nativeMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
+++ b/runtime/src/nativeMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
@@ -1,11 +1,7 @@
 package com.squareup.sqldelight.internal
 
-import co.touchlab.stately.collections.SharedHashMap
-import co.touchlab.stately.collections.SharedSet
 import co.touchlab.stately.collections.frozenCopyOnWriteList
 import co.touchlab.stately.concurrency.Lock
-import co.touchlab.stately.concurrency.ThreadLocalRef
-import co.touchlab.stately.concurrency.value
 import co.touchlab.stately.concurrency.withLock
 import com.squareup.sqldelight.Query
 

--- a/runtime/src/nativeMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
+++ b/runtime/src/nativeMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
@@ -22,13 +22,3 @@ internal actual class QueryLock {
 }
 
 internal actual inline fun <T> QueryLock.withLock(block: () -> T) = lock.withLock(block)
-
-internal actual fun <T> threadLocalRef(value: T): () -> T {
-  val threadLocal = ThreadLocalRef<T>()
-  threadLocal.value = value
-  return { threadLocal.value!! }
-}
-
-internal actual fun <T> sharedSet(): MutableSet<T> = SharedSet<T>()
-
-internal actual fun <T, R> sharedMap(): MutableMap<T, R> = SharedHashMap<T, R>()

--- a/runtime/src/nativeMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
+++ b/runtime/src/nativeMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
@@ -13,6 +13,10 @@ actual fun copyOnWriteList(): MutableList<Query<*>> {
   return frozenCopyOnWriteList()
 }
 
+internal actual fun <T> copyOnWriteList(): MutableList<T> {
+  return frozenCopyOnWriteList()
+}
+
 internal actual class QueryLock {
   internal val lock = Lock()
 }

--- a/runtime/src/nativeMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
+++ b/runtime/src/nativeMain/kotlin/com/squareup/sqldelight/internal/Functions.kt
@@ -4,6 +4,7 @@ import co.touchlab.stately.collections.frozenCopyOnWriteList
 import co.touchlab.stately.concurrency.Lock
 import co.touchlab.stately.concurrency.withLock
 import com.squareup.sqldelight.Query
+import kotlin.native.concurrent.Worker
 
 actual fun copyOnWriteList(): MutableList<Query<*>> {
   return frozenCopyOnWriteList()
@@ -18,3 +19,5 @@ internal actual class QueryLock {
 }
 
 internal actual inline fun <T> QueryLock.withLock(block: () -> T) = lock.withLock(block)
+
+internal actual fun currentThreadId(): Long = Worker.current.id.toLong()


### PR DESCRIPTION
Resolves #2235.

Profiling of our production apps shows, that a vast majority of time being spent in write transacitons is in the Kotlin runtime entry point `FreezeSubgraph()`. There are three root contributors to calls into `FreezeSubraph()`:

* The `SharedSet<Listener>` in **every** `Query<T>` created, regardless whether the query is listened to or not.

* The native driver `Transaction` being frozen in `NativeSqliteDriver.newTransaction()`.

* Within the `Transactor.Transaction` base class in sqldelight-runtime, the `SharedSet`s and `SharedMap` used to hold registered callbacks.

What we observe in practice is that:

* The transaction object should never have escaped the thread it is created on, since connections are only temporarily aligned to a thread, and so by extension the transactions too.

* The user-facing SQLDelight `Transacter` API supports only non-suspending transaction scopes, but not explicit transactions requiring manual closure. So there is very little chance of any transaction object being escaped.

* We rarely churn through listeners, i.e. rapidly adding and removing many listeners. Most are added at specific screen/activity lifecycle moments, and stays on until screen/activity deactivation.

So this PR proposes a few changes:

* [Common] `Query<T>` uses the copy-on-write list to hold listeners, instead of a `SharedSet<T>`.

   CoW list is already used by the generated queries interface implementation classes. If we assume that listener churn is rare and therefore not worth optimizing for, then the CoW list sounds an ideal candidate for the job.

* [Common] Add an assumption to `Transacter.Transaction` that it is expected never to escape the thread it is created on, and the scope of `Transacter.transaction()` or `Transacter.transactionWithResult()`.

   With this, we drop the use of `SharedSet<T>`, `SharedMap<T>` and other atomic types in `Transacter.Transaction`.

* [Native] The native `Transacter.Transaction` implementation is marked as `ensureNeverFrozen()`, and is now held by `ThreadConnection` through a `ThreadLocalRef<T>`, so that it can stay mutable.

   `ensureNeverFrozen()` will help surface accidential escapes, since it will prevent any lambda having captured the transaction object from being frozen.

In our case, all of these together eliminated almost all calls into `FreezeSubgraph()` during write transactions, even though there is still a couple, e.g. one from SQLiter in `beginTransaction()`. Nonetheless, it has brought down the execution time substantially for us (e.g., a simple UPSERT, 2ms -> 0.5ms, 4x speedup), with SQLite execution now taking the dorminant slice of time in the transaction call tree as supposed.