### PR TITLE
Ensure we register query listener before notifying

### DIFF
--- a/extensions/coroutines-extensions/src/commonMain/kotlin/com/squareup/sqldelight/runtime/coroutines/FlowExtensions.kt
+++ b/extensions/coroutines-extensions/src/commonMain/kotlin/com/squareup/sqldelight/runtime/coroutines/FlowExtensions.kt
@@ -34,14 +34,15 @@ import kotlin.jvm.JvmOverloads
 /** Turns this [Query] into a [Flow] which emits whenever the underlying result set changes. */
 @JvmName("toFlow")
 fun <T : Any> Query<T>.asFlow(): Flow<Query<T>> = flow {
-  emit(this@asFlow)
-
   val channel = Channel<Unit>(CONFLATED)
+  channel.trySend(Unit)
+
   val listener = object : Query.Listener {
     override fun queryResultsChanged() {
-      channel.offer(Unit)
+      channel.trySend(Unit)
     }
   }
+
   addListener(listener)
   try {
     for (item in channel) {


### PR DESCRIPTION
Avoid a race condition between these events by propagating the initial notification through the same mechanism that the listener uses. With this we can register the listener and then start the notification loop which will immediately trigger having been seeded with an initial notification.