### PR TITLE
Remove sql.js dependency from sqljs-driver

### DIFF
--- a/docs/js_sqlite/index.md
+++ b/docs/js_sqlite/index.md
@@ -8,6 +8,8 @@
 kotlin {
   sourceSets.jsMain.dependencies {
     implementation "com.squareup.sqldelight:sqljs-driver:{{ versions.sqldelight }}"
+    implementation npm("sql.js", "1.6.2")  
+    implementation devNpm("copy-webpack-plugin", "9.1.0")
   }
 }
 ```
@@ -25,7 +27,7 @@ suspend fun createDriver() {
 }
 ```
 
-If building for browsers, some additional webpack configuration is also required.
+If building for browsers, some [additional webpack configuration](https://kotlinlang.org/docs/js-project-setup.html#webpack-configuration-file) is also required.
 ```js
 // project/webpack.conf.d/fs.js
 config.resolve = {
@@ -41,10 +43,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 config.plugins.push(
     new CopyWebpackPlugin({
         patterns: [
-            {
-                from: '../../node_modules/sql.js/dist/sql-wasm.wasm',
-                to: '../../../{your project}/build/distributions'
-            }
+            '../../node_modules/sql.js/dist/sql-wasm.wasm'
         ]
     })
 );

--- a/docs/js_sqlite/multiplatform.md
+++ b/docs/js_sqlite/multiplatform.md
@@ -23,6 +23,8 @@ kotlin {
 
   sourceSets.jsMain.dependencies {
     implementation "com.squareup.sqldelight:sqljs-driver:{{ versions.sqldelight }}"
+    implementation npm("sql.js", "1.6.2")
+    implementation devNpm("copy-webpack-plugin", "9.1.0")
   }
 }
 ```

--- a/drivers/sqljs-driver/build.gradle
+++ b/drivers/sqljs-driver/build.gradle
@@ -23,10 +23,10 @@ kotlin {
 
   sourceSets["main"].dependencies {
     api project(':runtime')
-    api npm(deps.sqljs, versions.sqljs)
   }
   sourceSets["test"].dependencies {
     implementation deps.kotlin.test.js
+    implementation npm(deps.sqljs, versions.sqljs)
   }
 }
 

--- a/sample/README.md
+++ b/sample/README.md
@@ -27,14 +27,10 @@ The Xcode build *may* fail because it can't see ANDROID_HOME, in which case you 
 
 ## Running the web sample  
 
-Build the sample by running
+Open the sample by running
 
 ````
-./gradlew :sample:web:browserWebpack
+./gradlew :browserRun
 ````
 
-Open the generated webpage
-
-```
-open sample/web/build/distributions/index.html
-```
+The sample will be open at `http://localhost:8080`

--- a/sample/web/build.gradle
+++ b/sample/web/build.gradle
@@ -19,7 +19,8 @@ dependencies {
   implementation project(':common')
   implementation "app.cash.sqldelight:sqljs-driver"
   implementation "org.jetbrains.kotlinx:kotlinx-html-js:0.7.3"
-  implementation npm("copy-webpack-plugin", "5.1.1")
+  implementation devNpm("copy-webpack-plugin", "9.1.0")
+  implementation npm("sql.js", "1.6.2")
 
   testImplementation 'org.jetbrains.kotlin:kotlin-test-js'
 }

--- a/sample/web/webpack.config.d/resources.js
+++ b/sample/web/webpack.config.d/resources.js
@@ -1,7 +1,0 @@
-var CopyWebpackPlugin = require('copy-webpack-plugin');
-config.plugins.push(
-    new CopyWebpackPlugin([
-        { from: '../../../../sample/web/src/main/resources',
-            to: '../../../../sample/web/build/distributions' }
-    ])
-);

--- a/sample/web/webpack.config.d/wasm.js
+++ b/sample/web/webpack.config.d/wasm.js
@@ -1,7 +1,8 @@
-var CopyWebpackPlugin = require('copy-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 config.plugins.push(
-    new CopyWebpackPlugin([
-        { from: '../../node_modules/sql.js/dist/sql-wasm.wasm',
-            to: '../../../../sample/web/build/distributions' }
-    ])
+    new CopyWebpackPlugin({
+        patterns: [
+            '../../node_modules/sql.js/dist/sql-wasm.wasm'
+        ]
+    })
 );


### PR DESCRIPTION
The title is a bit counterintuitive, but here's the problem that this solves:

If you want to add additional SQLite modules (like FTS5) to sql.js you have to recompile it yourself with additional compile flags, which is relatively easy to do. Unfortunately, it is currently not possible to use these custom builds of sql.js with the sqljs-driver. The compiled wasm binary needs to be loaded with the matching JS script generated by Emscripten during that particular compilation, otherwise you can end up with [weird out of memory errors](https://github.com/sql-js/sql.js/issues/201#issuecomment-751487367), or the app simply hanging. In other words, you can't simply copy in the new wasm binary because the sqljs-driver depends on a different build of sql.js which will have an incompatible emscripten script. In addition, as long as the driver has a hard dependency on some specific version of sql.js, it won't be possible to override/replace that version in the project's `node_modules`.

The solution in this PR is to simply remove the sql.js dependency on sqljs-driver (technically it isn't needed to begin with).
It's now left up to the consumer of the driver to add a dependency to _a_ version of sql.js. This not only makes it possible to use custom builds of sql.js, but also makes it possible to upgrade sql.js (with new versions of SQLite) independently of the driver. 

From the Kotlin compiler's perspective, it just sees the external sql.js declarations that are included in the driver sources, but since no binary is produced this means webpack never needs to try and resolve those references when building the library. When the driver is included in a project, as long as some version of sql.js is in the project's `node_modules`, the references will resolve correctly once an actual executable binary is built.

The only limitation is that the sql.js package being used still needs to be named "sql.js" so it's not possible to use forks like [@jlongster/sql.js](https://www.npmjs.com/package/@jlongster/sql.js) (at least not without somehow renaming the package after yarn imports it). The [module name in the driver sources](https://github.com/cashapp/sqldelight/blob/master/drivers/sqljs-driver/src/main/kotlin/app/cash/sqldelight/driver/sqljs/sqljs.kt#L13) would need to be changed and I think that would only be possible through code generation, which is just a whole new level of jank.

Lastly, sql.js _could_ be added as a peer dependency for the driver, but as far as I can tell from my tests this doesn't actually do anything. Yarn will always give a warning that the peer dependency isn't met, regardless of whether or not sql.js is depended on by the consuming project.

Other misc. changes:
* Improve documentation on using copy-webpack-plugin
* Use devNpm for copy-webpack-plugin
* Remove obsolete resources.js config file from sample
* Update sample README