### PR TITLE
Update pip requirements path for Github Actions website publishing

### DIFF
--- a/.github/workflows/Publish-Website.yml
+++ b/.github/workflows/Publish-Website.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Build mkdocs
         run: |
-          pip3 install -r requirements.txt
+          pip3 install -r .github/workflows/requirements.txt
           mkdocs build
 
       - name: Deploy 🚀


### PR DESCRIPTION
Looks similar to my original failing setup here: https://github.com/cashapp/paparazzi/pull/242

So I figure the same problem exists in this repo?