### PR TITLE
Updated getting started documentation 

### DIFF
--- a/docs/common/index_gradle_database.md
+++ b/docs/common/index_gradle_database.md
@@ -1,2 +1,23 @@
 {% include 'common/index_gradle_database_pre_dialect.md' %}
 {% include 'common/index_gradle_database_post_dialect.md' %}
+
+If you're using Kotlin for your Gradle files:
+
+```groovy
+plugins {
+    id("com.squareup.sqldelight") version "{{ versions.sqldelight }}"
+}
+
+apply(plugin = "com.squareup.sqldelight")
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+sqldelight {
+    database("Database") {
+        packageName = "com.example"
+    }
+}
+```

--- a/docs/common/index_gradle_database.md
+++ b/docs/common/index_gradle_database.md
@@ -3,7 +3,7 @@
 
 If you're using Kotlin for your Gradle files:
 
-```groovy
+```kotlin
 plugins {
     id("com.squareup.sqldelight") version "{{ versions.sqldelight }}"
 }


### PR DESCRIPTION
Updated getting started documentation with information when using Kotlin for Gradle.
The Getting Started documentation was missing the information on how to get it running, at least I had difficulty getting with it, so for completeness I added the missing information.