### PR TITLE
Upgrade sql.js to 1.5.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,7 +10,7 @@ ext.versions = [
     stately: '1.1.7',
     sqliter: '1.0.3',
     testhelp: '0.5.0',
-    sqljs: '1.0.0',
+    sqljs: '1.5.0',
     paging: '2.1.2',
     paging3: '3.0.0',
     ktlint: '0.40.0',


### PR DESCRIPTION
This just bumps the version of sql.js that is depended upon by the sqljs driver.

Purely coincidental that the latest versions of SQLDelight, Kotlin (ignoring 1.5.10...), and sql.js are all 1.5.0.
