### PR TITLE
[Sqldelight] Sort `notifyQueries` to have consistent kotlin output file

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/ExecuteQueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/ExecuteQueryGenerator.kt
@@ -49,7 +49,7 @@ open class ExecuteQueryGenerator(private val query: NamedExecute) : QueryGenerat
     addStatement(
       "notifyQueries(%L, {%L})",
       query.id,
-      resultSetsUpdated.map { it.queryProperty }.joinToCode(separator = " + ")
+      resultSetsUpdated.sortedBy { it.id }.map { it.queryProperty }.joinToCode(separator = " + ")
     )
 
     return this


### PR DESCRIPTION
**Background**
Notify queries do not produce deterministic output. This might break some cache systems if they are depending on the output of `generateDebugDatabaseInterface`

**Changes**
* sort the generated code for notifyQueries function call by the query id (which is gauranteed to be deterministically produced by this prior fix https://github.com/cashapp/sqldelight/pull/1377)

**Test Plan**
* Verify it works locally