### PR TITLE
Remove explicit setting of JVM target

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 import org.jetbrains.grammarkit.tasks.GenerateParser
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
   apply from: "$rootDir/gradle/dependencies.gradle"
@@ -60,17 +59,6 @@ allprojects {
     testLogging {
       events = ["failed", "skipped", "passed"]
       exceptionFormat "full"
-    }
-  }
-
-  plugins.withId("org.jetbrains.kotlin.jvm") {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-  }
-
-  tasks.withType(KotlinCompile).configureEach {
-    kotlinOptions {
-      jvmTarget = "1.8"
     }
   }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 buildscript {
   apply from: "$rootDir/../gradle/dependencies.gradle"
 
@@ -24,16 +22,5 @@ allprojects {
   repositories {
     mavenCentral()
     google()
-  }
-
-  plugins.withId("org.jetbrains.kotlin.jvm") {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-  }
-
-  tasks.withType(KotlinCompile).configureEach {
-    kotlinOptions {
-      jvmTarget = "1.8"
-    }
   }
 }


### PR DESCRIPTION
Starting with Kotlin 1.5, the [new default JVM target is 1.8](https://kotlinlang.org/docs/whatsnew15.html#new-default-jvm-target-1-8), so we don't have to explicitly specify it anymore.