### PR TITLE
Build tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ generated
 lib
 .sqldelight
 out
-sqldelight-gradle-plugin/src/test/*/gradle
 sqldelight-gradle-plugin/src/test/*/gradle.properties
 sqldelight-gradle-plugin/src/test/integration-android-library/src/
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ buildscript {
     classpath deps.plugins.dokka
     classpath deps.plugins.intellij
     classpath deps.plugins.android
+    classpath deps.plugins.grammarKit
     classpath deps.plugins.grammarKitComposer
     classpath deps.plugins.publish
     classpath deps.plugins.spotless

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ allprojects {
   }
 
   configurations {
-    grammar
+    grammar.extendsFrom compileOnly
   }
 
   dependencies {
@@ -71,7 +71,7 @@ allprojects {
   }
 
   tasks.withType(GenerateParser).configureEach {
-    classpath = configurations.grammar + configurations.compileOnly
+    classpath = configurations.grammar
   }
 
   configurations.all {

--- a/drivers/android-driver/build.gradle
+++ b/drivers/android-driver/build.gradle
@@ -1,6 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'org.jetbrains.kotlin.android'
-
+plugins {
+  id("com.android.library")
+  id("org.jetbrains.kotlin.android")
+}
 archivesBaseName = 'sqldelight-android-driver'
 
 android {

--- a/drivers/driver-test/build.gradle
+++ b/drivers/driver-test/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'org.jetbrains.kotlin.multiplatform'
+plugins {
+  id("org.jetbrains.kotlin.multiplatform")
+}
 
 kotlin {
   sourceSets {

--- a/drivers/jdbc-driver/build.gradle
+++ b/drivers/jdbc-driver/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'org.jetbrains.kotlin.jvm'
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+}
 
 archivesBaseName = 'sqldelight-jdbc-driver'
 

--- a/drivers/native-driver/build.gradle
+++ b/drivers/native-driver/build.gradle
@@ -1,6 +1,8 @@
 import org.jetbrains.kotlin.konan.target.HostManager
 
-apply plugin: 'org.jetbrains.kotlin.multiplatform'
+plugins {
+  id("org.jetbrains.kotlin.multiplatform")
+}
 
 def ideaActive = System.getProperty("idea.active") == "true"
 

--- a/drivers/sqlite-driver/build.gradle
+++ b/drivers/sqlite-driver/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'org.jetbrains.kotlin.jvm'
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+}
 
 archivesBaseName = 'sqldelight-sqlite-driver'
 

--- a/drivers/sqljs-driver/build.gradle
+++ b/drivers/sqljs-driver/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'org.jetbrains.kotlin.js'
+plugins {
+  id("org.jetbrains.kotlin.js")
+}
 
 kotlin {
 

--- a/extensions/android-paging/build.gradle
+++ b/extensions/android-paging/build.gradle
@@ -20,6 +20,10 @@ android {
   buildFeatures {
     buildConfig = false
   }
+
+  testOptions {
+    unitTests.includeAndroidResources = true
+  }
 }
 
 dependencies {

--- a/extensions/android-paging/build.gradle
+++ b/extensions/android-paging/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'org.jetbrains.kotlin.android'
+plugins {
+  id("com.android.library")
+  id("org.jetbrains.kotlin.android")
+}
 
 archivesBaseName = 'sqldelight-android-paging'
 

--- a/extensions/android-paging3/build.gradle
+++ b/extensions/android-paging3/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'org.jetbrains.kotlin.jvm'
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+}
 
 archivesBaseName = 'sqldelight-android-paging3'
 

--- a/extensions/android-paging3/src/test/java/com/squareup/sqldelight/android/paging3/KeyedQueryPagingSourceTest.kt
+++ b/extensions/android-paging3/src/test/java/com/squareup/sqldelight/android/paging3/KeyedQueryPagingSourceTest.kt
@@ -12,10 +12,8 @@ import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineDispatcher
-import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
@@ -26,14 +24,10 @@ class KeyedQueryPagingSourceTest {
   private lateinit var transacter: Transacter
 
   @Before fun before() {
-    driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY + "test.db")
+    driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
     driver.execute(null, "CREATE TABLE testTable(value INTEGER PRIMARY KEY)", 0)
     (0L until 10L).forEach(this::insert)
     transacter = object : TransacterImpl(driver) {}
-  }
-
-  @After fun after() {
-    File("test.db").delete()
   }
 
   @Test fun `aligned page exhaustion gives correct results`() {

--- a/extensions/android-paging3/src/test/java/com/squareup/sqldelight/android/paging3/OffsetQueryPagingSourceTest.kt
+++ b/extensions/android-paging3/src/test/java/com/squareup/sqldelight/android/paging3/OffsetQueryPagingSourceTest.kt
@@ -26,13 +26,11 @@ import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineDispatcher
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import java.io.File
 import kotlin.test.assertFailsWith
 
 @ExperimentalCoroutinesApi
@@ -42,15 +40,10 @@ class OffsetQueryPagingSourceTest {
   private lateinit var transacter: Transacter
 
   @Before fun before() {
-    driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY + "test.db")
+    driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
     driver.execute(null, "CREATE TABLE testTable(value INTEGER PRIMARY KEY)", 0)
     (0L until 10L).forEach(this::insert)
     transacter = object : TransacterImpl(driver) {}
-  }
-
-  @After
-  fun after() {
-    File("test.db").delete()
   }
 
   @Test fun `empty page gives correct prevKey and nextKey`() {
@@ -247,7 +240,7 @@ class OffsetQueryPagingSourceTest {
     }
   }
 
-  @Test fun `query invaliation invalidates paging source`() {
+  @Test fun `query invalidation invalidates paging source`() {
     val query = query(2, 0)
     val source = OffsetQueryPagingSource(
       { _, _ -> query },

--- a/extensions/coroutines-extensions/build.gradle
+++ b/extensions/coroutines-extensions/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.konan.target.HostManager
+
 plugins {
   id("org.jetbrains.kotlin.multiplatform")
 }
@@ -122,6 +124,13 @@ kotlin {
       optIn('kotlin.time.ExperimentalTime')
       optIn('kotlinx.coroutines.ExperimentalCoroutinesApi')
     }
+  }
+
+  //linking fails for the linux test build if not built on a linux host
+  //ensure the tests and linking for them is only done on linux hosts
+  if(!HostManager.hostIsLinux) {
+    tasks.findByName("linuxX64Test")?.enabled = false
+    tasks.findByName("linkDebugTestLinuxX64")?.enabled = false
   }
 }
 

--- a/extensions/coroutines-extensions/build.gradle
+++ b/extensions/coroutines-extensions/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'org.jetbrains.kotlin.multiplatform'
+plugins {
+  id("org.jetbrains.kotlin.multiplatform")
+}
 
 archivesBaseName = 'sqldelight-coroutines-extensions'
 

--- a/extensions/rxjava2-extensions/build.gradle
+++ b/extensions/rxjava2-extensions/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'org.jetbrains.kotlin.jvm'
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+}
 
 archivesBaseName = 'sqldelight-rxjava2-extensions'
 

--- a/extensions/rxjava3-extensions/build.gradle
+++ b/extensions/rxjava3-extensions/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'org.jetbrains.kotlin.jvm'
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+}
 
 archivesBaseName = 'sqldelight-rxjava3-extensions'
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -77,7 +77,7 @@ ext.deps = [
     ],
     sqlitePsi: "com.alecstrong:sqlite-psi-core:0.3.15",
     sqliteJdbc: "org.xerial:sqlite-jdbc:3.34.0",
-    robolectric: 'org.robolectric:robolectric:4.4',
+    robolectric: 'org.robolectric:robolectric:4.7.2',
     rxJava2: "io.reactivex.rxjava2:rxjava:2.2.5",
     rxJava3: "io.reactivex.rxjava3:rxjava:3.1.2",
     guava: "com.google.guava:guava:23.0",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,6 +23,7 @@ ext.deps = [
         kotlin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
         dokka: "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokka}",
         intellij: "org.jetbrains.intellij.plugins:gradle-intellij-plugin:1.1.2",
+        grammarKit: "gradle.plugin.org.jetbrains.intellij.plugins:gradle-grammarkit-plugin:2021.1.3",
         grammarKitComposer: "com.alecstrong:grammar-kit-composer:0.1.5",
         publish: "com.vanniktech:gradle-maven-publish-plugin:0.14.2",
         spotless: "com.diffplug.spotless:spotless-plugin-gradle:5.17.1",

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'org.jetbrains.kotlin.multiplatform'
+plugins {
+  id("org.jetbrains.kotlin.multiplatform")
+}
 
 kotlin {
   jvm()

--- a/sample/android/build.gradle
+++ b/sample/android/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'com.android.application'
-apply plugin: 'org.jetbrains.kotlin.android'
+plugins {
+  id("com.android.application")
+  id("org.jetbrains.kotlin.android")
+}
 
 android {
   compileSdkVersion versions.compileSdk

--- a/sample/common/build.gradle
+++ b/sample/common/build.gradle
@@ -1,6 +1,8 @@
-apply plugin: 'org.jetbrains.kotlin.multiplatform'
-apply plugin: 'org.jetbrains.kotlin.native.cocoapods'
-apply plugin: 'com.squareup.sqldelight'
+plugins {
+  id("org.jetbrains.kotlin.multiplatform")
+  id("org.jetbrains.kotlin.native.cocoapods")
+  id("com.squareup.sqldelight")
+}
 
 archivesBaseName = 'sample-common'
 

--- a/sample/web/build.gradle
+++ b/sample/web/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'org.jetbrains.kotlin.js'
+plugins {
+  id("org.jetbrains.kotlin.js")
+}
 
 kotlin {
   js {

--- a/sqldelight-compiler/build.gradle
+++ b/sqldelight-compiler/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'org.jetbrains.kotlin.jvm'
-apply plugin: 'com.alecstrong.grammar.kit.composer'
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+  id("com.alecstrong.grammar.kit.composer")
+}
 
 test {
   testLogging {

--- a/sqldelight-compiler/build.gradle
+++ b/sqldelight-compiler/build.gradle
@@ -17,6 +17,10 @@ sourceSets {
   main.java.srcDir "gen"
 }
 
+grammarKit {
+  grammarKitRelease = "2020.1"
+}
+
 dependencies {
   api deps.sqlitePsi
 

--- a/sqldelight-compiler/integration-tests/build.gradle
+++ b/sqldelight-compiler/integration-tests/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'org.jetbrains.kotlin.jvm'
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+}
 
 dependencies {
   testImplementation project(':runtime')

--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -15,17 +15,8 @@ gradlePlugin {
 }
 
 configurations {
-  fixtureClasspath
   bundled
   shade
-}
-
-
-// Append any extra dependencies to the test fixtures via a custom configuration classpath. This
-// allows us to apply additional plugins in a fixture while still leveraging dependency resolution
-// and de-duplication semantics.
-tasks.named('pluginUnderTestMetadata').configure {
-  getPluginClasspath().from(configurations.fixtureClasspath)
 }
 
 dependencies {
@@ -52,9 +43,6 @@ dependencies {
   testImplementation project(':sqldelight-compiler')
   testImplementation deps.junit
   testImplementation deps.truth
-
-  fixtureClasspath deps.plugins.kotlin
-  fixtureClasspath deps.plugins.android
 }
 
 test {

--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -1,7 +1,9 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 
-apply plugin: 'org.jetbrains.kotlin.jvm'
-apply plugin: 'java-gradle-plugin'
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+  id("java-gradle-plugin")
+}
 
 gradlePlugin {
   plugins {
@@ -117,7 +119,6 @@ if (System.getenv("CI") == "true") {
     runtimeOnly(shadowJar)
     archives(shadowJar)
   }
-
 } else {
   configurations.implementation.extendsFrom(configurations.shade)
 }

--- a/sqldelight-gradle-plugin/src/test/integration-multiplatform/android-build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-multiplatform/android-build.gradle
@@ -6,8 +6,6 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'com.squareup.sqldelight'
 apply plugin: 'com.android.library'
 
-apply from: '../../../../gradle/dependencies.gradle'
-
 repositories {
   maven {
     url "file://${projectDir.absolutePath}/../../../../build/localMaven"

--- a/sqldelight-gradle-plugin/src/test/integration-multiplatform/ios-build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-multiplatform/ios-build.gradle
@@ -5,8 +5,6 @@ buildscript {
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'com.squareup.sqldelight'
 
-apply from: '../../../../gradle/dependencies.gradle'
-
 repositories {
   maven {
     url "file://${projectDir.absolutePath}/../../../../build/localMaven"

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/GradleRunner.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/GradleRunner.kt
@@ -4,10 +4,6 @@ import org.gradle.testkit.runner.GradleRunner
 import java.io.File
 
 internal fun GradleRunner.withCommonConfiguration(projectRoot: File): GradleRunner {
-  val gradleRoot = File(projectRoot, "gradle").apply {
-    mkdir()
-  }
-  File("../gradle/wrapper").copyRecursively(File(gradleRoot, "wrapper"), true)
   File(projectRoot, "gradle.properties").writeText(
     """
       |org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/properties/PropertiesFileTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/properties/PropertiesFileTest.kt
@@ -60,7 +60,6 @@ class PropertiesFileTest {
         |apply plugin: 'org.jetbrains.kotlin.multiplatform'
         |apply plugin: 'com.squareup.sqldelight'
         |apply plugin: 'com.android.library'
-        |apply from: "${"$"}{rootDir}/../../../../gradle/dependencies.gradle"
         |
         |repositories {
         |  maven {

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/CompilationUnitTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/CompilationUnitTests.kt
@@ -21,7 +21,6 @@ class CompilationUnitTests {
         |
         |apply plugin: 'org.jetbrains.kotlin.jvm'
         |apply plugin: 'com.squareup.sqldelight'
-        |apply from: "${"$"}{rootDir}/../../../../gradle/dependencies.gradle"
         |
         |repositories {
         |  maven {
@@ -65,7 +64,6 @@ class CompilationUnitTests {
         |
         |apply plugin: 'org.jetbrains.kotlin.jvm'
         |apply plugin: 'com.squareup.sqldelight'
-        |apply from: "${"$"}{rootDir}/../../../../gradle/dependencies.gradle"
         |
         |repositories {
         |  maven {
@@ -135,7 +133,6 @@ class CompilationUnitTests {
         |
         |apply plugin: 'org.jetbrains.kotlin.multiplatform'
         |apply plugin: 'com.squareup.sqldelight'
-        |apply from: "${"$"}{rootDir}/../../../../gradle/dependencies.gradle"
         |
         |repositories {
         |  maven {
@@ -189,14 +186,12 @@ class CompilationUnitTests {
         |apply plugin: 'org.jetbrains.kotlin.multiplatform'
         |apply plugin: 'com.android.application'
         |apply plugin: 'com.squareup.sqldelight'
-        |apply from: "${"$"}{rootDir}/../../../../gradle/dependencies.gradle"
         |
         |repositories {
         |  maven {
         |    url "file://${"$"}{rootDir}/../../../../build/localMaven"
         |  }
         |}
-        |
         |
         |sqldelight {
         |  CommonDb {
@@ -268,7 +263,6 @@ class CompilationUnitTests {
         |apply plugin: 'com.android.application'
         |apply plugin: 'org.jetbrains.kotlin.android'
         |apply plugin: 'com.squareup.sqldelight'
-        |apply from: "${"$"}{rootDir}/../../../../gradle/dependencies.gradle"
         |
         |repositories {
         |  maven {

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/GradlePluginCombinationTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/GradlePluginCombinationTests.kt
@@ -59,7 +59,6 @@ class GradlePluginCombinationTests {
     |
     |apply plugin: 'org.jetbrains.kotlin.multiplatform'
     |apply plugin: 'com.squareup.sqldelight'
-    |apply from: "${"$"}{rootDir}/../../../../gradle/dependencies.gradle"
     |
     |repositories {
     |  maven {

--- a/sqldelight-gradle-plugin/src/test/schema-file-android/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/schema-file-android/build.gradle
@@ -6,8 +6,6 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.squareup.sqldelight'
 apply plugin: 'org.jetbrains.kotlin.android'
 
-apply from: '../../../../gradle/dependencies.gradle'
-
 repositories {
   maven {
     url "file://${projectDir.absolutePath}/../../../../build/localMaven"

--- a/sqldelight-idea-plugin/build.gradle
+++ b/sqldelight-idea-plugin/build.gradle
@@ -1,8 +1,10 @@
 import org.jetbrains.intellij.tasks.RunPluginVerifierTask.FailureLevel
 
-apply plugin: 'org.jetbrains.intellij'
-apply plugin: 'org.jetbrains.kotlin.jvm'
-apply plugin: "org.jetbrains.changelog"
+plugins {
+  id("org.jetbrains.intellij")
+  id("org.jetbrains.kotlin.jvm")
+  id("org.jetbrains.changelog")
+}
 
 intellij {
   updateSinceUntilBuild = false

--- a/sqldelight-idea-plugin/build.gradle
+++ b/sqldelight-idea-plugin/build.gradle
@@ -104,4 +104,7 @@ internal val BUGSNAG_KEY = "${getBugsnagKey()}"
 """
   }
 }
+
 tasks.named('compileKotlin').configure { dependsOn('bugsnagKey') }
+
+tasks.named('buildSearchableOptions').configure { enabled = false }

--- a/sqlite-migrations/build.gradle
+++ b/sqlite-migrations/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'org.jetbrains.kotlin.jvm'
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+}
 
 dependencies {
   // These dependencies will not be shadowed by sqldelight-gradle-plugin

--- a/test-util/build.gradle
+++ b/test-util/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'org.jetbrains.kotlin.jvm'
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+}
 
 dependencies {
   implementation project(':sqldelight-compiler')


### PR DESCRIPTION
A few tweaks to the build with the intention of removing deprecation warnings and improving reliability on Windows.

The changes are mostly uninteresting except for using an in-memory DB for the Paging 3 extension tests. On my Windows machine the tests kept failing because the test.db file wasn't deleted after each test. When I updated to use `Files.delete` the error said the file was still in use by the process.

Closing the driver or connection before deletion didn't help so I switched to an in-memory DB instead. I'm not sure if this means there's another bug but I didn't look further.