### PR TITLE
Update docs to reflect Webpack 5 requirements

### DIFF
--- a/docs/js_sqlite/index.md
+++ b/docs/js_sqlite/index.md
@@ -28,17 +28,25 @@ suspend fun createDriver() {
 If building for browsers, some additional webpack configuration is also required.
 ```js
 // project/webpack.conf.d/fs.js
-config.node = {
-    fs: 'empty'
+config.resolve = {
+    fallback: {
+        fs: false,
+        path: false,
+        crypto: false,
+    }
 };
 
 // project/webpack.conf.d/wasm.js
-var CopyWebpackPlugin = require('copy-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 config.plugins.push(
-    new CopyWebpackPlugin([
-        { from: '../../node_modules/sql.js/dist/sql-wasm.wasm',
-            to: '../../../{your project}/build/distributions' }
-    ])
+    new CopyWebpackPlugin({
+        patterns: [
+            {
+                from: '../../node_modules/sql.js/dist/sql-wasm.wasm',
+                to: '../../../{your project}/build/distributions'
+            }
+        ]
+    })
 );
 
 ```

--- a/sample/web/webpack.config.d/fs.js
+++ b/sample/web/webpack.config.d/fs.js
@@ -3,6 +3,7 @@
 config.resolve = {
     fallback: {
         fs: false,
-        path: false
+        path: false,
+        crypto: false,
     }
 };


### PR DESCRIPTION
Update docs for the JS driver:
 * Use config.resolve to disable fallbacks
 * Use latest copy-webpack-plugin API

Add crypto to disabled fallbacks to suppress a warning
