### PR TITLE
Fix IndexOutOfBounds after getRefreshKey

### DIFF
--- a/extensions/android-paging3/src/main/java/app/cash/sqldelight/paging3/OffsetQueryPagingSource.kt
+++ b/extensions/android-paging3/src/main/java/app/cash/sqldelight/paging3/OffsetQueryPagingSource.kt
@@ -37,7 +37,12 @@ internal class OffsetQueryPagingSource<RowType : Any>(
       transacter.transactionWithResult {
         val count = countQuery.executeAsOne()
         val key = when (params) {
-          is LoadParams.Refresh -> params.key?.coerceIn(minimumValue = 0L, maximumValue = count - 1)
+          is LoadParams.Refresh -> params.key?.coerceIn(
+            minimumValue = 0L,
+            // coerce this key so that the max value would be a key
+            // that has a full page refresh
+            maximumValue = count - params.loadSize
+          )
           else -> params.key
         } ?: 0L
 

--- a/extensions/android-paging3/src/main/java/app/cash/sqldelight/paging3/OffsetQueryPagingSource.kt
+++ b/extensions/android-paging3/src/main/java/app/cash/sqldelight/paging3/OffsetQueryPagingSource.kt
@@ -37,7 +37,7 @@ internal class OffsetQueryPagingSource<RowType : Any>(
       transacter.transactionWithResult {
         val count = countQuery.executeAsOne()
         val key = when (params) {
-          is LoadParams.Refresh -> params.key?.let { notNullKey -> minOf(count - 1, notNullKey) }
+          is LoadParams.Refresh -> params.key?.coerceIn(minimumValue = 0L, maximumValue = count - 1)
           else -> params.key
         } ?: 0L
 

--- a/extensions/android-paging3/src/main/java/app/cash/sqldelight/paging3/OffsetQueryPagingSource.kt
+++ b/extensions/android-paging3/src/main/java/app/cash/sqldelight/paging3/OffsetQueryPagingSource.kt
@@ -17,53 +17,50 @@ package app.cash.sqldelight.paging3
 
 import androidx.paging.PagingState
 import app.cash.sqldelight.Query
-import app.cash.sqldelight.Transacter
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
 internal class OffsetQueryPagingSource<RowType : Any>(
   private val queryProvider: (limit: Long, offset: Long) -> Query<RowType>,
   private val countQuery: Query<Long>,
-  private val transacter: Transacter,
   private val context: CoroutineContext,
 ) : QueryPagingSource<Long, RowType>() {
 
   override val jumpingSupported get() = true
+  private var cachedCount: Long? = null
 
   override suspend fun load(
     params: LoadParams<Long>,
   ): LoadResult<Long, RowType> = withContext(context) {
     try {
-      transacter.transactionWithResult {
-        val count = countQuery.executeAsOne()
-        val key = when (params) {
-          is LoadParams.Refresh -> params.key?.coerceIn(
-            minimumValue = 0L,
-            // coerce this key so that the max value would be a key
-            // that has a full page refresh
-            maximumValue = count - params.loadSize
-          )
-          else -> params.key
-        } ?: 0L
-
-        if (count != 0L && key >= count) throw IndexOutOfBoundsException()
-
-        val loadSize = if (key < 0) params.loadSize + key else params.loadSize
-
-        val data = queryProvider(loadSize.toLong(), maxOf(0, key))
-          .also { currentQuery = it }
-          .executeAsList()
-
-        LoadResult.Page(
-          data = data,
-          // allow one, and only one negative prevKey in a paging set. This is done for
-          // misaligned prepend queries to avoid duplicates.
-          prevKey = if (key <= 0L) null else key - params.loadSize,
-          nextKey = if (key + params.loadSize >= count) null else key + params.loadSize,
-          itemsBefore = maxOf(0L, key).toInt(),
-          itemsAfter = maxOf(0, (count - (key + params.loadSize))).toInt(),
+      val count = cachedCount ?: countQuery.executeAsOne().also { cachedCount = it }
+      val key = when (params) {
+        is LoadParams.Refresh -> params.key?.coerceIn(
+          minimumValue = 0L,
+          // coerce this key so that the max value would be a key
+          // that has a full page refresh
+          maximumValue = count - params.loadSize
         )
-      }
+        else -> params.key
+      } ?: 0L
+
+      if (count != 0L && key >= count) throw IndexOutOfBoundsException()
+
+      val loadSize = if (key < 0) params.loadSize + key else params.loadSize
+
+      val data = queryProvider(loadSize.toLong(), maxOf(0, key))
+        .also { currentQuery = it }
+        .executeAsList()
+
+      LoadResult.Page(
+        data = data,
+        // allow one, and only one negative prevKey in a paging set. This is done for
+        // misaligned prepend queries to avoid duplicates.
+        prevKey = if (key <= 0L) null else key - params.loadSize,
+        nextKey = if (key + params.loadSize >= count) null else key + params.loadSize,
+        itemsBefore = maxOf(0L, key).toInt(),
+        itemsAfter = maxOf(0, (count - (key + params.loadSize))).toInt()
+      )
     } catch (e: Exception) {
       if (e is IndexOutOfBoundsException) throw e
       LoadResult.Error(e)

--- a/extensions/android-paging3/src/main/java/app/cash/sqldelight/paging3/QueryPagingSource.kt
+++ b/extensions/android-paging3/src/main/java/app/cash/sqldelight/paging3/QueryPagingSource.kt
@@ -60,13 +60,11 @@ internal abstract class QueryPagingSource<Key : Any, RowType : Any> :
 @Suppress("FunctionName")
 fun <RowType : Any> QueryPagingSource(
   countQuery: Query<Long>,
-  transacter: Transacter,
   context: CoroutineContext = Dispatchers.IO,
   queryProvider: (limit: Long, offset: Long) -> Query<RowType>,
 ): PagingSource<Long, RowType> = OffsetQueryPagingSource(
   queryProvider,
   countQuery,
-  transacter,
   context,
 )
 

--- a/extensions/android-paging3/src/test/java/app/cash/sqldelight/paging3/OffsetQueryPagingSourceTest.kt
+++ b/extensions/android-paging3/src/test/java/app/cash/sqldelight/paging3/OffsetQueryPagingSourceTest.kt
@@ -235,8 +235,22 @@ class OffsetQueryPagingSourceTest {
 
     runBlocking {
       assertFailsWith<IndexOutOfBoundsException> {
-        source.load(Refresh(10, 2, false))
+        source.load(PagingSource.LoadParams.Append(10, 2, false))
       }
+    }
+  }
+
+  @Test fun `refresh key too big gets truncated`() {
+    val source = OffsetQueryPagingSource(
+      this::query,
+      countQuery(),
+      transacter,
+      TestCoroutineDispatcher()
+    )
+
+    runBlocking {
+      val results = source.load(Refresh(10, 2, false))
+      assertEquals(listOf(9L), (results as LoadResult.Page).data)
     }
   }
 

--- a/extensions/android-paging3/src/test/java/app/cash/sqldelight/paging3/OffsetQueryPagingSourceTest.kt
+++ b/extensions/android-paging3/src/test/java/app/cash/sqldelight/paging3/OffsetQueryPagingSourceTest.kt
@@ -120,7 +120,7 @@ class OffsetQueryPagingSourceTest {
 
     val results = runBlocking { source.load(Refresh(9, 2, false)) }
 
-    assertEquals(7L, (results as LoadResult.Page).prevKey)
+    assertEquals(6L, (results as LoadResult.Page).prevKey)
     assertNull(results.nextKey)
   }
 
@@ -188,7 +188,7 @@ class OffsetQueryPagingSourceTest {
       EmptyCoroutineContext,
     )
 
-    val results = runBlocking { source.load(Refresh(9, 2, false)) }
+    val results = runBlocking { source.load(Append(9, 2, false)) }
 
     assertEquals(9, (results as LoadResult.Page).itemsBefore)
     assertEquals(0, results.itemsAfter)
@@ -242,7 +242,7 @@ class OffsetQueryPagingSourceTest {
     }
   }
 
-  @Test fun `refresh key too big gets truncated`() {
+  @Test fun `refresh key too big gets coerced to have full refresh page`() {
     val source = OffsetQueryPagingSource(
       this::query,
       countQuery(),
@@ -252,7 +252,7 @@ class OffsetQueryPagingSourceTest {
 
     runBlocking {
       val results = source.load(Refresh(10, 2, false))
-      assertEquals(listOf(9L), (results as LoadResult.Page).data)
+      assertEquals(listOf(8L, 9L), (results as LoadResult.Page).data)
     }
   }
 

--- a/extensions/android-paging3/src/test/java/app/cash/sqldelight/paging3/OffsetQueryPagingSourceTest.kt
+++ b/extensions/android-paging3/src/test/java/app/cash/sqldelight/paging3/OffsetQueryPagingSourceTest.kt
@@ -15,7 +15,9 @@
  */
 package app.cash.sqldelight.paging3
 
+import androidx.paging.PagingSource
 import androidx.paging.PagingSource.LoadParams.Refresh
+import androidx.paging.PagingSource.LoadParams.Append
 import androidx.paging.PagingSource.LoadResult
 import app.cash.sqldelight.Query
 import app.cash.sqldelight.Transacter
@@ -218,7 +220,7 @@ class OffsetQueryPagingSourceTest {
       val expected = listOf(listOf(1L, 2L), listOf(0L)).iterator()
       var prevKey: Long? = 1L
       do {
-        val results = source.load(Refresh(prevKey, 2, false))
+        val results = source.load(PagingSource.LoadParams.Prepend(prevKey!!, 2, false))
         assertEquals(expected.next(), (results as LoadResult.Page).data)
         prevKey = results.prevKey
       } while (prevKey != null)
@@ -235,7 +237,7 @@ class OffsetQueryPagingSourceTest {
 
     runBlocking {
       assertFailsWith<IndexOutOfBoundsException> {
-        source.load(PagingSource.LoadParams.Append(10, 2, false))
+        source.load(Append(10, 2, false))
       }
     }
   }

--- a/extensions/android-paging3/src/test/java/app/cash/sqldelight/paging3/OffsetQueryPagingSourceTest.kt
+++ b/extensions/android-paging3/src/test/java/app/cash/sqldelight/paging3/OffsetQueryPagingSourceTest.kt
@@ -16,8 +16,8 @@
 package app.cash.sqldelight.paging3
 
 import androidx.paging.PagingSource
-import androidx.paging.PagingSource.LoadParams.Refresh
 import androidx.paging.PagingSource.LoadParams.Append
+import androidx.paging.PagingSource.LoadParams.Refresh
 import androidx.paging.PagingSource.LoadResult
 import app.cash.sqldelight.Query
 import app.cash.sqldelight.Transacter
@@ -53,7 +53,6 @@ class OffsetQueryPagingSourceTest {
     val source = OffsetQueryPagingSource(
       this::query,
       countQuery(),
-      transacter,
       EmptyCoroutineContext,
     )
 
@@ -67,7 +66,6 @@ class OffsetQueryPagingSourceTest {
     val source = OffsetQueryPagingSource(
       this::query,
       countQuery(),
-      transacter,
       EmptyCoroutineContext,
     )
 
@@ -81,7 +79,6 @@ class OffsetQueryPagingSourceTest {
     val source = OffsetQueryPagingSource(
       this::query,
       countQuery(),
-      transacter,
       EmptyCoroutineContext,
     )
 
@@ -95,7 +92,6 @@ class OffsetQueryPagingSourceTest {
     val source = OffsetQueryPagingSource(
       this::query,
       countQuery(),
-      transacter,
       EmptyCoroutineContext,
     )
 
@@ -114,7 +110,6 @@ class OffsetQueryPagingSourceTest {
     val source = OffsetQueryPagingSource(
       this::query,
       countQuery(),
-      transacter,
       EmptyCoroutineContext,
     )
 
@@ -128,7 +123,6 @@ class OffsetQueryPagingSourceTest {
     val source = OffsetQueryPagingSource(
       this::query,
       countQuery(),
-      transacter,
       EmptyCoroutineContext,
     )
 
@@ -142,7 +136,6 @@ class OffsetQueryPagingSourceTest {
     val source = OffsetQueryPagingSource(
       this::query,
       countQuery(),
-      transacter,
       EmptyCoroutineContext,
     )
 
@@ -156,7 +149,6 @@ class OffsetQueryPagingSourceTest {
     val source = OffsetQueryPagingSource(
       this::query,
       countQuery(),
-      transacter,
       EmptyCoroutineContext,
     )
 
@@ -170,7 +162,6 @@ class OffsetQueryPagingSourceTest {
     val source = OffsetQueryPagingSource(
       this::query,
       countQuery(),
-      transacter,
       EmptyCoroutineContext,
     )
 
@@ -184,7 +175,6 @@ class OffsetQueryPagingSourceTest {
     val source = OffsetQueryPagingSource(
       this::query,
       countQuery(),
-      transacter,
       EmptyCoroutineContext,
     )
 
@@ -198,7 +188,6 @@ class OffsetQueryPagingSourceTest {
     val source = OffsetQueryPagingSource(
       this::query,
       countQuery(),
-      transacter,
       EmptyCoroutineContext,
     )
 
@@ -212,7 +201,6 @@ class OffsetQueryPagingSourceTest {
     val source = OffsetQueryPagingSource(
       this::query,
       countQuery(),
-      transacter,
       EmptyCoroutineContext,
     )
 
@@ -231,7 +219,6 @@ class OffsetQueryPagingSourceTest {
     val source = OffsetQueryPagingSource(
       this::query,
       countQuery(),
-      transacter,
       EmptyCoroutineContext,
     )
 
@@ -246,8 +233,7 @@ class OffsetQueryPagingSourceTest {
     val source = OffsetQueryPagingSource(
       this::query,
       countQuery(),
-      transacter,
-      TestCoroutineDispatcher()
+      EmptyCoroutineContext,
     )
 
     runBlocking {
@@ -261,7 +247,6 @@ class OffsetQueryPagingSourceTest {
     val source = OffsetQueryPagingSource(
       { _, _ -> query },
       countQuery(),
-      transacter,
       EmptyCoroutineContext,
     )
 


### PR DESCRIPTION
It's possible that on a paging source that's not in the initial
generation, we fail with an `IndexOutOfBoundsException`. This
is caused when the underlying data source undergoes a delete, which
then invalidates the paging source, which then calls
`getRefreshKey`. In the event that the the refresh key is the
very last index of the previous paging source, we would fail
with the above exception because that index does not exist
in the next generation paging source.

Closes #2434.
