### PR TITLE
Don't use @JvmField for properties of an inline class

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/SelectQueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/SelectQueryGenerator.kt
@@ -292,7 +292,12 @@ class SelectQueryGenerator(private val query: NamedQuery) : QueryGenerator(query
       // val id: Int
       queryType.addProperty(
         PropertySpec.builder(parameter.name, parameter.argumentType())
-          .addAnnotation(JvmField::class)
+          .apply {
+            val annotations = Class.forName(parameter.javaType.toString().removeSuffix("?")).annotations
+            if (annotations.none { it.annotationClass == JvmInline::class }) {
+              addAnnotation(JvmField::class)
+            }
+          }
           .initializer(parameter.name)
           .build()
       )


### PR DESCRIPTION
Fixes #2449

@JakeWharton still not sure where this is coming from on Kotlin's side, or if this is a good solution to the problem. I also couldn't figure out a good way to test it (other than using `kotlin.time.Duration` in the tests since it is inline).