### PR TITLE
Add M1 targets for coroutines-extensions

### DIFF
--- a/extensions/coroutines-extensions/build.gradle
+++ b/extensions/coroutines-extensions/build.gradle
@@ -93,8 +93,12 @@ kotlin {
   macosX64()
   mingwX64()
   linuxX64()
+  macosArm64()
+  iosSimulatorArm64()
+  watchosSimulatorArm64()
+  tvosSimulatorArm64()
 
-  configure([targets.iosX64, targets.iosArm32, targets.iosArm64, targets.tvosX64, targets.tvosArm64, targets.watchosX86, targets.watchosX64, targets.watchosArm32, targets.watchosArm64, targets.macosX64, targets.linuxX64]) {
+  configure([targets.iosX64, targets.iosArm32, targets.iosArm64, targets.tvosX64, targets.tvosArm64, targets.watchosX86, targets.watchosX64, targets.watchosArm32, targets.watchosArm64, targets.macosX64, targets.linuxX64, targets.macosArm64, targets.iosSimulatorArm64, targets.watchosSimulatorArm64, targets.tvosSimulatorArm64]) {
     sourceSets.getByName("${name}Main").dependsOn(sourceSets.nativeMain)
     sourceSets.getByName("${name}Test").dependsOn(sourceSets.nativeTest)
     compilations.test {


### PR DESCRIPTION
Add new mac chip architectures introduced in Kotlin 1.5.30 for `coroutines-extensions`. #2549 added support for other targets, but missed this one.