### PR TITLE
Correct Idea Kotlin plugin dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,8 @@ allprojects {
 
   tasks.withType(KotlinCompile) {
     kotlinOptions {
+      // apiVersion must target Kotlin stdlib version bundled with the lowest supported IntelliJ version to avoid
+      // runtime errors. https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library
       apiVersion = "1.3"
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 import org.jetbrains.grammarkit.tasks.GenerateParser
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
   apply from: "$rootDir/gradle/dependencies.gradle"
@@ -61,6 +62,12 @@ allprojects {
   tasks.withType(JavaCompile) {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
+  }
+
+  tasks.withType(KotlinCompile) {
+    kotlinOptions {
+      apiVersion = "1.3"
+    }
   }
 
   configurations {

--- a/extensions/android-paging3/src/test/java/com/squareup/sqldelight/android/paging3/KeyedQueryPagingSourceTest.kt
+++ b/extensions/android-paging3/src/test/java/com/squareup/sqldelight/android/paging3/KeyedQueryPagingSourceTest.kt
@@ -26,7 +26,7 @@ class KeyedQueryPagingSourceTest {
   @Before fun before() {
     driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
     driver.execute(null, "CREATE TABLE testTable(value INTEGER PRIMARY KEY)", 0)
-    (0L until 10L).forEach(this::insert)
+    (0L until 10L).forEach { this.insert(it) }
     transacter = object : TransacterImpl(driver) {}
   }
 

--- a/extensions/android-paging3/src/test/java/com/squareup/sqldelight/android/paging3/OffsetQueryPagingSourceTest.kt
+++ b/extensions/android-paging3/src/test/java/com/squareup/sqldelight/android/paging3/OffsetQueryPagingSourceTest.kt
@@ -41,7 +41,7 @@ class OffsetQueryPagingSourceTest {
   @Before fun before() {
     driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
     driver.execute(null, "CREATE TABLE testTable(value INTEGER PRIMARY KEY)", 0)
-    (0L until 10L).forEach(this::insert)
+    (0L until 10L).forEach { this.insert(it) }
     transacter = object : TransacterImpl(driver) {}
   }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -41,7 +41,6 @@ ext.deps = [
             "core": "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.kotlinCoroutines}",
             "test": "org.jetbrains.kotlinx:kotlinx-coroutines-test:${versions.kotlinCoroutines}"
         ],
-        reflect: "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlin}"
     ],
     androidx: [
         test: [

--- a/runtime/src/commonMain/kotlin/app/cash/sqldelight/Transacter.kt
+++ b/runtime/src/commonMain/kotlin/app/cash/sqldelight/Transacter.kt
@@ -187,11 +187,11 @@ abstract class TransacterImpl(private val driver: SqlDriver) : Transacter {
     val transaction = driver.currentTransaction()
     if (transaction != null) {
       if (transaction.registeredQueries.add(identifier)) {
-        tableProvider(transaction.pendingTables::add)
+        tableProvider { transaction.pendingTables.add(it) }
       }
     } else {
       val tableKeys = mutableSetOf<String>()
-      tableProvider(tableKeys::add)
+      tableProvider { tableKeys.add(it) }
       driver.notifyListeners(tableKeys.toTypedArray())
     }
   }

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/NamedQuery.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/compiler/model/NamedQuery.kt
@@ -38,7 +38,6 @@ import com.squareup.sqldelight.core.lang.util.name
 import com.squareup.sqldelight.core.lang.util.sqFile
 import com.squareup.sqldelight.core.lang.util.tablesObserved
 import com.squareup.sqldelight.core.lang.util.type
-import java.util.Locale
 
 data class NamedQuery(
   val name: String,
@@ -92,7 +91,7 @@ data class NamedQuery(
    */
   internal val interfaceType: ClassName by lazy {
     pureTable?.let {
-      return@lazy ClassName(it.tableName.sqFile().packageName!!, allocateName(it.tableName).capitalize(Locale.ROOT))
+      return@lazy ClassName(it.tableName.sqFile().packageName!!, allocateName(it.tableName).capitalize())
     }
     var packageName = select.sqFile().packageName!!
     if (select.sqFile().parent?.files
@@ -100,9 +99,7 @@ data class NamedQuery(
       ?.filter { it.needsInterface() && it != this }
       ?.any { it.name == name } == true
     ) {
-      packageName = "$packageName.${select.sqFile().virtualFile!!.nameWithoutExtension.decapitalize(
-        Locale.ROOT
-      )}"
+      packageName = "$packageName.${select.sqFile().virtualFile!!.nameWithoutExtension.decapitalize()}"
     }
     return@lazy ClassName(packageName, name.capitalize())
   }

--- a/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
+++ b/sqldelight-compiler/src/main/kotlin/com/squareup/sqldelight/core/lang/IntermediateType.kt
@@ -84,7 +84,7 @@ internal data class IntermediateType(
     columnIndex: String,
     extractedVariable: String? = null
   ): CodeBlock {
-    val codeBlock = extractedVariable?.let(CodeBlock::of) ?: encodedJavaType()
+    val codeBlock = extractedVariable?.let { CodeBlock.of(it) } ?: encodedJavaType()
     if (codeBlock != null) {
       return dialectType.prepareStatementBinder(columnIndex, codeBlock)
     }

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/assertions/FileSubject.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/assertions/FileSubject.kt
@@ -7,6 +7,7 @@ import com.google.common.truth.Truth.assertAbout
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import java.io.File
+import java.util.ArrayDeque
 
 internal class FileSubject private constructor(
   metadata: FailureMetadata,

--- a/sqldelight-idea-plugin/build.gradle
+++ b/sqldelight-idea-plugin/build.gradle
@@ -76,7 +76,6 @@ repositories {
 dependencies {
   implementation project(':sqldelight-compiler')
 
-  implementation deps.kotlin.reflect
   implementation deps.sqliteJdbc
   implementation(deps.bugsnag) {
     exclude group: "org.slf4j"

--- a/sqldelight-idea-plugin/build.gradle
+++ b/sqldelight-idea-plugin/build.gradle
@@ -11,7 +11,7 @@ intellij {
   version = "IC-${versions.idea}"
   pluginName = 'SQLDelight'
   plugins = [
-      "org.jetbrains.kotlin:202-1.5.0-release-760-IJ8194.7",
+      "org.jetbrains.kotlin",
       "gradle",
       "com.intellij.java",
       "Groovy",

--- a/sqldelight-idea-plugin/build.gradle
+++ b/sqldelight-idea-plugin/build.gradle
@@ -14,8 +14,6 @@ intellij {
       "org.jetbrains.kotlin",
       "gradle",
       "com.intellij.java",
-      "Groovy",
-      "properties",
   ]
   if (!project.version.endsWith("SNAPSHOT")) {
     patchPluginXml {

--- a/sqldelight-idea-plugin/build.gradle
+++ b/sqldelight-idea-plugin/build.gradle
@@ -12,7 +12,7 @@ intellij {
   pluginName = 'SQLDelight'
   plugins = [
       "org.jetbrains.kotlin",
-      "gradle",
+      "com.intellij.gradle",
       "com.intellij.java",
   ]
   if (!project.version.endsWith("SNAPSHOT")) {

--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightClassNameElementAnnotator.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightClassNameElementAnnotator.kt
@@ -73,7 +73,7 @@ class SqlDelightClassNameElementAnnotator : Annotator {
   private fun missingNestedClass(classes: List<PsiClass>, javaTypeMixin: JavaTypeMixin): PsiElement {
     val elementText = javaTypeMixin.text
     val className = classes.map { clazz -> findMissingNestedClassName(clazz, elementText) }
-      .maxByOrNull { it.length }
+      .maxBy { it.length }
       ?.substringBefore(".") ?: return javaTypeMixin.firstChild
     return javaTypeMixin.findChildrenOfType<PsiElement>().first { it.textMatches(className) }
   }

--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightCopyPasteProcessor.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightCopyPasteProcessor.kt
@@ -129,7 +129,7 @@ class SqlDelightCopyPasteProcessor : CopyPastePostProcessor<ReferenceTransferabl
       if (oldImports.isEmpty()) {
         document.insertString(0, "$newImports\n\n")
       } else {
-        val endOffset = importStmtList.maxOfOrNull { it.textOffset + it.textLength } ?: 0
+        val endOffset = importStmtList.map { it.textOffset + it.textLength }.max() ?: 0
         document.replaceString(0, endOffset, newImports)
       }
     }

--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightFindUsagesHandlerFactory.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/SqlDelightFindUsagesHandlerFactory.kt
@@ -129,7 +129,7 @@ internal fun PsiElement.generatedKtFiles(): List<KtFile> {
 }
 
 internal fun SqlColumnName.generatedProperties(): Collection<KtNamedDeclaration> {
-  return generatedKtFiles().asSequence()
+  return generatedKtFiles()
     .flatMap { it.declarations.filterIsInstance<KtClass>() }
     .filter(KtClass::isData)
     .flatMap(KtClass::getPrimaryConstructorParameters)

--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/inspections/UnusedColumnInspection.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/inspections/UnusedColumnInspection.kt
@@ -61,7 +61,6 @@ class UnusedColumnInspection : LocalInspectionTool() {
 
       FileTypeIndex.getFiles(SqlDelightFileType, GlobalSearchScope.allScope(project))
         .mapNotNull { vFile -> psiManager.findFile(vFile) as SqlDelightFile? }
-        .asSequence()
         .flatMap { file -> file.sqlStmtList?.stmtList.orEmpty() }
         .flatMap { stmt -> stmt.compoundSelectStmt?.queryExposed().orEmpty() }
         .flatMap { queryResult -> queryResult.columns }

--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/inspections/UnusedImportInspection.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/inspections/UnusedImportInspection.kt
@@ -58,7 +58,6 @@ class UnusedImportInspection : LocalInspectionTool() {
 
 fun PsiFile.columnJavaTypes(): Set<String> =
   findChildrenOfType<SqlDelightColumnType>()
-    .asSequence()
     .flatMap { columnType ->
       columnType.findChildrenOfType<SqlDelightJavaType>() + columnType.findChildrenOfType<SqlDelightJavaTypeName>()
     }

--- a/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/intentions/QualifyColumnNameIntention.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/com/squareup/sqldelight/intellij/intentions/QualifyColumnNameIntention.kt
@@ -31,7 +31,6 @@ class QualifyColumnNameIntention : BaseElementAtCaretIntentionAction() {
     val columnName = element.parentOfType<SqlColumnName>(true) ?: return
     val columnText = columnName.text
     val tableNamesOrAliases = columnName.queryAvailable(columnName)
-      .asSequence()
       .filter { result -> result.table != null }
       .flatMap { result ->
         result.columns.filter { column -> column.element.textMatches(columnText) }

--- a/sqlite-migrations/src/main/kotlin/com/squareup/sqlite/migrations/DatabaseFilesCollector.kt
+++ b/sqlite-migrations/src/main/kotlin/com/squareup/sqlite/migrations/DatabaseFilesCollector.kt
@@ -2,6 +2,6 @@ package com.squareup.sqlite.migrations
 
 import java.io.File
 
-fun Sequence<File>.findDatabaseFiles(): Sequence<File> = flatMap(File::walk).filter { entry ->
+fun Sequence<File>.findDatabaseFiles(): Sequence<File> = flatMap { it.walk() }.filter { entry ->
   entry.isFile && entry.name.endsWith(".db")
 }


### PR DESCRIPTION
Compiling and testing the Idea plugin on Kotlin 1.5 can lead to runtime errors when bundled Kotlin version is used.

IntelliJ 2020.2, the min supported version, bundles 1.3.70, and plugin dependencies in `plugin.xml` can't specify a required minimum version ([IDEABKL-7906](https://youtrack.jetbrains.com/issue/IDEABKL-7906)) so users could be using any Kotlin version from 1.3.70 to the max supported on that platform (1.5.31).

Compilation and test will now be done against the bundled Kotlin version. A few compilation errors that resulted are also fixed.

Also note that runtime dependencies will need to be updated to target API version 1.3 as well - I believe this only impacts sql-psi, see https://github.com/AlecStrong/sql-psi/pull/301.

Possibly fixed (I was seeing red text in IntelliJ in SqlDelightGotoDeclarationHandler in `targetData` function before this change):
* #2568 
* #2643 
* #2660 
* #2708 
* #2709

I haven't created reproducers for the above and can't see the stacktrace in bugsnag either, but it may be worth checking them.