### PR TITLE
Add missing functions for time increments

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/FunctionExprMixin.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/psi/FunctionExprMixin.kt
@@ -103,7 +103,7 @@ internal class FunctionExprMixin(node: ASTNode?) : SqlFunctionExprImpl(node) {
     "concat" -> encapsulatingType(exprList, SqliteType.TEXT)
     "last_insert_id" -> IntermediateType(SqliteType.INTEGER)
     "row_count" -> IntermediateType(SqliteType.INTEGER)
-    "month", "year", "minute" -> IntermediateType(SqliteType.INTEGER)
+    "microsecond", "second", "minute", "hour", "day", "week", "month", "year" -> IntermediateType(SqliteType.INTEGER)
     "sin", "cos", "tan" -> IntermediateType(SqliteType.REAL)
     else -> null
   }


### PR DESCRIPTION
The functions currently supported are seemingly random. 

I added the missing increments as per mysql docs https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html