### PR TITLE
Add nested classes support to import inspection and class annotator

### DIFF
--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightClassNameElementAnnotator.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightClassNameElementAnnotator.kt
@@ -19,11 +19,16 @@ import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
 import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.module.ModuleUtil
+import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
 import com.intellij.psi.search.GlobalSearchScope
-import com.intellij.psi.search.PsiShortNamesCache
+import com.squareup.sqldelight.core.lang.SqlDelightFile
+import com.squareup.sqldelight.core.lang.psi.ImportStmtMixin
 import com.squareup.sqldelight.core.lang.psi.JavaTypeMixin
+import com.squareup.sqldelight.core.lang.util.findChildrenOfType
 import com.squareup.sqldelight.intellij.intentions.AddImportIntention
+import com.squareup.sqldelight.intellij.util.PsiClassSearchHelper
 
 class SqlDelightClassNameElementAnnotator : Annotator {
   override fun annotate(element: PsiElement, holder: AnnotationHolder) {
@@ -31,16 +36,58 @@ class SqlDelightClassNameElementAnnotator : Annotator {
       return
     }
 
-    holder.newAnnotation(HighlightSeverity.ERROR, "Unresolved reference: ${element.text}")
-      .range(element)
+    val project = element.project
+    val sqlDelightFile = element.containingFile as SqlDelightFile
+    val module = ModuleUtil.findModuleForFile(sqlDelightFile) ?: return
+    val scope = GlobalSearchScope.moduleWithDependenciesAndLibrariesScope(module, false)
+    val outerClassElement = element.firstChild
+    val outerClassName = outerClassElement.text
+    val classes = PsiClassSearchHelper.getClassesByShortName(outerClassName, project, scope)
+
+    val hasImport = sqlDelightFile.hasImport(outerClassName)
+    val psiElement = if (hasImport) {
+      missingNestedClass(classes, element)
+    } else {
+      outerClassElement
+    }
+
+    val needsQuickFix = classes.isNotEmpty() && !hasImport
+
+    holder.newAnnotation(HighlightSeverity.ERROR, "Unresolved reference: ${psiElement.text}")
+      .range(psiElement)
       .highlightType(ProblemHighlightType.LIKE_UNKNOWN_SYMBOL)
       .apply {
-        val classes = PsiShortNamesCache.getInstance(element.project)
-          .getClassesByName(element.text, GlobalSearchScope.allScope(element.project))
-        if (classes.isNotEmpty()) {
-          withFix(AddImportIntention(element.text))
+        if (needsQuickFix) {
+          withFix(AddImportIntention(outerClassName))
         }
       }
       .create()
+  }
+
+  private fun SqlDelightFile.hasImport(outerClassName: String): Boolean {
+    return sqlStmtList?.findChildrenOfType<ImportStmtMixin>()
+      .orEmpty()
+      .any { it.javaType.text.endsWith(outerClassName) }
+  }
+
+  private fun missingNestedClass(classes: List<PsiClass>, javaTypeMixin: JavaTypeMixin): PsiElement {
+    val elementText = javaTypeMixin.text
+    val className = classes.map { clazz -> findMissingNestedClassName(clazz, elementText) }
+      .maxByOrNull { it.length }
+      ?.substringBefore(".") ?: return javaTypeMixin.firstChild
+    return javaTypeMixin.findChildrenOfType<PsiElement>().first { it.textMatches(className) }
+  }
+
+  private fun findMissingNestedClassName(psiClass: PsiClass, className: String): String {
+    val nestedClassName = className.substringBefore(".")
+    if (psiClass.name != nestedClassName) {
+      return nestedClassName
+    }
+    val nextName = className.removePrefix(nestedClassName).removePrefix(".")
+    val lookupString = nextName.substringBefore(".")
+    val nextClass = psiClass.innerClasses.firstOrNull { clazz ->
+      clazz.textMatches(lookupString)
+    }
+    return nextClass?.let { findMissingNestedClassName(it, nextName) } ?: nextName
   }
 }

--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/inspections/UnusedImportInspection.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/inspections/UnusedImportInspection.kt
@@ -28,7 +28,7 @@ class UnusedImportInspection : LocalInspectionTool() {
 
     return file.findChildrenOfType<ImportStmtMixin>()
       .filter { importStmtMixin ->
-        importStmtMixin.text.substringAfterLast(".").removeSuffix(";") !in javaTypes
+        importStmtMixin.javaType.text.substringAfterLast(".").removeSuffix(";") !in javaTypes
       }
       .map { importStmtMixin ->
         manager.createProblemDescriptor(
@@ -62,5 +62,5 @@ fun PsiFile.columnJavaTypes(): Set<String> =
     .flatMap { columnType ->
       columnType.findChildrenOfType<SqlDelightJavaType>() + columnType.findChildrenOfType<SqlDelightJavaTypeName>()
     }
-    .mapNotNull { it.text }
+    .mapNotNull { it.text.substringBefore(".") }
     .toSet()

--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/util/PsiClassSearchHelper.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/util/PsiClassSearchHelper.kt
@@ -1,0 +1,25 @@
+package com.squareup.sqldelight.intellij.util
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.PsiShortNamesCache
+import org.jetbrains.kotlin.idea.refactoring.memberInfo.qualifiedClassNameForRendering
+import org.jetbrains.kotlin.idea.stubindex.KotlinClassShortNameIndex
+
+object PsiClassSearchHelper {
+
+  fun getClassesByShortName(shortName: String, project: Project, scope: GlobalSearchScope): List<PsiClass> {
+    val javaPsiFacade = JavaPsiFacade.getInstance(project)
+
+    val kotlinClasses = KotlinClassShortNameIndex.getInstance()
+      .get(shortName, project, scope)
+      .mapNotNull { javaPsiFacade.findClass(it.qualifiedClassNameForRendering(), scope) }
+
+    val javaClasses = PsiShortNamesCache.getInstance(project)
+      .getClassesByName(shortName, scope)
+    return (kotlinClasses + javaClasses)
+      .distinctBy { it.qualifiedName }
+  }
+}


### PR DESCRIPTION
This should fix issues reported by @ursusursus [here](https://github.com/cashapp/sqldelight/pull/2260#issuecomment-828072605), [here](https://github.com/cashapp/sqldelight/pull/2260#issuecomment-828078002), [here](https://github.com/cashapp/sqldelight/pull/2260#issuecomment-828078279) and [here](https://github.com/cashapp/sqldelight/pull/2260#issuecomment-828100519)