### PR TITLE
Replace deprecated IntelliJ Platform Artifacts Repositories url

### DIFF
--- a/docs/android_sqlite/index.md
+++ b/docs/android_sqlite/index.md
@@ -8,7 +8,7 @@ buildscript {
     google()
     mavenCentral()
     maven { url 'https://www.jetbrains.com/intellij-repository/releases' }
-    maven { url "https://jetbrains.bintray.com/intellij-third-party-dependencies" }
+    maven { url "https://cache-redirector.jetbrains.com/intellij-dependencies" }
   }
   dependencies {
     classpath 'com.squareup.sqldelight:gradle-plugin:{{ versions.sqldelight }}'

--- a/docs/common/index_gradle_database_pre_dialect.md
+++ b/docs/common/index_gradle_database_pre_dialect.md
@@ -6,7 +6,7 @@ buildscript {
     google()
     mavenCentral()
     maven { url 'https://www.jetbrains.com/intellij-repository/releases' }
-    maven { url "https://jetbrains.bintray.com/intellij-third-party-dependencies" }
+    maven { url "https://cache-redirector.jetbrains.com/intellij-dependencies" }
   }
   dependencies {
     classpath 'com.squareup.sqldelight:gradle-plugin:{{ versions.sqldelight }}'

--- a/sqldelight-gradle-plugin/src/test/buildscript.gradle
+++ b/sqldelight-gradle-plugin/src/test/buildscript.gradle
@@ -8,7 +8,7 @@
     google()
     jcenter()
     maven { url 'https://www.jetbrains.com/intellij-repository/releases' }
-    maven { url "https://jetbrains.bintray.com/intellij-third-party-dependencies" }
+    maven { url "https://cache-redirector.jetbrains.com/intellij-dependencies" }
   }
 
   project.buildscript.dependencies {


### PR DESCRIPTION
Per the [documentation](https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html#third-party-dependencies):

> Usages of deprecated URL https://jetbrains.bintray.com/intellij-third-party-dependencies must be replaced with https://cache-redirector.jetbrains.com/intellij-dependencies in build scripts.