### PR TITLE
Fix linux publication task execution

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -50,7 +50,7 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralRepositoryUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralRepositoryPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
-        run: ./gradlew publishLinuxPublicationToMavenRepository
+        run: ./gradlew publishLinuxX64PublicationToMavenRepository
 
   publish_plugin:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This fixes the linux publication as the linux targets for x64 were renamed from `linux` to `linuxX64` with https://github.com/cashapp/sqldelight/pull/2548. This updates the deploy workflow to execute `publishLinuxX64PublicationToMavenRepository` rather than the now non existent `publishLinuxPublicationToMavenRepository`.