### PR TITLE
Remove unnecessary Bintray repository url

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -24,7 +24,6 @@ allprojects {
   repositories {
     mavenCentral()
     google()
-    maven { url 'https://dl.bintray.com/kotlin/kotlinx' }
   }
 
   plugins.withId("org.jetbrains.kotlin.jvm") {


### PR DESCRIPTION
The `kotlinx-html-js` version we're using is on Maven Central (https://github.com/cashapp/sqldelight/pull/2478/commits/11b274d0bbfec20e3367eb77930f637b75810ce2) so we can remove the Bintray repository url that was required for previous versions.