### PR TITLE
Update TestContainer and driver in integrationTests

### DIFF
--- a/sqldelight-gradle-plugin/src/test/integration-mysql-schema/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-mysql-schema/build.gradle
@@ -21,8 +21,8 @@ repositories {
 }
 
 dependencies {
-  implementation "mysql:mysql-connector-java:8.0.19"
-  implementation "org.testcontainers:mysql:1.15.2"
+  implementation "mysql:mysql-connector-java:8.0.27"
+  implementation 'org.testcontainers:mysql:1.16.2'
   implementation "app.cash.sqldelight:jdbc-driver:${app.cash.sqldelight.VersionKt.VERSION}"
   implementation deps.truth
 }

--- a/sqldelight-gradle-plugin/src/test/integration-mysql/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-mysql/build.gradle
@@ -20,8 +20,8 @@ repositories {
 }
 
 dependencies {
-  implementation "mysql:mysql-connector-java:8.0.19"
-  implementation "org.testcontainers:mysql:1.15.2"
+  implementation "mysql:mysql-connector-java:8.0.27"
+  implementation "org.testcontainers:mysql:1.16.2"
   implementation "app.cash.sqldelight:jdbc-driver:${app.cash.sqldelight.VersionKt.VERSION}"
   implementation deps.truth
 }

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/build.gradle
@@ -20,8 +20,8 @@ repositories {
 }
 
 dependencies {
-  implementation "org.postgresql:postgresql:42.2.12"
-  implementation "org.testcontainers:postgresql:1.15.2"
+  implementation "org.postgresql:postgresql:42.3.1"
+  implementation "org.testcontainers:postgresql:1.16.2"
   implementation "app.cash.sqldelight:jdbc-driver:${app.cash.sqldelight.VersionKt.VERSION}"
   implementation deps.truth
 }

--- a/sqldelight-gradle-plugin/src/test/integration-sqlite-3-24/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-sqlite-3-24/build.gradle
@@ -22,6 +22,6 @@ sqldelight {
 dependencies {
   implementation deps.sqliteJdbc
   implementation "app.cash.sqldelight:sqlite-driver:${app.cash.sqldelight.VersionKt.VERSION}"
-  implementation "org.xerial:sqlite-jdbc:3.30.1"
+  implementation "org.xerial:sqlite-jdbc:3.34.0"
   implementation deps.truth
 }

--- a/sqldelight-gradle-plugin/src/test/multithreaded-sqlite/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/multithreaded-sqlite/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-  implementation "org.xerial:sqlite-jdbc:3.32.3"
+  implementation "org.xerial:sqlite-jdbc:3.34.0"
   implementation "app.cash.sqldelight:sqlite-driver:${app.cash.sqldelight.VersionKt.VERSION}"
   implementation deps.truth
 }


### PR DESCRIPTION
At least TestContainers `1.16.0` is need to run the integration tests on a M1 Mac.