### PR TITLE
Sort files when generating code to ensure idempotent outputs

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/DatabaseGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/DatabaseGenerator.kt
@@ -120,7 +120,9 @@ internal class DatabaseGenerator(
   private fun forAdapters(
     block: (PropertySpec) -> Unit
   ) {
-    val queriesFile = sourceFolders.flatMap { it.findChildrenOfType<SqlDelightQueriesFile>() }
+    val queriesFile = sourceFolders
+      .flatMap { it.findChildrenOfType<SqlDelightQueriesFile>() }
+      .sortedBy { it.name }
       .firstOrNull() ?: return
     queriesFile.tables(true)
       .toSet()
@@ -184,6 +186,7 @@ internal class DatabaseGenerator(
     if (!fileIndex.deriveSchemaFromMigrations) {
       // Derive the schema from queries files.
       sourceFolders.flatMap { it.findChildrenOfType<SqlDelightQueriesFile>() }
+        .sortedBy { it.name }
         .forInitializationStatements(dialect.allowsReferenceCycles) { sqlText ->
           createFunction.addStatement("$DRIVER_NAME.execute(null, %L, 0)", sqlText.toCodeLiteral())
         }


### PR DESCRIPTION
This fixes remote build cache misses when the files have different outputs based on file system ordering across different OS's.

This is a port of my patch for the 1.5.3 tag, which can be found here: https://github.com/ZacSweers/sqldelight/commit/b45540ac942738972c76d979ddd85fd835a8ba60

Tested the 1.5.3 patch at least and confirmed this fixes things on our side