### PR TITLE
Use faster APIs for iterating files and dont explore the entire PSI graph

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/SqlDelightQueriesFile.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/SqlDelightQueriesFile.kt
@@ -32,6 +32,7 @@ import com.alecstrong.sql.psi.core.psi.SqlAnnotatedElement
 import com.alecstrong.sql.psi.core.psi.SqlBindExpr
 import com.alecstrong.sql.psi.core.psi.SqlStmt
 import com.intellij.psi.FileViewProvider
+import com.intellij.psi.PsiDirectory
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.PsiTreeUtil
 import com.squareup.kotlinpoet.PropertySpec
@@ -122,8 +123,15 @@ class SqlDelightQueriesFile(
   fun iterateSqlFiles(block: (SqlDelightQueriesFile) -> Unit) {
     val module = module ?: return
 
+    fun PsiDirectory.iterateSqlFiles() {
+      children.forEach {
+        if (it is PsiDirectory) it.iterateSqlFiles()
+        if (it is SqlDelightQueriesFile) block(it)
+      }
+    }
+
     SqlDelightFileIndex.getInstance(module).sourceFolders(this).forEach { dir ->
-      PsiTreeUtil.findChildrenOfAnyType(dir, SqlDelightQueriesFile::class.java).forEach(block)
+      dir.iterateSqlFiles()
     }
   }
 


### PR DESCRIPTION
Previously it was iterating over all PsiElements including individual tokens in a file when trying to find more files