### PR TITLE
Fix IDE autocomplete for generated files for Android

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightDatabase.kt
@@ -9,6 +9,7 @@ import com.squareup.sqldelight.gradle.kotlin.sources
 import groovy.lang.GroovyObject
 import org.gradle.api.GradleException
 import org.gradle.api.Project
+import org.gradle.api.provider.Provider
 import java.io.File
 
 class SqlDelightDatabase(
@@ -145,14 +146,14 @@ class SqlDelightDatabase(
         it.verifyMigrations = verifyMigrations
       }
 
+      val outputDirectoryProvider: Provider<File> = task.map { it.outputDirectory!! }
+
       // Add the source dependency on the generated code.
-      source.sourceDirectorySet.srcDir(
-        // Use a Provider generated from the task to carry task dependencies
-        // See https://github.com/cashapp/sqldelight/issues/2119
-        task.map {
-          it.outputDirectory
-        }
-      )
+      // Use a Provider generated from the task to carry task dependencies
+      // See https://github.com/cashapp/sqldelight/issues/2119
+      source.sourceDirectorySet.srcDir(outputDirectoryProvider)
+      // And register the output directory to the IDE if needed
+      source.registerGeneratedDirectory?.invoke(outputDirectoryProvider)
 
       project.tasks.named("generateSqlDelightInterface").configure {
         it.dependsOn(task)

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/kotlin/SourceRoots.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/kotlin/SourceRoots.kt
@@ -5,7 +5,6 @@ import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.api.BaseVariant
 import com.squareup.sqldelight.gradle.SqlDelightDatabase
-import com.squareup.sqldelight.gradle.SqlDelightTask
 import org.gradle.api.DomainObjectSet
 import org.gradle.api.Project
 import org.gradle.api.Task

--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/kotlin/SourceRoots.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/kotlin/SourceRoots.kt
@@ -5,10 +5,12 @@ import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.api.BaseVariant
 import com.squareup.sqldelight.gradle.SqlDelightDatabase
+import com.squareup.sqldelight.gradle.SqlDelightTask
 import org.gradle.api.DomainObjectSet
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
@@ -17,6 +19,7 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJvmAndroidCompilation
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinMetadataTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import java.io.File
 
 /**
  * @return A list of source roots and their dependencies.
@@ -102,6 +105,9 @@ private fun BaseExtension.sources(project: Project): List<Source> {
       sourceDirectorySet = sourceSets[variant.name]
         ?: throw IllegalStateException("Couldn't find ${variant.name} in $sourceSets"),
       sourceSets = variant.sourceSets.map { it.name },
+      registerGeneratedDirectory = { outputDirectoryProvider ->
+        variant.addJavaSourceFoldersToModel(outputDirectoryProvider.get())
+      }
     )
   }
 }
@@ -123,6 +129,7 @@ internal data class Source(
   val name: String,
   val variantName: String? = null,
   val sourceSets: List<String>,
+  val registerGeneratedDirectory: ((Provider<File>) -> Unit)? = null
 ) {
   fun closestMatch(sources: Collection<Source>): Source? {
     var matches = sources.filter {


### PR DESCRIPTION
Follow up from https://github.com/cashapp/sqldelight/pull/2518. It turns out that calling `sourceSet.srcDir()` is not enough to have Android Studio pickup the generated folder.
This commit fixes this.﻿
