### PR TITLE
add row_count function to mysql

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/FunctionExprMixin.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/FunctionExprMixin.kt
@@ -102,6 +102,7 @@ internal class FunctionExprMixin(node: ASTNode?) : SqlFunctionExprImpl(node) {
     "greatest" -> encapsulatingType(exprList, SqliteType.INTEGER, SqliteType.REAL, SqliteType.TEXT, SqliteType.BLOB)
     "concat" -> encapsulatingType(exprList, SqliteType.TEXT)
     "last_insert_id" -> IntermediateType(SqliteType.INTEGER)
+    "row_count" -> IntermediateType(SqliteType.INTEGER)
     "month", "year", "minute" -> IntermediateType(SqliteType.INTEGER)
     "sin", "cos", "tan" -> IntermediateType(SqliteType.REAL)
     else -> null


### PR DESCRIPTION
Hello!

this adds ROW_COUNT function to mysql

(ps: is the omission is intentional?
  -- I mean, from some discussions, I was wondering if this function was omitted because it shouldn't be called directly