### PR TITLE
Fix error message to allow jumping to error

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightEnvironment.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightEnvironment.kt
@@ -217,10 +217,8 @@ class SqlDelightEnvironment(
       }
   }
 
-  private fun errorMessage(element: PsiElement, message: String): String {
-    return "${element.containingFile.virtualFile.path} " +
-      "line ${element.lineStart}:${element.charPositionInLine} - $message\n${detailText(element)}"
-  }
+  private fun errorMessage(element: PsiElement, message: String): String =
+    "${element.containingFile.virtualFile.path}: (${element.lineStart}, ${element.charPositionInLine}): $message\n${detailText(element)}"
 
   private fun detailText(element: PsiElement) = try {
     val context = context(element) ?: element

--- a/sqldelight-compiler/src/test/errors/duplicate-sqlite-identifiers/failure.txt
+++ b/sqldelight-compiler/src/test/errors/duplicate-sqlite-identifiers/failure.txt
@@ -1,2 +1,2 @@
-Sample.sq line 1:0 - Duplicate SQL identifier
-Sample.sq line 4:0 - Duplicate SQL identifier
+Sample.sq: (1, 0): Duplicate SQL identifier
+Sample.sq: (4, 0): Duplicate SQL identifier

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/ImportTests.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/ImportTests.kt
@@ -23,8 +23,8 @@ class ImportTests {
     )
 
     assertThat(result.errors).containsExactly(
-      "Test.sq line 1:0 - Multiple imports for type Thing",
-      "Test.sq line 2:0 - Multiple imports for type Thing"
+      "Test.sq: (1, 0): Multiple imports for type Thing",
+      "Test.sq: (2, 0): Multiple imports for type Thing"
     )
   }
 }

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/errors/DuplicateSqlIdentifiers.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/errors/DuplicateSqlIdentifiers.kt
@@ -37,7 +37,7 @@ class DuplicateSqlIdentifiers {
       tempFolder
     )
 
-    assertThat(result.errors).contains("Test.sq line 1:0 - Duplicate SQL identifier")
-    assertThat(result.errors).contains("Test.sq line 4:0 - Duplicate SQL identifier")
+    assertThat(result.errors).contains("Test.sq: (1, 0): Duplicate SQL identifier")
+    assertThat(result.errors).contains("Test.sq: (4, 0): Duplicate SQL identifier")
   }
 }

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/errors/InsertStmtErrors.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/errors/InsertStmtErrors.kt
@@ -27,7 +27,7 @@ class InsertStmtErrors {
     )
 
     assertThat(result.errors).hasSize(1)
-    assertThat(result.errors).contains("Test.sq line 9:0 - Cannot populate default value for column value4, it must be specified in insert statement.")
+    assertThat(result.errors).contains("Test.sq: (9, 0): Cannot populate default value for column value4, it must be specified in insert statement.")
   }
 
   @Test fun `multiple columns without default values not provided`() {
@@ -48,6 +48,6 @@ class InsertStmtErrors {
     )
 
     assertThat(result.errors).hasSize(1)
-    assertThat(result.errors).contains("Test.sq line 9:0 - Cannot populate default values for columns (value3, value4), they must be specified in insert statement.")
+    assertThat(result.errors).contains("Test.sq: (9, 0): Cannot populate default values for columns (value3, value4), they must be specified in insert statement.")
   }
 }

--- a/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/errors/SyntaxErrors.kt
+++ b/sqldelight-compiler/src/test/kotlin/com/squareup/sqldelight/core/errors/SyntaxErrors.kt
@@ -19,7 +19,7 @@ class SyntaxErrors {
       tempFolder
     )
 
-    assertThat(result.errors).containsExactly("Test.sq line 2:19 - Unknown type long")
+    assertThat(result.errors).containsExactly("Test.sq: (2, 19): Unknown type long")
   }
 
   @Test fun `unknown function`() {
@@ -31,7 +31,7 @@ class SyntaxErrors {
       tempFolder
     )
 
-    assertThat(result.errors).containsExactly("Test.sq line 2:7 - Unknown function scoobyDoo")
+    assertThat(result.errors).containsExactly("Test.sq: (2, 7): Unknown function scoobyDoo")
   }
 
   @Test fun `illegal type fails gracefully`() {
@@ -44,7 +44,7 @@ class SyntaxErrors {
       tempFolder
     )
 
-    assertThat(result.errors).containsExactly("Test.sq line 2:19 - Unknown type team")
+    assertThat(result.errors).containsExactly("Test.sq: (2, 19): Unknown type team")
   }
 
   @Test fun `lowercase 'as' in column type`() {
@@ -58,8 +58,8 @@ class SyntaxErrors {
     )
 
     assertThat(result.errors).containsExactly(
-      "Test.sq line 2:8 - Reserved keyword in sqlite",
-      "Test.sq line 2:16 - Expected 'AS', got 'as'"
+      "Test.sq: (2, 8): Reserved keyword in sqlite",
+      "Test.sq: (2, 16): Expected 'AS', got 'as'"
     )
   }
 }

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/integrations/VariantTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/integrations/VariantTest.kt
@@ -21,7 +21,7 @@ class VariantTest {
       .buildAndFail()
     assertThat(result.output).contains(
       """
-      MainTable.sq line 8:12 - No column found with name some_column1
+      MainTable.sq: (8, 12): No column found with name some_column1
       8    SELECT _id, some_column1
                        ^^^^^^^^^^^^
       9    FROM some_table
@@ -47,7 +47,7 @@ class VariantTest {
       .buildAndFail()
     assertThat(result.output).contains(
       """
-      src/minApi21DemoDebug/sqldelight/com/sample/demo/debug/DemoDebug.sq line 8:5 - No table found with name full_table
+      src/minApi21DemoDebug/sqldelight/com/sample/demo/debug/DemoDebug.sq: (8, 5): No table found with name full_table
       7    SELECT *
       8    FROM full_table
                 ^^^^^^^^^^

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/FailureTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/FailureTest.kt
@@ -17,7 +17,7 @@ class FailureTest {
 
     assertThat(output.output).contains(
       """
-      |NoPackage.sq line 1:0 - SqlDelight files must be placed in a package directory.
+      |NoPackage.sq: (1, 0): SqlDelight files must be placed in a package directory.
       |1    CREATE TABLE test (
       |2      value TEXT
       |3    );

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/MigrationTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/MigrationTest.kt
@@ -36,7 +36,7 @@ class MigrationTest {
 
     assertThat(output.output).contains(
       """
-      |1.sqm line 1:5 - TABLE expected, got 'TABE'
+      |1.sqm: (1, 5): TABLE expected, got 'TABE'
       |1    ALTER TABE test ADD COLUMN value2 TEXT
       """.trimMargin()
     )
@@ -50,7 +50,7 @@ class MigrationTest {
 
     assertThat(output.output).contains(
       """
-      |1.sqm line 5:22 - No column found with name new_column
+      |1.sqm: (5, 22): No column found with name new_column
       |5    INSERT INTO test (id, new_column)
       |                           ^^^^^^^^^^
       |6    VALUES ("hello", "world")
@@ -145,7 +145,7 @@ class MigrationTest {
       .withArguments("clean", "generateSqlDelightInterface", "--stacktrace", "--debug")
       .buildAndFail()
 
-    assertThat(output.output).contains("1.sqm line 1:12 - No table found with name test")
+    assertThat(output.output).contains("1.sqm: (1, 12): No table found with name test")
   }
 
   @Test fun `compilation succeeds when verifyMigrations is set to false but the migrations are incomplete`() {

--- a/test-util/src/main/kotlin/com/squareup/sqldelight/test/util/FixtureCompiler.kt
+++ b/test-util/src/main/kotlin/com/squareup/sqldelight/test/util/FixtureCompiler.kt
@@ -153,7 +153,7 @@ object FixtureCompiler {
       val document = documentManager.getDocument(element.containingFile)!!
       val lineNum = document.getLineNumber(element.textOffset)
       val offsetInLine = element.textOffset - document.getLineStartOffset(lineNum)
-      errors += "$name line ${lineNum + 1}:$offsetInLine - $s"
+      errors += "$name: (${lineNum + 1}, $offsetInLine): $s"
     }
   }
 


### PR DESCRIPTION
With the new error syntax you can jump to the problematic line by simple clicking the error message in IntelliJ. This is very useful with long `sq` files.
https://user-images.githubusercontent.com/22521688/143685699-c4abef68-415b-41d7-957a-81aaa0bf9709.mov

