### PR TITLE
Remove the custom toString generation of generated data classes.

### DIFF
--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/Group.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/Group.kt
@@ -1,14 +1,7 @@
 package com.example
 
 import kotlin.Long
-import kotlin.String
 
 public data class Group(
   public val index: Long
-) {
-  public override fun toString(): String = """
-  |Group [
-  |  index: $index
-  |]
-  """.trimMargin()
-}
+)

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/Player.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/Player.kt
@@ -11,15 +11,6 @@ public data class Player(
   public val team: String?,
   public val shoots: Shoots
 ) {
-  public override fun toString(): String = """
-  |Player [
-  |  name: $name
-  |  number: $number
-  |  team: $team
-  |  shoots: $shoots
-  |]
-  """.trimMargin()
-
   public class Adapter(
     public val shootsAdapter: ColumnAdapter<Shoots, String>
   )

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/SelectNull.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/SelectNull.kt
@@ -1,14 +1,7 @@
 package com.example
 
 import java.lang.Void
-import kotlin.String
 
 public data class SelectNull(
   public val expr: Void?
-) {
-  public override fun toString(): String = """
-  |SelectNull [
-  |  expr: $expr
-  |]
-  """.trimMargin()
-}
+)

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/Team.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/Team.kt
@@ -11,15 +11,6 @@ public data class Team(
   public val inner_type: Shoots.Type?,
   public val coach: String
 ) {
-  public override fun toString(): String = """
-  |Team [
-  |  name: $name
-  |  captain: $captain
-  |  inner_type: $inner_type
-  |  coach: $coach
-  |]
-  """.trimMargin()
-
   public class Adapter(
     public val inner_typeAdapter: ColumnAdapter<Shoots.Type, String>
   )

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TeamForCoach.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TeamForCoach.kt
@@ -6,11 +6,4 @@ import kotlin.String
 public data class TeamForCoach(
   public val name: String,
   public val captain: Long
-) {
-  public override fun toString(): String = """
-  |TeamForCoach [
-  |  name: $name
-  |  captain: $captain
-  |]
-  """.trimMargin()
-}
+)

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/player/SelectStuff.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/player/SelectStuff.kt
@@ -1,16 +1,8 @@
 package com.example.player
 
 import kotlin.Long
-import kotlin.String
 
 public data class SelectStuff(
   public val expr: Long,
   public val expr_: Long
-) {
-  public override fun toString(): String = """
-  |SelectStuff [
-  |  expr: $expr
-  |  expr_: $expr_
-  |]
-  """.trimMargin()
-}
+)

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/team/SelectStuff.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/team/SelectStuff.kt
@@ -1,16 +1,8 @@
 package com.example.team
 
 import kotlin.Long
-import kotlin.String
 
 public data class SelectStuff(
   public val expr: Long,
   public val expr_: Long
-) {
-  public override fun toString(): String = """
-  |SelectStuff [
-  |  expr: $expr
-  |  expr_: $expr_
-  |]
-  """.trimMargin()
-}
+)

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
@@ -46,14 +46,7 @@ class InterfaceGeneration {
       |public data class LeftJoin(
       |  public val val1: kotlin.String,
       |  public val val2: kotlin.String?
-      |) {
-      |  public override fun toString(): kotlin.String = ""${'"'}
-      |  |LeftJoin [
-      |  |  val1: ${"$"}val1
-      |  |  val2: ${"$"}val2
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
+      |)
       |""".trimMargin()
     )
   }
@@ -82,14 +75,7 @@ class InterfaceGeneration {
       |public data class LeftJoin(
       |  public val value_: kotlin.String,
       |  public val value__: kotlin.String
-      |) {
-      |  public override fun toString(): kotlin.String = ""${'"'}
-      |  |LeftJoin [
-      |  |  value_: ${"$"}value_
-      |  |  value__: ${"$"}value__
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
+      |)
       |""".trimMargin()
     )
   }
@@ -121,14 +107,7 @@ class InterfaceGeneration {
       |public data class UnionOfBoth(
       |  public val value_: kotlin.String?,
       |  public val value__: kotlin.String?
-      |) {
-      |  public override fun toString(): kotlin.String = ""${'"'}
-      |  |UnionOfBoth [
-      |  |  value_: ${"$"}value_
-      |  |  value__: ${"$"}value__
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
+      |)
       |""".trimMargin()
     )
   }
@@ -156,14 +135,7 @@ class InterfaceGeneration {
       |public data class UnionOfBoth(
       |  public val value_: kotlin.collections.List,
       |  public val value__: kotlin.collections.List?
-      |) {
-      |  public override fun toString(): kotlin.String = ""${'"'}
-      |  |UnionOfBoth [
-      |  |  value_: ${"$"}value_
-      |  |  value__: ${"$"}value__
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
+      |)
       |""".trimMargin()
     )
   }
@@ -195,14 +167,7 @@ class InterfaceGeneration {
       |public data class UnionOfBoth(
       |  public val value_: kotlin.collections.List,
       |  public val value__: kotlin.collections.List?
-      |) {
-      |  public override fun toString(): kotlin.String = ""${'"'}
-      |  |UnionOfBoth [
-      |  |  value_: ${"$"}value_
-      |  |  value__: ${"$"}value__
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
+      |)
       |""".trimMargin()
     )
   }
@@ -230,14 +195,7 @@ class InterfaceGeneration {
       |public data class UnionOfBoth(
       |  public val value_: kotlin.collections.List?,
       |  public val expr: kotlin.collections.List?
-      |) {
-      |  public override fun toString(): kotlin.String = ""${'"'}
-      |  |UnionOfBoth [
-      |  |  value_: ${"$"}value_
-      |  |  expr: ${"$"}expr
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
+      |)
       |""".trimMargin()
     )
   }
@@ -265,14 +223,7 @@ class InterfaceGeneration {
       |public data class UnionOfBoth(
       |  public val value_: kotlin.collections.List,
       |  public val expr: kotlin.collections.List
-      |) {
-      |  public override fun toString(): kotlin.String = ""${'"'}
-      |  |UnionOfBoth [
-      |  |  value_: ${"$"}value_
-      |  |  expr: ${"$"}expr
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
+      |)
       |""".trimMargin()
     )
   }
@@ -317,19 +268,7 @@ class InterfaceGeneration {
       |  public val _id_: kotlin.Long,
       |  public val name_: kotlin.String,
       |  public val address_: kotlin.String
-      |) {
-      |  public override fun toString(): kotlin.String = ""${'"'}
-      |  |Select_all [
-      |  |  _id: ${"$"}_id
-      |  |  name: ${"$"}name
-      |  |  address: ${"$"}address
-      |  |  status: ${"$"}status
-      |  |  _id_: ${"$"}_id_
-      |  |  name_: ${"$"}name_
-      |  |  address_: ${"$"}address_
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
+      |)
       |""".trimMargin()
     )
   }
@@ -368,14 +307,7 @@ class InterfaceGeneration {
       |public data class SelectFromView(
       |  public val name: kotlin.String?,
       |  public val nameB: kotlin.String?
-      |) {
-      |  public override fun toString(): kotlin.String = ""${'"'}
-      |  |SelectFromView [
-      |  |  name: ${"$"}name
-      |  |  nameB: ${"$"}nameB
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
+      |)
       |""".trimMargin()
     )
   }
@@ -404,15 +336,7 @@ class InterfaceGeneration {
       |  public val is_cool: String,
       |  public val get_cheese: String,
       |  public val stuff: String
-      |) {
-      |  public override fun toString(): String = ""${'"'}
-      |  |SomeSelect [
-      |  |  is_cool: ${"$"}is_cool
-      |  |  get_cheese: ${"$"}get_cheese
-      |  |  stuff: ${"$"}stuff
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
+      |)
       |""".trimMargin()
     )
   }
@@ -462,16 +386,7 @@ class InterfaceGeneration {
       |  public val status: Test.Status?,
       |  public val attr: String?,
       |  public val ordering: Long
-      |) {
-      |  public override fun toString(): String = ""${'"'}
-      |  |SomeSelect [
-      |  |  id: ${"$"}id
-      |  |  status: ${"$"}status
-      |  |  attr: ${"$"}attr
-      |  |  ordering: ${"$"}ordering
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
+      |)
       |""".trimMargin()
     )
   }
@@ -506,14 +421,7 @@ class InterfaceGeneration {
       |public data class SomeSelect(
       |  public val text_content: String?,
       |  public val expr: Long
-      |) {
-      |  public override fun toString(): String = ""${'"'}
-      |  |SomeSelect [
-      |  |  text_content: ${"$"}text_content
-      |  |  expr: ${"$"}expr
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
+      |)
       |""".trimMargin()
     )
   }
@@ -549,14 +457,7 @@ class InterfaceGeneration {
       |public data class SomeSelect(
       |  public val text_content: String?,
       |  public val expr: Long
-      |) {
-      |  public override fun toString(): String = ""${'"'}
-      |  |SomeSelect [
-      |  |  text_content: ${"$"}text_content
-      |  |  expr: ${'$'}expr
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
+      |)
       |""".trimMargin()
     )
   }
@@ -614,99 +515,7 @@ class InterfaceGeneration {
       |  public val category_: List,
       |  public val type_: List,
       |  public val name_: String
-      |) {
-      |  public override fun toString(): String = ""${'"'}
-      |  |Exact_match [
-      |  |  _id: ${"$"}_id
-      |  |  parent_id: ${"$"}parent_id
-      |  |  child_id: ${"$"}child_id
-      |  |  _id_: ${"$"}_id_
-      |  |  category: ${"$"}category
-      |  |  type: ${"$"}type
-      |  |  name: ${"$"}name
-      |  |  _id__: ${"$"}_id__
-      |  |  category_: ${"$"}category_
-      |  |  type_: ${"$"}type_
-      |  |  name_: ${"$"}name_
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
-      |""".trimMargin()
-    )
-  }
-
-  @Test fun `kotlin array types are printed properly`() {
-    val result = FixtureCompiler.compileSql(
-      """
-      |CREATE TABLE test (
-      |  arrayValue BLOB AS kotlin.Array<kotlin.Int> NOT NULL,
-      |  booleanArrayValue BLOB AS kotlin.BooleanArray NOT NULL,
-      |  byteArrayValue BLOB AS kotlin.ByteArray NOT NULL,
-      |  charArrayValue BLOB AS kotlin.CharArray NOT NULL,
-      |  doubleArrayValue BLOB AS kotlin.DoubleArray NOT NULL,
-      |  floatArrayValue BLOB AS kotlin.FloatArray NOT NULL,
-      |  intArrayValue BLOB AS kotlin.IntArray NOT NULL,
-      |  longArrayValue BLOB AS kotlin.LongArray NOT NULL,
-      |  shortArrayValue BLOB AS kotlin.ShortArray NOT NULL
-      |);
-      |
-      |selectAll:
-      |SELECT *, 1
-      |FROM test;
-      |""".trimMargin(),
-      temporaryFolder
-    )
-
-    assertThat(result.errors).isEmpty()
-    val generatedInterface = result.compilerOutput.get(
-      File(result.outputDirectory, "com/example/SelectAll.kt")
-    )
-    assertThat(generatedInterface).isNotNull()
-    assertThat(generatedInterface.toString()).isEqualTo(
-      """
-      |package com.example
-      |
-      |import kotlin.Array
-      |import kotlin.BooleanArray
-      |import kotlin.ByteArray
-      |import kotlin.CharArray
-      |import kotlin.DoubleArray
-      |import kotlin.FloatArray
-      |import kotlin.Int
-      |import kotlin.IntArray
-      |import kotlin.Long
-      |import kotlin.LongArray
-      |import kotlin.ShortArray
-      |import kotlin.String
-      |import kotlin.collections.contentToString
-      |
-      |public data class SelectAll(
-      |  public val arrayValue: Array<Int>,
-      |  public val booleanArrayValue: BooleanArray,
-      |  public val byteArrayValue: ByteArray,
-      |  public val charArrayValue: CharArray,
-      |  public val doubleArrayValue: DoubleArray,
-      |  public val floatArrayValue: FloatArray,
-      |  public val intArrayValue: IntArray,
-      |  public val longArrayValue: LongArray,
-      |  public val shortArrayValue: ShortArray,
-      |  public val expr: Long
-      |) {
-      |  public override fun toString(): String = ""${'"'}
-      |  |SelectAll [
-      |  |  arrayValue: ${'$'}{arrayValue.contentToString()}
-      |  |  booleanArrayValue: ${'$'}{booleanArrayValue.contentToString()}
-      |  |  byteArrayValue: ${'$'}{byteArrayValue.contentToString()}
-      |  |  charArrayValue: ${'$'}{charArrayValue.contentToString()}
-      |  |  doubleArrayValue: ${'$'}{doubleArrayValue.contentToString()}
-      |  |  floatArrayValue: ${'$'}{floatArrayValue.contentToString()}
-      |  |  intArrayValue: ${'$'}{intArrayValue.contentToString()}
-      |  |  longArrayValue: ${'$'}{longArrayValue.contentToString()}
-      |  |  shortArrayValue: ${'$'}{shortArrayValue.contentToString()}
-      |  |  expr: ${'$'}expr
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
+      |)
       |""".trimMargin()
     )
   }
@@ -740,21 +549,12 @@ class InterfaceGeneration {
       |package com.example
       |
       |import kotlin.Double
-      |import kotlin.String
       |
       |public data class Average(
       |  public val avg_integer_value: Double?,
       |  public val avg_real_value: Double?,
       |  public val avg_nullable_real_value: Double?
-      |) {
-      |  public override fun toString(): String = ""${'"'}
-      |  |Average [
-      |  |  avg_integer_value: ${'$'}avg_integer_value
-      |  |  avg_real_value: ${'$'}avg_real_value
-      |  |  avg_nullable_real_value: ${'$'}avg_nullable_real_value
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
+      |)
       |""".trimMargin()
     )
   }
@@ -810,15 +610,7 @@ class InterfaceGeneration {
       |  public val id: Long,
       |  public val name: String,
       |  public val emojis: String?
-      |) {
-      |  public override fun toString(): String = ""${'"'}
-      |  |TargetWithEmojis [
-      |  |  id: ${'$'}id
-      |  |  name: ${'$'}name
-      |  |  emojis: ${'$'}emojis
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
+      |)
       |""".trimMargin()
     )
   }
@@ -874,15 +666,7 @@ class InterfaceGeneration {
       |  public val id: Long,
       |  public val name: String,
       |  public val emojis: String?
-      |) {
-      |  public override fun toString(): String = ""${'"'}
-      |  |TargetWithEmojis [
-      |  |  id: ${'$'}id
-      |  |  name: ${'$'}name
-      |  |  emojis: ${'$'}emojis
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
+      |)
       |""".trimMargin()
     )
   }
@@ -909,14 +693,7 @@ class InterfaceGeneration {
       |public data class SelectWithCast(
       |  public val foo: kotlin.String?,
       |  public val bar: kotlin.ByteArray?
-      |) {
-      |  public override fun toString(): kotlin.String = ""${'"'}
-      |  |SelectWithCast [
-      |  |  foo: ${'$'}foo
-      |  |  bar: ${'$'}bar
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
+      |)
       |""".trimMargin()
     )
   }

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/tables/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/tables/InterfaceGeneration.kt
@@ -7,7 +7,6 @@ import app.cash.sqldelight.test.util.withInvariantLineSeparators
 import com.alecstrong.sql.psi.core.DialectPreset
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
-import com.squareup.kotlinpoet.FileSpec
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -50,18 +49,11 @@ class InterfaceGeneration {
       |import com.sample.SomeOtherAnnotation
       |import java.util.List
       |import kotlin.Int
-      |import kotlin.String
       |
       |public data class Test(
       |  public val annotated: @SomeAnnotation(cheese = ["havarti","provalone"], age = 10, type =
       |      List::class, otherAnnotation = SomeOtherAnnotation("value")) Int?
-      |) {
-      |  public override fun toString(): String = ""${'"'}
-      |  |Test [
-      |  |  annotated: ${"$"}annotated
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
+      |)
       |""".trimMargin()
     )
   }
@@ -93,16 +85,7 @@ class InterfaceGeneration {
       |  public val get_cheese: String?,
       |  public val isle: String?,
       |  public val stuff: String?
-      |) {
-      |  public override fun toString(): String = ""${'"'}
-      |  |Test [
-      |  |  is_cool: ${"$"}is_cool
-      |  |  get_cheese: ${"$"}get_cheese
-      |  |  isle: ${"$"}isle
-      |  |  stuff: ${"$"}stuff
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
+      |)
       |""".trimMargin()
     )
   }
@@ -136,99 +119,7 @@ class InterfaceGeneration {
       |  public val floatValue: kotlin.Float,
       |  public val doubleValue: kotlin.Double,
       |  public val blobValue: kotlin.ByteArray
-      |) {
-      |  public override fun toString(): kotlin.String = ""${'"'}
-      |  |Test [
-      |  |  intValue: ${"$"}intValue
-      |  |  intValue2: ${"$"}intValue2
-      |  |  booleanValue: ${"$"}booleanValue
-      |  |  shortValue: ${"$"}shortValue
-      |  |  longValue: ${"$"}longValue
-      |  |  floatValue: ${"$"}floatValue
-      |  |  doubleValue: ${"$"}doubleValue
-      |  |  blobValue: ${"$"}{blobValue.kotlin.collections.contentToString()}
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
-      |""".trimMargin()
-    )
-  }
-
-  @Test fun `kotlin array types are printed properly`() {
-    val result = FixtureCompiler.parseSql(
-      """
-      |CREATE TABLE test (
-      |  arrayValue BLOB AS kotlin.Array<kotlin.Int> NOT NULL,
-      |  booleanArrayValue BLOB AS kotlin.BooleanArray NOT NULL,
-      |  byteArrayValue BLOB AS kotlin.ByteArray NOT NULL,
-      |  charArrayValue BLOB AS kotlin.CharArray NOT NULL,
-      |  doubleArrayValue BLOB AS kotlin.DoubleArray NOT NULL,
-      |  floatArrayValue BLOB AS kotlin.FloatArray NOT NULL,
-      |  intArrayValue BLOB AS kotlin.IntArray NOT NULL,
-      |  longArrayValue BLOB AS kotlin.LongArray NOT NULL,
-      |  shortArrayValue BLOB AS kotlin.ShortArray NOT NULL
-      |);
-      |""".trimMargin(),
-      tempFolder
-    )
-
-    val generator = TableInterfaceGenerator(result.sqliteStatements().first().statement.createTableStmt!!.tableExposed())
-    val file = FileSpec.builder("", "Test")
-      .addType(generator.kotlinImplementationSpec())
-      .build()
-    assertThat(file.toString()).isEqualTo(
-      """
-      |import app.cash.sqldelight.ColumnAdapter
-      |import kotlin.Array
-      |import kotlin.BooleanArray
-      |import kotlin.ByteArray
-      |import kotlin.CharArray
-      |import kotlin.DoubleArray
-      |import kotlin.FloatArray
-      |import kotlin.Int
-      |import kotlin.IntArray
-      |import kotlin.LongArray
-      |import kotlin.ShortArray
-      |import kotlin.String
-      |import kotlin.collections.contentToString
-      |
-      |public data class Test(
-      |  public val arrayValue: Array<Int>,
-      |  public val booleanArrayValue: BooleanArray,
-      |  public val byteArrayValue: ByteArray,
-      |  public val charArrayValue: CharArray,
-      |  public val doubleArrayValue: DoubleArray,
-      |  public val floatArrayValue: FloatArray,
-      |  public val intArrayValue: IntArray,
-      |  public val longArrayValue: LongArray,
-      |  public val shortArrayValue: ShortArray
-      |) {
-      |  public override fun toString(): String = ""${'"'}
-      |  |Test [
-      |  |  arrayValue: ${'$'}{arrayValue.contentToString()}
-      |  |  booleanArrayValue: ${'$'}{booleanArrayValue.contentToString()}
-      |  |  byteArrayValue: ${'$'}{byteArrayValue.contentToString()}
-      |  |  charArrayValue: ${'$'}{charArrayValue.contentToString()}
-      |  |  doubleArrayValue: ${'$'}{doubleArrayValue.contentToString()}
-      |  |  floatArrayValue: ${'$'}{floatArrayValue.contentToString()}
-      |  |  intArrayValue: ${'$'}{intArrayValue.contentToString()}
-      |  |  longArrayValue: ${'$'}{longArrayValue.contentToString()}
-      |  |  shortArrayValue: ${'$'}{shortArrayValue.contentToString()}
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |
-      |  public class Adapter(
-      |    public val arrayValueAdapter: ColumnAdapter<Array<Int>, ByteArray>,
-      |    public val booleanArrayValueAdapter: ColumnAdapter<BooleanArray, ByteArray>,
-      |    public val byteArrayValueAdapter: ColumnAdapter<ByteArray, ByteArray>,
-      |    public val charArrayValueAdapter: ColumnAdapter<CharArray, ByteArray>,
-      |    public val doubleArrayValueAdapter: ColumnAdapter<DoubleArray, ByteArray>,
-      |    public val floatArrayValueAdapter: ColumnAdapter<FloatArray, ByteArray>,
-      |    public val intArrayValueAdapter: ColumnAdapter<IntArray, ByteArray>,
-      |    public val longArrayValueAdapter: ColumnAdapter<LongArray, ByteArray>,
-      |    public val shortArrayValueAdapter: ColumnAdapter<ShortArray, ByteArray>
-      |  )
-      |}
+      |)
       |""".trimMargin()
     )
   }
@@ -249,12 +140,6 @@ class InterfaceGeneration {
       |public data class Test(
       |  public val mapValue: kotlin.collections.Map<kotlin.collections.List<kotlin.collections.List<String>>, kotlin.collections.List<kotlin.collections.List<String>>>?
       |) {
-      |  public override fun toString(): kotlin.String = ""${'"'}
-      |  |Test [
-      |  |  mapValue: ${"$"}mapValue
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |
       |  public class Adapter(
       |    public val mapValueAdapter: app.cash.sqldelight.ColumnAdapter<kotlin.collections.Map<kotlin.collections.List<kotlin.collections.List<String>>, kotlin.collections.List<kotlin.collections.List<String>>>, kotlin.Long>
       |  )
@@ -287,14 +172,6 @@ class InterfaceGeneration {
       |  public val enabledDays: kotlin.collections.Set<java.time.DayOfWeek>?,
       |  public val enabledWeeks: kotlin.collections.Set<com.gabrielittner.timetable.core.db.Week>?
       |) {
-      |  public override fun toString(): kotlin.String = ""${'"'}
-      |  |Test [
-      |  |  _id: ${"$"}_id
-      |  |  enabledDays: ${"$"}enabledDays
-      |  |  enabledWeeks: ${"$"}enabledWeeks
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |
       |  public class Adapter(
       |    public val enabledDaysAdapter: app.cash.sqldelight.ColumnAdapter<kotlin.collections.Set<java.time.DayOfWeek>, kotlin.String>,
       |    public val enabledWeeksAdapter: app.cash.sqldelight.ColumnAdapter<kotlin.collections.Set<com.gabrielittner.timetable.core.db.Week>, kotlin.String>
@@ -325,16 +202,7 @@ class InterfaceGeneration {
       |  public val index2: kotlin.String?,
       |  public val index3: kotlin.String?,
       |  public val index4: kotlin.String?
-      |) {
-      |  public override fun toString(): kotlin.String = ""${'"'}
-      |  |Group [
-      |  |  index1: ${"$"}index1
-      |  |  index2: ${"$"}index2
-      |  |  index3: ${"$"}index3
-      |  |  index4: ${"$"}index4
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
+      |)
       |""".trimMargin()
     )
   }
@@ -367,18 +235,6 @@ class InterfaceGeneration {
       |  public val bigIntValue: kotlin.Any,
       |  public val bitValue: kotlin.Any
       |) {
-      |  public override fun toString(): kotlin.String = ""${'"'}
-      |  |Test [
-      |  |  tinyIntValue: ${"$"}tinyIntValue
-      |  |  tinyIntBoolValue: ${"$"}tinyIntBoolValue
-      |  |  smallIntValue: ${"$"}smallIntValue
-      |  |  mediumIntValue: ${"$"}mediumIntValue
-      |  |  intValue: ${"$"}intValue
-      |  |  bigIntValue: ${"$"}bigIntValue
-      |  |  bitValue: ${"$"}bitValue
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |
       |  public class Adapter(
       |    public val tinyIntValueAdapter: app.cash.sqldelight.ColumnAdapter<kotlin.Any, kotlin.Byte>,
       |    public val tinyIntBoolValueAdapter: app.cash.sqldelight.ColumnAdapter<kotlin.Any, kotlin.Boolean>,
@@ -419,17 +275,6 @@ class InterfaceGeneration {
       |  public val serialValue: kotlin.Any,
       |  public val bigSerialValue: kotlin.Any
       |) {
-      |  public override fun toString(): kotlin.String = ""${'"'}
-      |  |Test [
-      |  |  smallIntValue: ${"$"}smallIntValue
-      |  |  intValue: ${"$"}intValue
-      |  |  bigIntValue: ${"$"}bigIntValue
-      |  |  smallSerialValue: ${"$"}smallSerialValue
-      |  |  serialValue: ${"$"}serialValue
-      |  |  bigSerialValue: ${"$"}bigSerialValue
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |
       |  public class Adapter(
       |    public val smallIntValueAdapter: app.cash.sqldelight.ColumnAdapter<kotlin.Any, kotlin.Short>,
       |    public val intValueAdapter: app.cash.sqldelight.ColumnAdapter<kotlin.Any, kotlin.Int>,
@@ -467,16 +312,6 @@ class InterfaceGeneration {
       |  public val bigIntValue: kotlin.Any,
       |  public val booleanValue: kotlin.Any
       |) {
-      |  public override fun toString(): kotlin.String = ""${'"'}
-      |  |Test [
-      |  |  tinyIntValue: ${"$"}tinyIntValue
-      |  |  smallIntValue: ${"$"}smallIntValue
-      |  |  intValue: ${"$"}intValue
-      |  |  bigIntValue: ${"$"}bigIntValue
-      |  |  booleanValue: ${"$"}booleanValue
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |
       |  public class Adapter(
       |    public val tinyIntValueAdapter: app.cash.sqldelight.ColumnAdapter<kotlin.Any, kotlin.Byte>,
       |    public val smallIntValueAdapter: app.cash.sqldelight.ColumnAdapter<kotlin.Any, kotlin.Short>,

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/views/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/views/InterfaceGeneration.kt
@@ -48,19 +48,11 @@ class InterfaceGeneration {
       |package com.example
       |
       |import kotlin.Boolean
-      |import kotlin.String
       |
       |public data class SomeView(
       |  public val val_: Boolean,
       |  public val val__: Boolean
-      |) {
-      |  public override fun toString(): String = ""${'"'}
-      |  |SomeView [
-      |  |  val_: ${"$"}val_
-      |  |  val__: ${"$"}val__
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
+      |)
       |""".trimMargin()
     )
   }
@@ -96,95 +88,11 @@ class InterfaceGeneration {
       |package com.example
       |
       |import kotlin.Boolean
-      |import kotlin.String
       |
       |public data class SomeView(
       |  public val val_: Boolean,
       |  public val val__: Boolean
-      |) {
-      |  public override fun toString(): String = ""${'"'}
-      |  |SomeView [
-      |  |  val_: ${"$"}val_
-      |  |  val__: ${"$"}val__
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
-      |""".trimMargin()
-    )
-  }
-
-  @Test fun `kotlin array types are printed properly`() {
-    val result = FixtureCompiler.compileSql(
-      """
-      |CREATE TABLE test (
-      |  arrayValue BLOB AS kotlin.Array<kotlin.Int> NOT NULL,
-      |  booleanArrayValue BLOB AS kotlin.BooleanArray NOT NULL,
-      |  byteArrayValue BLOB AS kotlin.ByteArray NOT NULL,
-      |  charArrayValue BLOB AS kotlin.CharArray NOT NULL,
-      |  doubleArrayValue BLOB AS kotlin.DoubleArray NOT NULL,
-      |  floatArrayValue BLOB AS kotlin.FloatArray NOT NULL,
-      |  intArrayValue BLOB AS kotlin.IntArray NOT NULL,
-      |  longArrayValue BLOB AS kotlin.LongArray NOT NULL,
-      |  shortArrayValue BLOB AS kotlin.ShortArray NOT NULL
-      |);
-      |
-      |CREATE VIEW someView AS
-      |SELECT *, 1
-      |FROM test;
-      |""".trimMargin(),
-      temporaryFolder
-    )
-
-    assertThat(result.errors).isEmpty()
-    val generatedInterface = result.compilerOutput.get(
-      File(result.outputDirectory, "com/example/SomeView.kt")
-    )
-    assertThat(generatedInterface).isNotNull()
-    assertThat(generatedInterface.toString()).isEqualTo(
-      """
-      |package com.example
-      |
-      |import kotlin.Array
-      |import kotlin.BooleanArray
-      |import kotlin.ByteArray
-      |import kotlin.CharArray
-      |import kotlin.DoubleArray
-      |import kotlin.FloatArray
-      |import kotlin.Int
-      |import kotlin.IntArray
-      |import kotlin.Long
-      |import kotlin.LongArray
-      |import kotlin.ShortArray
-      |import kotlin.String
-      |import kotlin.collections.contentToString
-      |
-      |public data class SomeView(
-      |  public val arrayValue: Array<Int>,
-      |  public val booleanArrayValue: BooleanArray,
-      |  public val byteArrayValue: ByteArray,
-      |  public val charArrayValue: CharArray,
-      |  public val doubleArrayValue: DoubleArray,
-      |  public val floatArrayValue: FloatArray,
-      |  public val intArrayValue: IntArray,
-      |  public val longArrayValue: LongArray,
-      |  public val shortArrayValue: ShortArray,
-      |  public val expr: Long
-      |) {
-      |  public override fun toString(): String = ""${'"'}
-      |  |SomeView [
-      |  |  arrayValue: ${'$'}{arrayValue.contentToString()}
-      |  |  booleanArrayValue: ${'$'}{booleanArrayValue.contentToString()}
-      |  |  byteArrayValue: ${'$'}{byteArrayValue.contentToString()}
-      |  |  charArrayValue: ${'$'}{charArrayValue.contentToString()}
-      |  |  doubleArrayValue: ${'$'}{doubleArrayValue.contentToString()}
-      |  |  floatArrayValue: ${'$'}{floatArrayValue.contentToString()}
-      |  |  intArrayValue: ${'$'}{intArrayValue.contentToString()}
-      |  |  longArrayValue: ${'$'}{longArrayValue.contentToString()}
-      |  |  shortArrayValue: ${'$'}{shortArrayValue.contentToString()}
-      |  |  expr: ${'$'}expr
-      |  |]
-      |  ""${'"'}.trimMargin()
-      |}
+      |)
       |""".trimMargin()
     )
   }

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/output/com/example/New_test.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/output/com/example/New_test.kt
@@ -9,13 +9,6 @@ public data class New_test(
   public val first: String,
   public val second: List<Int>?
 ) {
-  public override fun toString(): String = """
-  |New_test [
-  |  first: $first
-  |  second: $second
-  |]
-  """.trimMargin()
-
   public class Adapter(
     public val secondAdapter: ColumnAdapter<List<Int>, String>
   )

--- a/sqldelight-compiler/src/test/query-interface-fixtures/query-requires-type/output/com/sample/JoinedWithUsing.kt
+++ b/sqldelight-compiler/src/test/query-interface-fixtures/query-requires-type/output/com/sample/JoinedWithUsing.kt
@@ -6,11 +6,4 @@ import kotlin.String
 public data class JoinedWithUsing(
   public val name: String,
   public val is_cool: Boolean
-) {
-  public override fun toString(): String = """
-  |JoinedWithUsing [
-  |  name: $name
-  |  is_cool: $is_cool
-  |]
-  """.trimMargin()
-}
+)

--- a/sqldelight-compiler/src/test/table-interface-fixtures/requires-adapter/output/com/sample/Person.kt
+++ b/sqldelight-compiler/src/test/table-interface-fixtures/requires-adapter/output/com/sample/Person.kt
@@ -19,17 +19,6 @@ public data class Person(
   public val friends: List<Person>?,
   public val shhh_its_secret: @Redacted String
 ) {
-  public override fun toString(): String = """
-  |Person [
-  |  _id: $_id
-  |  name: $name
-  |  last_name: $last_name
-  |  is_cool: $is_cool
-  |  friends: $friends
-  |  shhh_its_secret: $shhh_its_secret
-  |]
-  """.trimMargin()
-
   public class Adapter(
     public val friendsAdapter: ColumnAdapter<List<Person>, ByteArray>
   )

--- a/sqldelight-compiler/src/test/view-interface-fixtures/only-table-type/output/com/sample/Person.kt
+++ b/sqldelight-compiler/src/test/view-interface-fixtures/only-table-type/output/com/sample/Person.kt
@@ -16,17 +16,6 @@ public data class Person(
   public val friends: List<Person>?,
   public val shhh_its_secret: @Redacted String
 ) {
-  public override fun toString(): String = """
-  |Person [
-  |  _id: $_id
-  |  name: $name
-  |  last_name: $last_name
-  |  is_cool: $is_cool
-  |  friends: $friends
-  |  shhh_its_secret: $shhh_its_secret
-  |]
-  """.trimMargin()
-
   public class Adapter(
     public val friendsAdapter: ColumnAdapter<List<Person>, ByteArray>
   )

--- a/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/Person.kt
+++ b/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/Person.kt
@@ -16,17 +16,6 @@ public data class Person(
   public val friends: List<Person>?,
   public val shhh_its_secret: @Redacted String
 ) {
-  public override fun toString(): String = """
-  |Person [
-  |  _id: $_id
-  |  name: $name
-  |  last_name: $last_name
-  |  is_cool: $is_cool
-  |  friends: $friends
-  |  shhh_its_secret: $shhh_its_secret
-  |]
-  """.trimMargin()
-
   public class Adapter(
     public val friendsAdapter: ColumnAdapter<List<Person>, ByteArray>
   )

--- a/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/PersonAndFriends.kt
+++ b/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/PersonAndFriends.kt
@@ -10,13 +10,4 @@ public data class PersonAndFriends(
   public val friends: List<Person>?,
   public val shhh_its_secret: @Redacted String,
   public val casted: Double
-) {
-  public override fun toString(): String = """
-  |PersonAndFriends [
-  |  full_name: $full_name
-  |  friends: $friends
-  |  shhh_its_secret: $shhh_its_secret
-  |  casted: $casted
-  |]
-  """.trimMargin()
-}
+)

--- a/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/PersonCool.kt
+++ b/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/PersonCool.kt
@@ -14,16 +14,4 @@ public data class PersonCool(
   public val friends: List<Person>?,
   public val shhh_its_secret: @Redacted String,
   public val how_cool: String
-) {
-  public override fun toString(): String = """
-  |PersonCool [
-  |  _id: $_id
-  |  name: $name
-  |  last_name: $last_name
-  |  is_cool: $is_cool
-  |  friends: $friends
-  |  shhh_its_secret: $shhh_its_secret
-  |  how_cool: $how_cool
-  |]
-  """.trimMargin()
-}
+)


### PR DESCRIPTION
The current custom implementation existed only for the reason that historically, an interface and an implementation was generated named `Impl`. This lead to all classes printing their names as Impl.
As this is no longer the case the custom toString is no longer necessary.

I noticed this when I analyzed the generated code and oversaw that an actual data class was generated. The fact that it had a toString implementation made me think that it was not a data class so I was initially googling how to let sqldelight generate data classes - which it already does.

So this PR simplifies that and just uses kotlins built in toString implementation.