### PR TITLE
Don't annotate select query class properties with `@JvmField`

### DIFF
--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/testmodule/TestDatabaseImpl.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/testmodule/TestDatabaseImpl.kt
@@ -23,7 +23,6 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.Collection
 import kotlin.collections.MutableList
-import kotlin.jvm.JvmField
 import kotlin.reflect.KClass
 
 internal val KClass<TestDatabase>.schema: SqlDriver.Schema
@@ -157,7 +156,6 @@ private class TeamQueriesImpl(
   }
 
   private inner class TeamForCoachQuery<out T : Any>(
-    @JvmField
     public val coach: String,
     mapper: (SqlCursor) -> T
   ) : Query<T>(teamForCoach, mapper) {
@@ -173,7 +171,6 @@ private class TeamQueriesImpl(
   }
 
   private inner class ForInnerTypeQuery<out T : Any>(
-    @JvmField
     public val inner_type: Shoots.Type?,
     mapper: (SqlCursor) -> T
   ) : Query<T>(forInnerType, mapper) {
@@ -350,7 +347,6 @@ private class PlayerQueriesImpl(
   }
 
   private inner class PlayersForTeamQuery<out T : Any>(
-    @JvmField
     public val team: String?,
     mapper: (SqlCursor) -> T
   ) : Query<T>(playersForTeam, mapper) {
@@ -366,7 +362,6 @@ private class PlayerQueriesImpl(
   }
 
   private inner class PlayersForNumbersQuery<out T : Any>(
-    @JvmField
     public val number: Collection<Long>,
     mapper: (SqlCursor) -> T
   ) : Query<T>(playersForNumbers, mapper) {

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/SelectQueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/SelectQueryGenerator.kt
@@ -292,7 +292,6 @@ class SelectQueryGenerator(private val query: NamedQuery) : QueryGenerator(query
       // val id: Int
       queryType.addProperty(
         PropertySpec.builder(parameter.name, parameter.argumentType())
-          .addAnnotation(JvmField::class)
           .initializer(parameter.name)
           .build()
       )

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/QueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/QueriesTypeTest.kt
@@ -55,7 +55,6 @@ class QueriesTypeTest {
       |import kotlin.Unit
       |import kotlin.collections.List
       |import kotlin.collections.MutableList
-      |import kotlin.jvm.JvmField
       |import kotlin.reflect.KClass
       |
       |internal val KClass<TestDatabase>.schema: SqlDriver.Schema
@@ -125,7 +124,6 @@ class QueriesTypeTest {
       |  }
       |
       |  private inner class SelectForIdQuery<out T : Any>(
-      |    @JvmField
       |    public val id: Long,
       |    mapper: (SqlCursor) -> T
       |  ) : Query<T>(selectForId, mapper) {
@@ -189,7 +187,6 @@ class QueriesTypeTest {
       |import kotlin.Unit
       |import kotlin.collections.List
       |import kotlin.collections.MutableList
-      |import kotlin.jvm.JvmField
       |import kotlin.reflect.KClass
       |
       |internal val KClass<TestDatabase>.schema: SqlDriver.Schema
@@ -259,7 +256,6 @@ class QueriesTypeTest {
       |  }
       |
       |  private inner class SelectForIdQuery<out T : Any>(
-      |    @JvmField
       |    public val id: Long,
       |    mapper: (SqlCursor) -> T
       |  ) : Query<T>(selectForId, mapper) {
@@ -322,7 +318,6 @@ class QueriesTypeTest {
       |import kotlin.String
       |import kotlin.Unit
       |import kotlin.collections.MutableList
-      |import kotlin.jvm.JvmField
       |import kotlin.reflect.KClass
       |
       |internal val KClass<TestDatabase>.schema: SqlDriver.Schema
@@ -392,7 +387,6 @@ class QueriesTypeTest {
       |  }
       |
       |  private inner class SelectOffsetsQuery<out T : Any>(
-      |    @JvmField
       |    public val search: String,
       |    mapper: (SqlCursor) -> T
       |  ) : Query<T>(selectOffsets, mapper) {

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryFunctionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryFunctionTest.kt
@@ -286,9 +286,7 @@ class SelectQueryFunctionTest {
     assertThat(generator.querySubtype().toString()).isEqualTo(
       """
       |private inner class SelectForIdQuery<out T : kotlin.Any>(
-      |  @kotlin.jvm.JvmField
       |  public val good: kotlin.collections.Collection<kotlin.Long>,
-      |  @kotlin.jvm.JvmField
       |  public val bad: kotlin.collections.Collection<kotlin.Long>,
       |  mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(selectForId, mapper) {
@@ -403,7 +401,6 @@ class SelectQueryFunctionTest {
     assertThat(generator.querySubtype().toString()).isEqualTo(
       """
       |private inner class EquivalentNamesNamedQuery<out T : kotlin.Any>(
-      |  @kotlin.jvm.JvmField
       |  public val name: kotlin.String,
       |  mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(equivalentNamesNamed, mapper) {

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/queries/SelectQueryTypeTest.kt
@@ -39,7 +39,6 @@ class SelectQueryTypeTest {
     assertThat(generator.querySubtype().toString()).isEqualTo(
       """
       |private inner class SelectForIdQuery<out T : kotlin.Any>(
-      |  @kotlin.jvm.JvmField
       |  public val id: kotlin.Long,
       |  mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(selectForId, mapper) {
@@ -80,9 +79,7 @@ class SelectQueryTypeTest {
     assertThat(generator.querySubtype().toString()).isEqualTo(
       """
       |private inner class SelectQuery<out T : kotlin.Any>(
-      |  @kotlin.jvm.JvmField
       |  public val value: kotlin.String,
-      |  @kotlin.jvm.JvmField
       |  public val id: kotlin.Long,
       |  mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(select, mapper) {
@@ -122,7 +119,6 @@ class SelectQueryTypeTest {
     assertThat(generator.querySubtype().toString()).isEqualTo(
       """
       |private inner class SelectForIdQuery<out T : kotlin.Any>(
-      |  @kotlin.jvm.JvmField
       |  public val id: kotlin.collections.Collection<kotlin.Long>,
       |  mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(selectForId, mapper) {
@@ -166,9 +162,7 @@ class SelectQueryTypeTest {
     assertThat(generator.querySubtype().toString()).isEqualTo(
       """
       |private inner class SelectForIdQuery<out T : kotlin.Any>(
-      |  @kotlin.jvm.JvmField
       |  public val id: kotlin.collections.Collection<kotlin.Long>,
-      |  @kotlin.jvm.JvmField
       |  public val message: kotlin.String,
       |  mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(selectForId, mapper) {
@@ -216,7 +210,6 @@ class SelectQueryTypeTest {
     assertThat(generator.querySubtype().toString()).isEqualTo(
       """
        |private inner class Select_news_listQuery<out T : kotlin.Any>(
-       |  @kotlin.jvm.JvmField
        |  public val userId: kotlin.String?,
        |  mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
        |) : com.squareup.sqldelight.Query<T>(select_news_list, mapper) {
@@ -253,9 +246,7 @@ class SelectQueryTypeTest {
     assertThat(generator.querySubtype().toString()).isEqualTo(
       """
        |private inner class SelectDataQuery<out T : kotlin.Any>(
-       |  @kotlin.jvm.JvmField
        |  public val userId: kotlin.String?,
-       |  @kotlin.jvm.JvmField
        |  public val username: kotlin.String,
        |  mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
        |) : com.squareup.sqldelight.Query<T>(selectData, mapper) {
@@ -299,13 +290,9 @@ class SelectQueryTypeTest {
     assertThat(generator.querySubtype().toString()).isEqualTo(
       """
       |private inner class SelectForIdQuery<out T : kotlin.Any>(
-      |  @kotlin.jvm.JvmField
       |  public val val_: kotlin.String?,
-      |  @kotlin.jvm.JvmField
       |  public val val__: kotlin.String?,
-      |  @kotlin.jvm.JvmField
       |  public val val___: kotlin.String?,
-      |  @kotlin.jvm.JvmField
       |  public val val____: kotlin.String?,
       |  mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(selectForId, mapper) {
@@ -350,9 +337,7 @@ class SelectQueryTypeTest {
     assertThat(generator.querySubtype().toString()).isEqualTo(
       """
       |private inner class SelectMatchingQuery<out T : kotlin.Any>(
-      |  @kotlin.jvm.JvmField
       |  public val `data`: kotlin.String,
-      |  @kotlin.jvm.JvmField
       |  public val rowid: kotlin.Long,
       |  mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(selectMatching, mapper) {
@@ -394,7 +379,6 @@ class SelectQueryTypeTest {
     assertThat(generator.querySubtype().toString()).isEqualTo(
       """
       |private inner class SelectMatchingQuery<out T : kotlin.Any>(
-      |  @kotlin.jvm.JvmField
       |  public val value: kotlin.String,
       |  mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(selectMatching, mapper) {
@@ -437,13 +421,9 @@ class SelectQueryTypeTest {
     assertThat(generator.querySubtype().toString()).isEqualTo(
       """
       |private inner class SelectForIdQuery<out T : kotlin.Any>(
-      |  @kotlin.jvm.JvmField
       |  public val token: kotlin.String,
-      |  @kotlin.jvm.JvmField
       |  public val id: kotlin.collections.Collection<kotlin.Long>,
-      |  @kotlin.jvm.JvmField
       |  public val name: kotlin.String,
-      |  @kotlin.jvm.JvmField
       |  public val token_: kotlin.collections.Collection<kotlin.String>,
       |  mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(selectForId, mapper) {
@@ -500,11 +480,8 @@ class SelectQueryTypeTest {
     assertThat(generator.querySubtype().toString()).isEqualTo(
       """
       |private inner class SelectForIdQuery<out T : kotlin.Any>(
-      |  @kotlin.jvm.JvmField
       |  public val id: kotlin.Long?,
-      |  @kotlin.jvm.JvmField
       |  public val limit: kotlin.Long,
-      |  @kotlin.jvm.JvmField
       |  public val offset: kotlin.Long,
       |  mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(selectForId, mapper) {
@@ -550,7 +527,6 @@ class SelectQueryTypeTest {
     assertThat(generator.querySubtype().toString()).isEqualTo(
       """
       |private inner class SelectForIdsQuery<out T : kotlin.Any>(
-      |  @kotlin.jvm.JvmField
       |  public val id: kotlin.collections.Collection<foo.Bar?>,
       |  mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(selectForIds, mapper) {
@@ -596,7 +572,6 @@ class SelectQueryTypeTest {
     assertThat(generator.querySubtype().toString()).isEqualTo(
       """
       |private inner class SelectByTokenOrAllQuery<out T : kotlin.Any>(
-      |  @kotlin.jvm.JvmField
       |  public val token: kotlin.String?,
       |  mapper: (com.squareup.sqldelight.db.SqlCursor) -> T
       |) : com.squareup.sqldelight.Query<T>(selectByTokenOrAll, mapper) {


### PR DESCRIPTION
  - Kotlin 1.5.20 produces a warning when a constructor property type that is an inline class is annotated with `@JvmField`
  - Since there is no way to know if the property is an inline class at compile time, `@JvmField` should be removed for now until there's a solution
    - if there ever is one

Fixes #2449