### PR TITLE
Distribute sqldelight-android-paging3 as JAR instead of AAR

### DIFF
--- a/extensions/android-paging3/build.gradle
+++ b/extensions/android-paging3/build.gradle
@@ -1,24 +1,6 @@
-apply plugin: 'com.android.library'
-apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'org.jetbrains.kotlin.jvm'
 
 archivesBaseName = 'sqldelight-android-paging3'
-
-android {
-  compileSdkVersion versions.compileSdk
-
-  lintOptions {
-    textReport true
-    textOutput 'stdout'
-  }
-
-  defaultConfig {
-    minSdkVersion versions.minSdk
-  }
-
-  buildFeatures {
-    buildConfig = false
-  }
-}
 
 dependencies {
   // workaround for https://youtrack.jetbrains.com/issue/KT-27059
@@ -28,8 +10,6 @@ dependencies {
   testImplementation project(':drivers:sqlite-driver')
   testImplementation deps.truth
   testImplementation deps.kotlin.test.junit
-  testImplementation deps.androidx.test.core
-  testImplementation deps.robolectric
   testImplementation deps.kotlin.coroutines.test
 }
 

--- a/extensions/android-paging3/gradle.properties
+++ b/extensions/android-paging3/gradle.properties
@@ -1,4 +1,4 @@
 POM_ARTIFACT_ID=android-paging3-extensions
 POM_NAME=SQLDelight Android Architecture Components Paging3 Coroutines Extension
 POM_DESCRIPTION=An implementation of Android Paging3 backed by SQLDelight Query
-POM_PACKAGING=aar
+POM_PACKAGING=jar

--- a/extensions/android-paging3/src/main/AndroidManifest.xml
+++ b/extensions/android-paging3/src/main/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.squareup.sqldelight.android.paging3" />

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -52,7 +52,7 @@ ext.deps = [
             'common': "androidx.paging:paging-common:${versions.paging}",
         ],
         paging3: [
-            'common': "androidx.paging:paging-runtime:${versions.paging3}",
+            'common': "androidx.paging:paging-common:${versions.paging3}",
             'rx3': "androidx.paging:paging-rxjava3:${versions.paging3}"
         ],
         recyclerView: "androidx.recyclerview:recyclerview:1.2.0",


### PR DESCRIPTION
Switch the sqldelight-android-paging3 module from an Android one to a JVM one.
This module doesn't actually rely on any Android specifics and distributing it as an .JAR instead of an .AAR will allow it to be used from within other java (i.e. non-android) modules.

Fixes https://github.com/cashapp/sqldelight/issues/2633