### PR TITLE
Explicitly support js/android plugins when adding runtime

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
@@ -80,9 +80,6 @@ abstract class SqlDelightPlugin : Plugin<Project> {
     }
 
     val isMultiplatform = project.plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")
-    val isJs = project.plugins.hasPlugin("org.jetbrains.kotlin.js")
-    val isJvmOrAndroid = project.plugins.hasPlugin("org.jetbrains.kotlin.jvm") ||
-      project.plugins.hasPlugin("org.jetbrains.kotlin.android")
 
     // Add the runtime dependency.
     when {
@@ -94,14 +91,9 @@ abstract class SqlDelightPlugin : Plugin<Project> {
           project.dependencies.create("app.cash.sqldelight:runtime:$VERSION")
         )
       }
-      isJvmOrAndroid -> {
+      else -> {
         project.configurations.getByName("api").dependencies.add(
-          project.dependencies.create("app.cash.sqldelight:runtime-jvm:$VERSION")
-        )
-      }
-      isJs -> {
-        project.configurations.getByName("api").dependencies.add(
-          project.dependencies.create("app.cash.sqldelight:runtime-js:$VERSION")
+          project.dependencies.create("app.cash.sqldelight:runtime:$VERSION")
         )
       }
     }

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
@@ -80,19 +80,30 @@ abstract class SqlDelightPlugin : Plugin<Project> {
     }
 
     val isMultiplatform = project.plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")
+    val isJs = project.plugins.hasPlugin("org.jetbrains.kotlin.js")
+    val isJvmOrAndroid = project.plugins.hasPlugin("org.jetbrains.kotlin.jvm") ||
+      project.plugins.hasPlugin("org.jetbrains.kotlin.android")
 
     // Add the runtime dependency.
-    if (isMultiplatform) {
-      val sourceSets =
-        project.extensions.getByType(KotlinMultiplatformExtension::class.java).sourceSets
-      val sourceSet = (sourceSets.getByName("commonMain") as DefaultKotlinSourceSet)
-      project.configurations.getByName(sourceSet.apiConfigurationName).dependencies.add(
-        project.dependencies.create("app.cash.sqldelight:runtime:$VERSION")
-      )
-    } else {
-      project.configurations.getByName("api").dependencies.add(
-        project.dependencies.create("app.cash.sqldelight:runtime-jvm:$VERSION")
-      )
+    when {
+      isMultiplatform -> {
+        val sourceSets =
+          project.extensions.getByType(KotlinMultiplatformExtension::class.java).sourceSets
+        val sourceSet = (sourceSets.getByName("commonMain") as DefaultKotlinSourceSet)
+        project.configurations.getByName(sourceSet.apiConfigurationName).dependencies.add(
+          project.dependencies.create("app.cash.sqldelight:runtime:$VERSION")
+        )
+      }
+      isJvmOrAndroid -> {
+        project.configurations.getByName("api").dependencies.add(
+          project.dependencies.create("app.cash.sqldelight:runtime-jvm:$VERSION")
+        )
+      }
+      isJs -> {
+        project.configurations.getByName("api").dependencies.add(
+          project.dependencies.create("app.cash.sqldelight:runtime-js:$VERSION")
+        )
+      }
     }
 
     if (extension.linkSqlite) {


### PR DESCRIPTION
This allows for projects that are other Kotlin project types (and not jvm or multiplatform) to still have the runtime dep automatically added. This also avoids an issue where the jvm dependency would be added if it was just a JS project.