### PR TITLE
Dont initialize the file index until a gradle sync has occurred

### DIFF
--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/ProjectService.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/ProjectService.kt
@@ -43,7 +43,8 @@ import timber.log.Timber
 import java.io.PrintStream
 
 class ProjectService(val project: Project) : SqlDelightProjectService, Disposable {
-  private var fileIndexes = FileIndexMap()
+  // This gets initialized after a gradle sync so we don't compete with the sync.
+  private var fileIndexes: FileIndexMap? = null
   private val loggingTree = LoggerTree(Logger.getInstance("SQLDelight[${project.name}]"))
 
   init {
@@ -94,11 +95,13 @@ class ProjectService(val project: Project) : SqlDelightProjectService, Disposabl
     }
   }
 
-  override var dialectPreset: DialectPreset = DialectPreset.SQLITE_3_18
+  private var _dialectPreset: DialectPreset? = null
+  override var dialectPreset: DialectPreset
+    get() = _dialectPreset ?: DialectPreset.SQLITE_3_18
     set(value) {
-      Timber.i("Setting dialect from $field to $value")
-      val invalidate = field != value
-      field = value
+      Timber.i("Setting dialect from $_dialectPreset to $value")
+      val invalidate = _dialectPreset != value
+      _dialectPreset = value
       if (invalidate) {
         val files = mutableListOf<VirtualFile>()
         ProjectRootManager.getInstance(project).fileIndex.iterateContent { vFile ->
@@ -123,6 +126,6 @@ class ProjectService(val project: Project) : SqlDelightProjectService, Disposabl
   }
 
   override fun fileIndex(module: Module): SqlDelightFileIndex {
-    return fileIndexes[module]
+    return fileIndexes?.get(module) ?: FileIndexMap.defaultIndex
   }
 }


### PR DESCRIPTION
 - This stops us from competing with the gradle sync for gradle's time,
   which appeared to be causing a deadlock.
 - Also having the dialect initialized to null means that once the
   configuration is loaded, if the dialect is sqlite:3.18 it will
   correctly reload and reparse all already open .sq files.