### PR TITLE
Fix windows publication task execution

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -43,7 +43,7 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralRepositoryUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralRepositoryPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
-        run: ./gradlew publishMingwPublicationToMavenRepository
+        run: ./gradlew publishMingwX64PublicationToMavenRepository
       - name: Publish the linux artifact
         if: matrix.os == 'ubuntu-18.04'
         env:


### PR DESCRIPTION
Same issue as there was for linux and was fixed in this PR: #2557 

This fixes the windows publication as the windows targets for x64 were renamed from `mingw` to `mingwX64` with #2548. This updates the deploy workflow to execute `publishMingwX64PublicationToMavenRepository` rather than the now non existent `publishMingwPublicationToMavenRepository`.