### PR TITLE
Update SQLiter to v1.0.8

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ ext.versions = [
     minSdk: 14,
     schemaCrawler: '14.16.04.01-java7',
     stately: '1.1.7',
-    sqliter: '1.0.3',
+    sqliter: '1.0.8',
     testhelp: '0.5.0',
     sqljs: '1.5.0',
     paging: '2.1.2',


### PR DESCRIPTION
Updated SQLiter dependency to [v1.0.8](https://github.com/touchlab/SQLiter/releases/tag/v1.0.8) where HMPP is now compatible with Kotlin 1.5.30.