### PR TITLE
Add executeAsFlow

### DIFF
--- a/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/QueryAsFlowTest.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/com/squareup/sqldelight/runtime/coroutines/QueryAsFlowTest.kt
@@ -1,12 +1,16 @@
 package com.squareup.sqldelight.runtime.coroutines
 
 import app.cash.turbine.test
+import com.squareup.sqldelight.Query
+import com.squareup.sqldelight.db.SqlCursor
 import com.squareup.sqldelight.runtime.coroutines.Employee.Companion.MAPPER
 import com.squareup.sqldelight.runtime.coroutines.Employee.Companion.SELECT_EMPLOYEES
 import com.squareup.sqldelight.runtime.coroutines.Employee.Companion.USERNAME
 import com.squareup.sqldelight.runtime.coroutines.TestDb.Companion.TABLE_EMPLOYEE
 import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.yield
 import kotlin.test.Test
@@ -29,6 +33,45 @@ class QueryAsFlowTest : DbTest {
 
         cancel()
       }
+  }
+
+  @Test fun queryExecuteAsFlow() = runTest { db ->
+    val data = db.createQuery(TABLE_EMPLOYEE, SELECT_EMPLOYEES, MAPPER)
+      .executeAsFlow()
+      .take(2)
+      .toList()
+    val expected = listOf(
+      Employee(username = "alice", name = "Alice Allison"),
+      Employee(username = "bob", name = "Bob Bobberson")
+    )
+    assertEquals(expected, actual = data)
+  }
+
+  @Test fun ensureExecuteAsFlowCallsClose() = runTest {
+    var calledClose = false
+    var numberOfNextCalls = 0
+    val initNextCall = 1
+
+    val fakeQuery = object : Query<Employee>(mutableListOf(), mapper = MAPPER) {
+      override fun execute(): SqlCursor = object : SqlCursor {
+        override fun close() {
+          calledClose = true
+        }
+
+        override fun next(): Boolean {
+          numberOfNextCalls++
+          return numberOfNextCalls < initNextCall
+        }
+
+        override fun getString(index: Int) = TODO("Not yet implemented")
+        override fun getLong(index: Int) = TODO("Not yet implemented")
+        override fun getBytes(index: Int) = TODO("Not yet implemented")
+        override fun getDouble(index: Int) = TODO("Not yet implemented")
+      }
+    }
+    fakeQuery.executeAsFlow().collect()
+    assertTrue(calledClose)
+    assertEquals(1, numberOfNextCalls)
   }
 
   @Test fun queryEmitsWithoutSuspending() = runTest { db ->


### PR DESCRIPTION
Allows you to lazily fetch each row. This implementation closes the connection after finished. 