### PR TITLE
Run all existing migrations for Android when database is created from scratch

### DIFF
--- a/drivers/android-driver/src/main/java/com/squareup/sqldelight/android/AndroidSqliteDriver.kt
+++ b/drivers/android-driver/src/main/java/com/squareup/sqldelight/android/AndroidSqliteDriver.kt
@@ -162,7 +162,10 @@ class AndroidSqliteDriver private constructor(
     ) : this(schema, *emptyArray())
 
     override fun onCreate(db: SupportSQLiteDatabase) {
-      schema.create(AndroidSqliteDriver(openHelper = null, database = db, cacheSize = 1))
+      val driver = AndroidSqliteDriver(openHelper = null, database = db, cacheSize = 1)
+
+      schema.create(driver)
+      schema.migrate(driver, 0, schema.version)
     }
 
     override fun onUpgrade(
@@ -170,13 +173,12 @@ class AndroidSqliteDriver private constructor(
       oldVersion: Int,
       newVersion: Int
     ) {
+      val driver = AndroidSqliteDriver(openHelper = null, database = db, cacheSize = 1)
+
       if (callbacks.isNotEmpty()) {
-        schema.migrateWithCallbacks(AndroidSqliteDriver(openHelper = null, database = db, cacheSize = 1), oldVersion, newVersion, *callbacks)
+        schema.migrateWithCallbacks(driver, oldVersion, newVersion, *callbacks)
       } else {
-        schema.migrate(
-          AndroidSqliteDriver(openHelper = null, database = db, cacheSize = 1),
-          oldVersion, newVersion
-        )
+        schema.migrate(driver, oldVersion, newVersion)
       }
     }
   }

--- a/sample/common/src/commonMain/kotlin/com/example/sqldelight/hockey/data/Schema.kt
+++ b/sample/common/src/commonMain/kotlin/com/example/sqldelight/hockey/data/Schema.kt
@@ -32,7 +32,7 @@ object Schema : SqlDriver.Schema by HockeyDb.Schema {
       val sharks = "San Jose Sharks"
 
       // Populate teams.
-      teamQueries.insertTeam(ducks, Date(1993, 3, 1), "Randy Carlyle", true)
+      teamQueries.insertTeam(ducks, Date(1993, 3, 1), "Bryan Murray", true)
       teamQueries.insertTeam(pens, Date(1966, 2, 8), "Mike Sullivan", true)
       teamQueries.insertTeam(sharks, Date(1990, 5, 5), "Peter DeBoer", false)
 


### PR DESCRIPTION
fix #2563 

Run `schema.migrate(driver, 0, schema.version)` when call `SupportSQLiteOpenHelper.Callback#onCreate`.