### PR TITLE
Update index.md

### DIFF
--- a/docs/android_sqlite/index.md
+++ b/docs/android_sqlite/index.md
@@ -1,6 +1,6 @@
 # Getting Started on Android
 
-First apply the gradle plugin in your project.
+First apply the gradle plugin in your project's top-level `build.gradle`.
 
 ```groovy
 buildscript {
@@ -12,7 +12,10 @@ buildscript {
     classpath 'com.squareup.sqldelight:gradle-plugin:{{ versions.sqldelight }}'
   }
 }
+```
+Then apply the gradle plugin in your app or module's `build.gradle`.
 
+```groovy
 apply plugin: 'com.squareup.sqldelight'
 ```
 


### PR DESCRIPTION
Clarify that the 'com.squareup.sqldelight' gradle plugin must be placed in the app or module level build.gradle file.