### PR TITLE
Update gradle docs to mention that a sqlite dialect version is auto picked on android

### DIFF
--- a/docs/common/gradle-common-groovy-properties.md
+++ b/docs/common/gradle-common-groovy-properties.md
@@ -4,7 +4,7 @@
     // An array of folders where the plugin will read your '.sq' and '.sqm' 
     // files. The folders are relative to the existing source set so if you
     // specify ["db"], the plugin will look into 'src/main/db' or 'src/commonMain/db' for KMM. 
-    // Defaults to ["sqldelight"]
+    // Defaults to ["sqldelight"].
     sourceFolders = ["db"]
 
     // The directory where to store '.db' schema files relative to the root 
@@ -16,10 +16,11 @@
     // Optionally specify schema dependencies on other gradle projects
     dependency project(':OtherProject')
 
-    // The dialect version you would like to target
-    // Defaults to "sqlite:3.18"
+    // The dialect version you would explicitly like to target. This can be skipped
+    // on Android where a SQLite version is automatically picked based on your minSdk.
+    // Defaults to "sqlite:3.18".
     dialect = "sqlite:3.24"
     
     // If set to true, migration files will fail during compilation if there are errors in them.
-    // Defaults to false
+    // Defaults to false.
     verifyMigrations = true

--- a/docs/common/gradle-common-groovy-properties.md
+++ b/docs/common/gradle-common-groovy-properties.md
@@ -18,7 +18,7 @@
 
     // The dialect version you would explicitly like to target. This can be skipped
     // on Android where a SQLite version is automatically picked based on your minSdk.
-    // Defaults to "sqlite:3.18".
+    // Otherwise defaults to "sqlite:3.18".
     dialect = "sqlite:3.24"
     
     // If set to true, migration files will fail during compilation if there are errors in them.


### PR DESCRIPTION
Just learned about https://github.com/cashapp/sqldelight/pull/2315. Thought we should mention it in our docs. Thoughts?