### PR TITLE
Use the old id for the intellij plugin

### DIFF
--- a/sqldelight-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/sqldelight-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,5 +1,5 @@
 <idea-plugin>
-  <id>app.cash.sqldelight</id>
+  <id>com.squareup.sqldelight</id>
   <name>SQLDelight</name>
   <category>Custom Languages</category>
   <vendor url="https://github.com/square">Square, Inc.</vendor>


### PR DESCRIPTION
Snapshot failed to publish so we need to continue using the old id