### PR TITLE
Update migrations.md

### DIFF
--- a/docs/common/migrations.md
+++ b/docs/common/migrations.md
@@ -2,6 +2,8 @@
 
 The `.sq` file always describes how to create the latest schema in an empty database. If your database is currently on an earlier version, migration files bring those databases up-to-date. 
 
+If the driver supports it, migrations are run in a transaction. You should not surround your migrations in `BEGIN/END TRANSACTION`, as this can cause a crash with some drivers.
+
 ## Versioning
 
 The first version of the schema is 1. Migration files are named `<version to upgrade from>.sqm`. To migrate to version 2, put migration statements in `1.sqm`:


### PR DESCRIPTION
On iOS we were experiencing a crash because we had added BEGIN/END TRANSACTION to our migrations. The error message indicated that a transaction had been nested – we checked the documentation and didn't find any mention of transactions running in a transaction, so it seemed like a good idea to mention it here.

Is this correct, though?  I couldn't find the relevant code to verify.