### PR TITLE
Correct migration callback AfterVersion range filter

### DIFF
--- a/runtime/src/commonMain/kotlin/com/squareup/sqldelight/db/SqlDriver.kt
+++ b/runtime/src/commonMain/kotlin/com/squareup/sqldelight/db/SqlDriver.kt
@@ -112,9 +112,9 @@ fun SqlDriver.Schema.migrateWithCallbacks(
 ) {
   var lastVersion = oldVersion
 
-  // For each callback within the oldVersion..newVersion range, alternate between migrating
+  // For each callback within the [oldVersion..newVersion) range, alternate between migrating
   // the schema and invoking each callback.
-  callbacks.filter { it.afterVersion in (oldVersion + 1) until newVersion }
+  callbacks.filter { it.afterVersion in oldVersion until newVersion }
     .sortedBy { it.afterVersion }
     .forEach { callback ->
       migrate(driver, oldVersion = lastVersion, newVersion = callback.afterVersion + 1)

--- a/runtime/src/commonTest/kotlin/com/squareup/sqldelight/logs/SqlDriverMigrationCallbackTest.kt
+++ b/runtime/src/commonTest/kotlin/com/squareup/sqldelight/logs/SqlDriverMigrationCallbackTest.kt
@@ -1,0 +1,98 @@
+package com.squareup.sqldelight.logs
+
+import com.squareup.sqldelight.db.AfterVersion
+import com.squareup.sqldelight.db.SqlDriver
+import com.squareup.sqldelight.db.migrateWithCallbacks
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SqlDriverMigrationCallbackTest {
+
+  @Test fun migrationCallbackInvokedOnCorrectVersion() {
+    val schema = fakeSchema()
+
+    var callbackInvoked = false
+
+    schema.migrateWithCallbacks(
+      driver = FakeSqlDriver(),
+      oldVersion = 1,
+      newVersion = 2,
+      AfterVersion(1) { callbackInvoked = true }
+    )
+
+    assertTrue(callbackInvoked)
+  }
+
+  @Test fun migrationCallbacks() {
+    val schema = fakeSchema()
+
+    var callback1Invoked = false
+    var callback2Invoked = false
+    var callback3Invoked = false
+
+    schema.migrateWithCallbacks(
+      driver = FakeSqlDriver(),
+      oldVersion = 0,
+      newVersion = 4,
+      AfterVersion(1) { callback1Invoked = true },
+      AfterVersion(2) { callback2Invoked = true },
+      AfterVersion(3) { callback3Invoked = true },
+    )
+
+    assertTrue(callback1Invoked)
+    assertTrue(callback2Invoked)
+    assertTrue(callback3Invoked)
+  }
+
+  @Test fun migrationCallbackLessThanOldVersionNotCalled() {
+    val schema = fakeSchema()
+
+    var callback1Invoked = false
+    var callback2Invoked = false
+    var callback3Invoked = false
+
+    schema.migrateWithCallbacks(
+      driver = FakeSqlDriver(),
+      oldVersion = 2,
+      newVersion = 4,
+      AfterVersion(1) { callback1Invoked = true },
+      AfterVersion(2) { callback2Invoked = true },
+      AfterVersion(3) { callback3Invoked = true },
+    )
+
+    assertFalse(callback1Invoked)
+    assertTrue(callback2Invoked)
+    assertTrue(callback3Invoked)
+  }
+
+  @Test fun migrationCallbackGreaterThanNewVersionNotCalled() {
+    val schema = fakeSchema()
+
+    var callback1Invoked = false
+    var callback2Invoked = false
+    var callback3Invoked = false
+    var callback4Invoked = false
+
+    schema.migrateWithCallbacks(
+      driver = FakeSqlDriver(),
+      oldVersion = 0,
+      newVersion = 4,
+      AfterVersion(1) { callback1Invoked = true },
+      AfterVersion(2) { callback2Invoked = true },
+      AfterVersion(3) { callback3Invoked = true },
+      AfterVersion(4) { callback4Invoked = true },
+    )
+
+    assertTrue(callback1Invoked)
+    assertTrue(callback2Invoked)
+    assertTrue(callback3Invoked)
+    assertFalse(callback4Invoked)
+  }
+
+  private fun fakeSchema() = object : SqlDriver.Schema {
+    override val version: Int = 1
+    override fun create(driver: SqlDriver) = Unit
+    override fun migrate(driver: SqlDriver, oldVersion: Int, newVersion: Int) = Unit
+  }
+}

--- a/sqldelight-gradle-plugin/src/test/integration-migration-callbacks/src/test/java/com/squareup/sqldelight/integration/IntegrationTests.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-migration-callbacks/src/test/java/com/squareup/sqldelight/integration/IntegrationTests.kt
@@ -33,11 +33,11 @@ class IntegrationTests {
     QueryWrapper.Schema.migrate(
       driver = database,
       oldVersion = 0,
-      newVersion = 1
+      newVersion = 2
     )
     QueryWrapper.Schema.migrateWithCallbacks(
       driver = database,
-      oldVersion = 1,
+      oldVersion = 2,
       newVersion = QueryWrapper.Schema.version,
       AfterVersion(1) { database.execute(null, "INSERT INTO test (value) VALUES('hello')", 0) },
       AfterVersion(2) { database.execute(null, "INSERT INTO test2 (value, value2) VALUES('hello2', 'sup2')", 0) },


### PR DESCRIPTION
Introduced in 1.5.0, SQLDelight had an off-by-one error
for determining when to invoke an `AfterMigration` callback.
This commit corrects the version range for which callbacks
are invoked.

Closes #2393.
