### PR TITLE
Set Java compatibility to Java8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,11 @@ allprojects {
     }
   }
 
+  tasks.withType(JavaCompile) {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+  }
+
   configurations {
     grammar
   }


### PR DESCRIPTION
This is similar to https://github.com/square/kotlinpoet/pull/1000 ﻿and makes sure Gradle metadata doesn't require Java11 if the project is built with Java11 (or greater)
