### PR TITLE
Don't warn with "Join compares two columns of different types" when joining nullable with non-nullable type

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/TypedColumn.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/TypedColumn.kt
@@ -34,4 +34,4 @@ internal interface TypedColumn {
 }
 
 fun SqlColumnName.isColumnSameAs(other: SqlColumnName) = type().let { it.column != null && it.column == other.type().column }
-fun SqlColumnName.isTypeSameAs(other: SqlColumnName) = type().javaType == other.type().javaType
+fun SqlColumnName.isTypeSameAs(other: SqlColumnName) = type().asNonNullable().javaType == other.type().asNonNullable().javaType

--- a/sqldelight-idea-plugin/src/test/kotlin/com/squareup/sqldelight/intellij/inspections/MismatchJoinColumnInspectionTest.kt
+++ b/sqldelight-idea-plugin/src/test/kotlin/com/squareup/sqldelight/intellij/inspections/MismatchJoinColumnInspectionTest.kt
@@ -7,7 +7,7 @@ class MismatchJoinColumnInspectionTest : SqlDelightFixtureTestCase() {
 
   override val fixtureDirectory: String = "join-inspections"
 
-  fun testUnusedImportInspection() {
+  fun testMismatchJoinColumnInspection() {
     myFixture.testInspection("", LocalInspectionToolWrapper(MismatchJoinColumnInspection()))
   }
 }

--- a/sqldelight-idea-plugin/testData/join-inspections/src/DifferentTypes.sq
+++ b/sqldelight-idea-plugin/testData/join-inspections/src/DifferentTypes.sq
@@ -8,6 +8,11 @@ SELECT *
 FROM thread
 INNER JOIN message ON thread.foreign_key = message.custom_key;
 
+proper_select_nullable_with_non_nullable:
+SELECT *
+FROM thread
+INNER JOIN message ON thread.nullable_foreign_key = message.custom_key;
+
 CREATE TABLE IF NOT EXISTS message (
     _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
     custom_key TEXT NOT NULL UNIQUE,
@@ -21,5 +26,7 @@ CREATE TABLE IF NOT EXISTS thread (
     _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
     title TEXT,
     foreign_key TEXT NOT NULL,
-    FOREIGN KEY(foreign_key) REFERENCES message(custom_key)
+    nullable_foreign_key TEXT,
+    FOREIGN KEY(foreign_key) REFERENCES message(custom_key),
+    FOREIGN KEY(nullable_foreign_key) REFERENCES message(custom_key)
 );


### PR DESCRIPTION
Fixes #2454