### PR TITLE
Verify plugin compatibility on IntelliJ 2021.2

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightEnvironment.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/SqlDelightEnvironment.kt
@@ -26,8 +26,6 @@ import com.intellij.mock.MockModule
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModuleExtension
-import com.intellij.openapi.roots.ModuleRootManager
-import com.intellij.openapi.roots.impl.ModuleRootManagerImpl
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.FileTypeFileViewProviders
 import com.intellij.psi.PsiDirectory
@@ -92,10 +90,6 @@ class SqlDelightEnvironment(
     CoreApplicationEnvironment.registerExtensionPoint(
       module.extensionArea,
       ModuleExtension.EP_NAME, ModuleExtension::class.java
-    )
-    module.picoContainer.registerComponentInstance(
-      ModuleRootManager::class.java.name,
-      ModuleRootManagerImpl(module)
     )
 
     initializeApplication {

--- a/sqldelight-idea-plugin/build.gradle
+++ b/sqldelight-idea-plugin/build.gradle
@@ -35,6 +35,7 @@ runPluginVerifier {
       "IC-2020.2.4",
       "IC-2020.3.2",
       "IC-2021.1",
+      "IC-2021.2.3",
   ]
 
   def customFailureLevel = FailureLevel.ALL

--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/actions/GenerateInsertIntoQueryAction.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/actions/GenerateInsertIntoQueryAction.kt
@@ -2,6 +2,7 @@ package com.squareup.sqldelight.intellij.actions
 
 import com.alecstrong.sql.psi.core.psi.SqlCreateTableStmt
 import com.intellij.codeInsight.CodeInsightActionHandler
+import com.intellij.codeInsight.template.TemplateActionContext
 import com.intellij.codeInsight.template.TemplateManager
 import com.intellij.codeInsight.template.impl.TemplateManagerImpl
 import com.intellij.openapi.editor.Editor
@@ -18,7 +19,7 @@ internal class GenerateInsertIntoQueryAction : BaseGenerateAction(InsertIntoHand
       val createTableStmt = file.findElementAt(caretOffset)?.parentOfType<SqlCreateTableStmt>() ?: return
 
       val tableName = createTableStmt.tableName.name
-      val template = TemplateManagerImpl.listApplicableTemplates(file, caretOffset, false)
+      val template = TemplateManagerImpl.listApplicableTemplates(TemplateActionContext.create(file, null, caretOffset, caretOffset, false))
         .first { it.key == "ins" }
 
       val stmtList = file.findChildOfType<SqlDelightStmtList>() ?: return

--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/actions/GenerateSelectAllQueryAction.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/actions/GenerateSelectAllQueryAction.kt
@@ -2,6 +2,7 @@ package com.squareup.sqldelight.intellij.actions
 
 import com.alecstrong.sql.psi.core.psi.SqlCreateTableStmt
 import com.intellij.codeInsight.CodeInsightActionHandler
+import com.intellij.codeInsight.template.TemplateActionContext
 import com.intellij.codeInsight.template.TemplateManager
 import com.intellij.codeInsight.template.impl.TemplateManagerImpl
 import com.intellij.openapi.editor.Editor
@@ -19,7 +20,7 @@ internal class GenerateSelectAllQueryAction : BaseGenerateAction(SelectAllHandle
       val createTableStmt = file.findElementAt(caretOffset)?.parentOfType<SqlCreateTableStmt>() ?: return
 
       val tableName = createTableStmt.tableName.name
-      val selectAllTemplate = TemplateManagerImpl.listApplicableTemplates(file, caretOffset, false)
+      val selectAllTemplate = TemplateManagerImpl.listApplicableTemplates(TemplateActionContext.create(file, null, caretOffset, caretOffset, false))
         .first { it.key == "sel" }
 
       val stmtList = file.findChildOfType<SqlDelightStmtList>() ?: return

--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/actions/QueryByPrimaryKeyHandler.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/actions/QueryByPrimaryKeyHandler.kt
@@ -2,6 +2,7 @@ package com.squareup.sqldelight.intellij.actions
 
 import com.alecstrong.sql.psi.core.psi.SqlCreateTableStmt
 import com.intellij.codeInsight.CodeInsightActionHandler
+import com.intellij.codeInsight.template.TemplateActionContext
 import com.intellij.codeInsight.template.TemplateManager
 import com.intellij.codeInsight.template.impl.TemplateManagerImpl
 import com.intellij.openapi.editor.Editor
@@ -23,7 +24,7 @@ class QueryByPrimaryKeyHandler(private val templateName: String) : CodeInsightAc
       }
     }?.columnName
 
-    val template = TemplateManagerImpl.listApplicableTemplates(file, caretOffset, false)
+    val template = TemplateManagerImpl.listApplicableTemplates(TemplateActionContext.create(file, null, caretOffset, caretOffset, false))
       .first { it.key == templateName }
 
     val args = mutableMapOf("table" to tableName)


### PR DESCRIPTION
`ModuleRootManagerImpl` was removed in IntelliJ 2021.2. Usage in SQLDelight was introduced by #1912, though I'm not clear on why it was needed based on a quick look through the SQLDelight codebase and a search within Gradle's codebase. Tests pass without it.

The update to use of `listApplicableTemplates` (also removed in 2021.2) will have no impact, as the old method just passed the parameters directly to the replacement method I've used.