### PR TITLE
Add linuxX64 support

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ macOS-latest, windows-latest, ubuntu-latest ]
+        os: [ macOS-latest, windows-latest, ubuntu-latest, ubuntu-18.04 ]
         job: [ instrumentation, test, gradle-plugin-tests, gradle-plugin-integrations ]
         exclude:
           - os: windows-latest
@@ -63,6 +63,10 @@ jobs:
       - name: Run windows tests
         if: matrix.os == 'windows-latest'
         run: ./gradlew mingwTest sqldelight-idea-plugin:check --stacktrace
+
+      - name: Run linux tests
+        if: matrix.os == 'ubuntu-18.04'
+        run: ./gradlew linuxTest
 
       - name: Run instrumentation tests
         if: matrix.os == 'macOS-latest' && matrix.job == 'instrumentation'

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -11,7 +11,7 @@ jobs:
   publish_archives:
     strategy:
       matrix:
-        os: [macOS-latest, windows-latest]
+        os: [macOS-latest, windows-latest, ubuntu-18.04]
 
     runs-on: ${{matrix.os}}
 
@@ -39,6 +39,13 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralRepositoryPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
         run: ./gradlew publishMingwPublicationToMavenRepository
+      - name: Publish the linux artifact
+        if: matrix.os == 'ubuntu-18.04'
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralRepositoryUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralRepositoryPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
+        run: ./gradlew publishLinuxPublicationToMavenRepository
 
   publish_plugin:
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ buildscript {
   apply from: "$rootDir/gradle/dependencies.gradle"
 
   repositories {
-    mavenLocal()
     mavenCentral()
     google()
     jcenter()
@@ -50,7 +49,6 @@ spotless {
 
 allprojects {
   repositories {
-    mavenLocal()
     mavenCentral()
     google()
     jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
   apply from: "$rootDir/gradle/dependencies.gradle"
 
   repositories {
+    mavenLocal()
     mavenCentral()
     google()
     jcenter()
@@ -49,6 +50,7 @@ spotless {
 
 allprojects {
   repositories {
+    mavenLocal()
     mavenCentral()
     google()
     jcenter()

--- a/drivers/driver-test/build.gradle
+++ b/drivers/driver-test/build.gradle
@@ -31,5 +31,6 @@ kotlin {
     targetFromPreset(presets.watchosArm64, 'watchosArm64')
     targetFromPreset(presets.macosX64, 'macosX64')
     targetFromPreset(presets.mingwX64, 'mingw')
+    targetFromPreset(presets.linuxX64, 'linux')
   }
 }

--- a/drivers/native-driver/build.gradle
+++ b/drivers/native-driver/build.gradle
@@ -5,6 +5,9 @@ apply plugin: 'org.jetbrains.kotlin.multiplatform'
 
 def ideaActive = System.getProperty("idea.active") == "true"
 
+//used to disable compilation depending on host
+//reason: cross compilation linking issues
+//see: https://youtrack.jetbrains.com/issue/KT-30498
 def disableCompilation(targets) {
   configure(targets) {
     compilations.all {

--- a/drivers/native-driver/build.gradle
+++ b/drivers/native-driver/build.gradle
@@ -1,26 +1,70 @@
+import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
+import org.jetbrains.kotlin.konan.target.HostManager
+
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 
 def ideaActive = System.getProperty("idea.active") == "true"
 
+def disableCompilation(targets) {
+  configure(targets) {
+    compilations.all {
+      cinterops.all { project.tasks[interopProcessingTaskName].enabled = false }
+      compileKotlinTask.enabled = false
+    }
+    binaries.all { linkTask.enabled = false }
+    mavenPublication { publicationToDisable ->
+      tasks.withType(AbstractPublishToMaven).all {
+        onlyIf { publication != publicationToDisable }
+      }
+      tasks.withType(GenerateModuleMetadata).all {
+        onlyIf { publication.get() != publicationToDisable }
+      }
+    }
+  }
+}
+
 kotlin {
+  def knTargets = new ArrayList<KotlinTarget>()
   if (ideaActive) {
-    macosX64("native")
+    knTargets.add(macosX64("native"))
 //    macosX64("nativeDarwin") // Uncomment to get IDE recognition for darwin code until HMPP fixed
-    mingwX64("mingw")
-    linuxX64("linux")
+    knTargets.add(mingwX64("mingw"))
+    knTargets.add(linuxX64("linux"))
   } else {
-    macosX64()
-    iosArm32()
-    iosArm64()
-    iosX64()
-    watchosArm32()
-    watchosArm64()
-    watchosX86()
-    watchosX64()
-    tvosArm64()
-    tvosX64()
-    mingwX64()
-    linuxX64()
+    knTargets.add(macosX64())
+    knTargets.add(iosArm32())
+    knTargets.add(iosArm64())
+    knTargets.add(iosX64())
+    knTargets.add(watchosArm32())
+    knTargets.add(watchosArm64())
+    knTargets.add(watchosX86())
+    knTargets.add(watchosX64())
+    knTargets.add(tvosArm64())
+    knTargets.add(tvosX64())
+    knTargets.add(mingwX64())
+    knTargets.add(linuxX64())
+
+    //disable compilations depending on host because of cross compilation linking issues
+    //see: https://youtrack.jetbrains.com/issue/KT-30498
+    if (HostManager.hostIsLinux) {
+      knTargets.remove(targets.linuxX64)
+    } else if (HostManager.hostIsMingw) {
+      knTargets.remove(targets.mingwX64)
+    } else {
+      knTargets.removeAll([
+            targets.macosX64,
+            targets.iosArm32,
+            targets.iosArm64,
+            targets.iosX64,
+            targets.watchosArm32,
+            targets.watchosArm64,
+            targets.watchosX86,
+            targets.watchosX64,
+            targets.tvosArm64,
+            targets.tvosX64
+      ])
+    }
+    disableCompilation(knTargets)
   }
 
   sourceSets {

--- a/drivers/native-driver/build.gradle
+++ b/drivers/native-driver/build.gradle
@@ -1,73 +1,28 @@
-import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 import org.jetbrains.kotlin.konan.target.HostManager
 
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 
 def ideaActive = System.getProperty("idea.active") == "true"
 
-//used to disable compilation depending on host
-//reason: cross compilation linking issues
-//see: https://youtrack.jetbrains.com/issue/KT-30498
-def disableCompilation(targets) {
-  configure(targets) {
-    compilations.all {
-      cinterops.all { project.tasks[interopProcessingTaskName].enabled = false }
-      compileKotlinTask.enabled = false
-    }
-    binaries.all { linkTask.enabled = false }
-    mavenPublication { publicationToDisable ->
-      tasks.withType(AbstractPublishToMaven).all {
-        onlyIf { publication != publicationToDisable }
-      }
-      tasks.withType(GenerateModuleMetadata).all {
-        onlyIf { publication.get() != publicationToDisable }
-      }
-    }
-  }
-}
-
 kotlin {
-  def knTargets = new ArrayList<KotlinTarget>()
   if (ideaActive) {
-    knTargets.add(macosX64("native"))
+    macosX64("native")
 //    macosX64("nativeDarwin") // Uncomment to get IDE recognition for darwin code until HMPP fixed
-    knTargets.add(mingwX64("mingw"))
-    knTargets.add(linuxX64("linux"))
+    mingwX64("mingw")
+    linuxX64("linux")
   } else {
-    knTargets.add(macosX64())
-    knTargets.add(iosArm32())
-    knTargets.add(iosArm64())
-    knTargets.add(iosX64())
-    knTargets.add(watchosArm32())
-    knTargets.add(watchosArm64())
-    knTargets.add(watchosX86())
-    knTargets.add(watchosX64())
-    knTargets.add(tvosArm64())
-    knTargets.add(tvosX64())
-    knTargets.add(mingwX64())
-    knTargets.add(linuxX64())
-
-    //disable compilations depending on host because of cross compilation linking issues
-    //see: https://youtrack.jetbrains.com/issue/KT-30498
-    if (HostManager.hostIsLinux) {
-      knTargets.remove(targets.linuxX64)
-    } else if (HostManager.hostIsMingw) {
-      knTargets.remove(targets.mingwX64)
-    } else {
-      knTargets.removeAll([
-            targets.macosX64,
-            targets.iosArm32,
-            targets.iosArm64,
-            targets.iosX64,
-            targets.watchosArm32,
-            targets.watchosArm64,
-            targets.watchosX86,
-            targets.watchosX64,
-            targets.tvosArm64,
-            targets.tvosX64
-      ])
-    }
-    disableCompilation(knTargets)
+    macosX64()
+    iosArm32()
+    iosArm64()
+    iosX64()
+    watchosArm32()
+    watchosArm64()
+    watchosX86()
+    watchosX64()
+    tvosArm64()
+    tvosX64()
+    mingwX64()
+    linuxX64()
   }
 
   sourceSets {
@@ -127,6 +82,13 @@ kotlin {
         kotlinOptions.freeCompilerArgs += ["-linker-options", "-L$projectDir\\libs".toString()]
         kotlinOptions.freeCompilerArgs += ["-linker-options", "-lsqlite3"]
       }
+    }
+
+    //linking fails for the linux test build if not built on a linux host
+    //ensure the tests and linking for them is only done on linux hosts
+    if(!HostManager.hostIsLinux) {
+      tasks.findByName("linuxX64Test")?.enabled = false
+      tasks.findByName("linkDebugTestLinuxX64")?.enabled = false
     }
   }
 }

--- a/drivers/native-driver/build.gradle
+++ b/drivers/native-driver/build.gradle
@@ -58,8 +58,15 @@ kotlin {
   }
 
   if (!ideaActive) {
-    configure([targets.iosX64, targets.iosArm32, targets.iosArm64, targets.tvosX64, targets.tvosArm64, targets.watchosX86, targets.watchosX64, targets.watchosArm32, targets.watchosArm64, targets.macosX64, targets.linuxX64]) {
+    configure([targets.iosX64, targets.iosArm32, targets.iosArm64, targets.tvosX64, targets.tvosArm64, targets.watchosX86, targets.watchosX64, targets.watchosArm32, targets.watchosArm64, targets.macosX64]) {
       compilations.main.source(sourceSets.nativeDarwinMain)
+      compilations.test.source(sourceSets.nativeTest)
+      compilations.test {
+        kotlinOptions.freeCompilerArgs += ["-linker-options", "-lsqlite3"]
+      }
+    }
+    configure([targets.linuxX64]) {
+      compilations.main.source(sourceSets.linuxMain)
       compilations.test.source(sourceSets.nativeTest)
       compilations.test {
         kotlinOptions.freeCompilerArgs += ["-linker-options", "-lsqlite3 -L/usr/lib/x86_64-linux-gnu -L/usr/lib"]

--- a/drivers/native-driver/build.gradle
+++ b/drivers/native-driver/build.gradle
@@ -7,6 +7,7 @@ kotlin {
     macosX64("native")
 //    macosX64("nativeDarwin") // Uncomment to get IDE recognition for darwin code until HMPP fixed
     mingwX64("mingw")
+    linuxX64("linux")
   } else {
     macosX64()
     iosArm32()
@@ -19,6 +20,7 @@ kotlin {
     tvosArm64()
     tvosX64()
     mingwX64()
+    linuxX64()
   }
 
   sourceSets {
@@ -50,14 +52,17 @@ kotlin {
     mingwMain{
       dependsOn(nativeMain)
     }
+    linuxMain{
+      dependsOn(nativeMain)
+    }
   }
 
   if (!ideaActive) {
-    configure([targets.iosX64, targets.iosArm32, targets.iosArm64, targets.tvosX64, targets.tvosArm64, targets.watchosX86, targets.watchosX64, targets.watchosArm32, targets.watchosArm64, targets.macosX64]) {
+    configure([targets.iosX64, targets.iosArm32, targets.iosArm64, targets.tvosX64, targets.tvosArm64, targets.watchosX86, targets.watchosX64, targets.watchosArm32, targets.watchosArm64, targets.macosX64, targets.linuxX64]) {
       compilations.main.source(sourceSets.nativeDarwinMain)
       compilations.test.source(sourceSets.nativeTest)
       compilations.test {
-        kotlinOptions.freeCompilerArgs += ["-linker-options", "-lsqlite3"]
+        kotlinOptions.freeCompilerArgs += ["-linker-options", "-lsqlite3 -L/usr/lib/x86_64-linux-gnu -L/usr/lib"]
       }
     }
     configure([targets.mingwX64]) {

--- a/drivers/native-driver/src/linuxMain/kotlin/com/squareup/sqldelight/drivers/native/util/NativeCache.kt
+++ b/drivers/native-driver/src/linuxMain/kotlin/com/squareup/sqldelight/drivers/native/util/NativeCache.kt
@@ -1,0 +1,18 @@
+package com.squareup.sqldelight.drivers.native.util
+
+import co.touchlab.stately.collections.SharedHashMap
+import co.touchlab.stately.collections.frozenHashMap
+
+internal actual fun <T : Any> nativeCache(): NativeCache<T> =
+  NativeCacheImpl()
+
+private class NativeCacheImpl<T : Any> : NativeCache<T> {
+  private val dictionary = frozenHashMap<String, T?>() as SharedHashMap<String, T?>
+
+  override fun put(key: String, value: T?): T? = dictionary.put(key, value)
+  override fun getOrCreate(key: String, block: () -> T): T = dictionary.getOrPut(key, block)!!
+  override fun remove(key: String): T? = dictionary.remove(key)
+  override fun cleanUp(block: (T) -> Unit) {
+    dictionary.values.filterNotNull().forEach(block)
+  }
+}

--- a/drivers/native-driver/src/linuxMain/kotlin/com/squareup/sqldelight/drivers/native/util/PoolLock.kt
+++ b/drivers/native-driver/src/linuxMain/kotlin/com/squareup/sqldelight/drivers/native/util/PoolLock.kt
@@ -1,0 +1,81 @@
+package com.squareup.sqldelight.drivers.native.util
+
+import co.touchlab.stately.concurrency.AtomicBoolean
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.free
+import kotlinx.cinterop.nativeHeap
+import kotlinx.cinterop.ptr
+import platform.posix.pthread_cond_destroy
+import platform.posix.pthread_cond_init
+import platform.posix.pthread_cond_signal
+import platform.posix.pthread_cond_tVar
+import platform.posix.pthread_cond_wait
+import platform.posix.pthread_mutex_destroy
+import platform.posix.pthread_mutex_init
+import platform.posix.pthread_mutex_lock
+import platform.posix.pthread_mutex_tVar
+import platform.posix.pthread_mutex_unlock
+
+internal actual class PoolLock actual constructor() {
+  private val isActive = AtomicBoolean(true)
+  private val mutex = nativeHeap.alloc<pthread_mutex_tVar>()
+    .apply { pthread_mutex_init(ptr, null) }
+  private val cond = nativeHeap.alloc<pthread_cond_tVar>()
+    .apply { pthread_cond_init(ptr, null) }
+
+  actual fun <R> withLock(
+    action: CriticalSection.() -> R
+  ): R {
+    check(isActive.value)
+    pthread_mutex_lock(mutex.ptr)
+
+    val result: R
+
+    try {
+      result = action(CriticalSection())
+    } finally {
+      pthread_mutex_unlock(mutex.ptr)
+    }
+
+    return result
+  }
+
+  actual fun notifyConditionChanged() {
+    pthread_cond_signal(cond.ptr)
+  }
+
+  actual fun close(): Boolean {
+    if (isActive.compareAndSet(expected = true, new = false)) {
+      pthread_cond_destroy(cond.ptr)
+      pthread_mutex_destroy(mutex.ptr)
+      nativeHeap.free(cond)
+      nativeHeap.free(mutex)
+      return true
+    }
+
+    return false
+  }
+
+  actual inner class CriticalSection {
+    actual fun <R> loopForConditionalResult(block: () -> R?): R {
+      check(isActive.value)
+
+      var result = block()
+
+      while (result == null) {
+        pthread_cond_wait(cond.ptr, mutex.ptr)
+        result = block()
+      }
+
+      return result
+    }
+
+    actual fun loopUntilConditionalResult(block: () -> Boolean) {
+      check(isActive.value)
+
+      while (!block()) {
+        pthread_cond_wait(cond.ptr, mutex.ptr)
+      }
+    }
+  }
+}

--- a/drivers/native-driver/src/linuxMain/kotlin/com/squareup/sqldelight/drivers/native/util/PoolLock.kt
+++ b/drivers/native-driver/src/linuxMain/kotlin/com/squareup/sqldelight/drivers/native/util/PoolLock.kt
@@ -8,19 +8,19 @@ import kotlinx.cinterop.ptr
 import platform.posix.pthread_cond_destroy
 import platform.posix.pthread_cond_init
 import platform.posix.pthread_cond_signal
-import platform.posix.pthread_cond_tVar
+import platform.posix.pthread_cond_t
 import platform.posix.pthread_cond_wait
 import platform.posix.pthread_mutex_destroy
 import platform.posix.pthread_mutex_init
 import platform.posix.pthread_mutex_lock
-import platform.posix.pthread_mutex_tVar
+import platform.posix.pthread_mutex_t
 import platform.posix.pthread_mutex_unlock
 
 internal actual class PoolLock actual constructor() {
   private val isActive = AtomicBoolean(true)
-  private val mutex = nativeHeap.alloc<pthread_mutex_tVar>()
+  private val mutex = nativeHeap.alloc<pthread_mutex_t>()
     .apply { pthread_mutex_init(ptr, null) }
-  private val cond = nativeHeap.alloc<pthread_cond_tVar>()
+  private val cond = nativeHeap.alloc<pthread_cond_t>()
     .apply { pthread_cond_init(ptr, null) }
 
   actual fun <R> withLock(

--- a/drivers/native-driver/src/linuxMain/kotlin/com/squareup/sqldelight/drivers/native/util/Stately.kt
+++ b/drivers/native-driver/src/linuxMain/kotlin/com/squareup/sqldelight/drivers/native/util/Stately.kt
@@ -1,0 +1,21 @@
+package com.squareup.sqldelight.drivers.native.util
+
+import co.touchlab.stately.collections.SharedHashMap
+import co.touchlab.stately.collections.SharedLinkedList
+
+/**
+ * This should probably be in Stately
+ */
+internal fun <T> SharedLinkedList<T>.cleanUp(block: (T) -> Unit) {
+  val extractList = ArrayList<T>(size)
+  extractList.addAll(this)
+  this.clear()
+  extractList.forEach(block)
+}
+
+internal fun <K, V> SharedHashMap<K, V>.cleanUp(block: (Map.Entry<K, V>) -> Unit) {
+  val extractMap = HashMap<K, V>(this.size)
+  extractMap.putAll(this)
+  this.clear()
+  extractMap.forEach(block)
+}

--- a/extensions/coroutines-extensions/build.gradle
+++ b/extensions/coroutines-extensions/build.gradle
@@ -87,12 +87,13 @@ kotlin {
   targetFromPreset(presets.watchosArm32, 'watchosArm32')
   targetFromPreset(presets.watchosArm64, 'watchosArm64')
   targetFromPreset(presets.macosX64, 'macosX64')
+  targetFromPreset(presets.linuxX64, 'linux')
 
-  configure([targets.iosX64, targets.iosArm32, targets.iosArm64, targets.tvosX64, targets.tvosArm64, targets.watchosX86, targets.watchosX64, targets.watchosArm32, targets.watchosArm64, targets.macosX64]) {
+  configure([targets.iosX64, targets.iosArm32, targets.iosArm64, targets.tvosX64, targets.tvosArm64, targets.watchosX86, targets.watchosX64, targets.watchosArm32, targets.watchosArm64, targets.macosX64, targets.linux]) {
     compilations.main.source(sourceSets.nativeMain)
     compilations.test {
       source(sourceSets.nativeTest)
-      kotlinOptions.freeCompilerArgs += ['-linker-options', '-lsqlite3']
+      kotlinOptions.freeCompilerArgs += ['-linker-options', '-lsqlite3 -L/usr/lib/x86_64-linux-gnu -L/usr/lib']
     }
   }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext.versions = [
     minSdk: 14,
     schemaCrawler: '14.16.04.01-java7',
     stately: '1.1.7',
-    sqliter: '1.0.4',
+    sqliter: '1.0.5',
     testhelp: '0.5.0',
     sqljs: '1.5.0',
     paging: '2.1.2',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext.versions = [
     minSdk: 14,
     schemaCrawler: '14.16.04.01-java7',
     stately: '1.1.7',
-    sqliter: '1.0.3',
+    sqliter: '1.0.4',
     testhelp: '0.5.0',
     sqljs: '1.5.0',
     paging: '2.1.2',

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -52,8 +52,9 @@ kotlin {
   targetFromPreset(presets.watchosArm64, 'watchosArm64')
   targetFromPreset(presets.macosX64, 'macosX64')
   targetFromPreset(presets.mingwX64, 'mingw')
+  targetFromPreset(presets.linuxX64, 'linux')
 
-  configure([targets.iosX64, targets.iosArm32, targets.iosArm64, targets.tvosX64, targets.tvosArm64, targets.watchosX86, targets.watchosX64, targets.watchosArm32, targets.watchosArm64, targets.macosX64, targets.mingw]) {
+  configure([targets.iosX64, targets.iosArm32, targets.iosArm64, targets.tvosX64, targets.tvosArm64, targets.watchosX86, targets.watchosX64, targets.watchosArm32, targets.watchosArm64, targets.macosX64, targets.mingw, targets.linux]) {
     compilations.main.source(sourceSets.nativeMain)
     compilations.test.source(sourceSets.nativeTest)
   }


### PR DESCRIPTION
Resolves #1835.
This adds the necessary `linuxX64` targets to support linux native-driver.
Uses `sqliter` version `1.0.5` which adds support for `linuxX64` as well