### PR TITLE
Filter out all characters when computing integer versions for the semver

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/GradleCompatibility.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/GradleCompatibility.kt
@@ -41,7 +41,7 @@ object GradleCompatibility {
     constructor(semVerText: String) : this(
       major = semVerText.split('.')[0].toInt(),
       minor = semVerText.split('.')[1].toInt(),
-      patch = semVerText.split('.')[2].removeSuffix("-SNAPSHOT").toInt(),
+      patch = semVerText.split('.')[2].filter { it.isDigit() }.toInt(),
       snapshot = semVerText.endsWith("-SNAPSHOT"),
     )
 


### PR DESCRIPTION
This is so that we can do alpha/beta/internal/etc releases and the IDE plugin will continue to work