### PR TITLE
Upgrade Android Gradle Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,13 +68,6 @@ allprojects {
     targetCompatibility = JavaVersion.VERSION_1_8
   }
 
-  plugins.withId("com.android.library") {
-    extensions.getByName("android").compileOptions {
-      sourceCompatibility JavaVersion.VERSION_1_8
-      targetCompatibility JavaVersion.VERSION_1_8
-    }
-  }
-
   tasks.withType(KotlinCompile).configureEach {
     kotlinOptions {
       jvmTarget = "1.8"

--- a/extensions/android-paging/build.gradle
+++ b/extensions/android-paging/build.gradle
@@ -6,11 +6,6 @@ archivesBaseName = 'sqldelight-android-paging'
 android {
   compileSdkVersion versions.compileSdk
 
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_7
-    targetCompatibility JavaVersion.VERSION_1_7
-  }
-
   lintOptions {
     textReport true
     textOutput 'stdout'

--- a/extensions/android-paging3/build.gradle
+++ b/extensions/android-paging3/build.gradle
@@ -6,11 +6,6 @@ archivesBaseName = 'sqldelight-android-paging3'
 android {
   compileSdkVersion versions.compileSdk
 
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_7
-    targetCompatibility JavaVersion.VERSION_1_7
-  }
-
   lintOptions {
     textReport true
     textOutput 'stdout'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -18,7 +18,7 @@ ext.versions = [
 
 ext.deps = [
     plugins: [
-        android: 'com.android.tools.build:gradle:4.1.3',
+        android: 'com.android.tools.build:gradle:4.2.2',
         kotlin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
         dokka: "org.jetbrains.dokka:dokka-gradle-plugin:${versions.dokka}",
         download: "de.undercouch:gradle-download-task:3.4.2",

--- a/sample/android/build.gradle
+++ b/sample/android/build.gradle
@@ -33,11 +33,6 @@ android {
       signingConfig signingConfigs.debug
     }
   }
-
-  compileOptions {
-    sourceCompatibility 1.8
-    targetCompatibility 1.8
-  }
 }
 
 dependencies {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -32,13 +32,6 @@ allprojects {
     targetCompatibility = JavaVersion.VERSION_1_8
   }
 
-  plugins.withId("com.android.library") {
-    extensions.getByName("android").compileOptions {
-      sourceCompatibility JavaVersion.VERSION_1_8
-      targetCompatibility JavaVersion.VERSION_1_8
-    }
-  }
-
   tasks.withType(KotlinCompile).configureEach {
     kotlinOptions {
       jvmTarget = "1.8"

--- a/sqldelight-gradle-plugin/src/test/integration-android-library/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-android-library/build.gradle
@@ -48,11 +48,6 @@ android {
   packagingOptions {
     exclude 'LICENSE.txt'
   }
-
-  compileOptions {
-    targetCompatibility 1.8
-    sourceCompatibility 1.8
-  }
 }
 
 afterEvaluate {

--- a/sqldelight-gradle-plugin/src/test/integration-android-variants/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-android-variants/build.gradle
@@ -41,9 +41,4 @@ android {
   packagingOptions {
     exclude 'LICENSE.txt'
   }
-
-  compileOptions {
-    targetCompatibility 1.8
-    sourceCompatibility 1.8
-  }
 }

--- a/sqldelight-gradle-plugin/src/test/integration-android/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-android/build.gradle
@@ -48,11 +48,6 @@ android {
   packagingOptions {
     exclude 'LICENSE.txt'
   }
-
-  compileOptions {
-    targetCompatibility 1.8
-    sourceCompatibility 1.8
-  }
 }
 
 afterEvaluate {

--- a/sqldelight-gradle-plugin/src/test/integration-multiplatform/android-build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-multiplatform/android-build.gradle
@@ -28,11 +28,6 @@ android {
     textOutput 'stdout'
     textReport true
   }
-
-  compileOptions {
-    targetCompatibility 1.8
-    sourceCompatibility 1.8
-  }
 }
 
 sqldelight {

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/properties/PropertiesFileTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/properties/PropertiesFileTest.kt
@@ -72,11 +72,6 @@ class PropertiesFileTest {
         |android {
         |  compileSdkVersion versions.compileSdk
         |
-        |  compileOptions {
-        |    sourceCompatibility JavaVersion.VERSION_1_8
-        |    targetCompatibility JavaVersion.VERSION_1_8
-        |  }
-        |
         |  defaultConfig {
         |    minSdkVersion versions.minSdk
         |  }


### PR DESCRIPTION
Per the [release notes](https://developer.android.com/studio/releases/gradle-plugin#4-2-0), AGP now uses Java 8 by default.