### PR TITLE
Cancel the SQLDelight import if a gradle sync begins

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/SqlDelightEnvironment.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/SqlDelightEnvironment.kt
@@ -110,6 +110,8 @@ class SqlDelightEnvironment(
 
   override fun resetIndex() = throw UnsupportedOperationException()
 
+  override fun clearIndex() = throw UnsupportedOperationException()
+
   override var dialectPreset: DialectPreset
     get() = properties.dialectPreset
     set(_) { throw UnsupportedOperationException() }

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/SqlDelightProjectService.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/SqlDelightProjectService.kt
@@ -30,6 +30,8 @@ interface SqlDelightProjectService {
 
   fun resetIndex()
 
+  fun clearIndex()
+
   companion object {
     fun getInstance(project: Project): SqlDelightProjectService {
       return ServiceManager.getService(project, SqlDelightProjectService::class.java)!!

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/GradleSystemListener.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/GradleSystemListener.kt
@@ -1,13 +1,29 @@
 package app.cash.sqldelight.intellij
 
 import app.cash.sqldelight.core.SqlDelightProjectService
+import app.cash.sqldelight.intellij.notifications.FileIndexingNotification
+import app.cash.sqldelight.intellij.notifications.FileIndexingNotification.UnconfiguredReason.GradleSyncing
 import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskId
 import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskNotificationListenerAdapter
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskType.RESOLVE_PROJECT
 import org.jetbrains.kotlin.idea.framework.GRADLE_SYSTEM_ID
 
 class GradleSystemListener : ExternalSystemTaskNotificationListenerAdapter() {
+  override fun onStart(
+    id: ExternalSystemTaskId,
+    workingDir: String?
+  ) {
+    if (id.projectSystemId == GRADLE_SYSTEM_ID && id.type == RESOLVE_PROJECT) {
+      // Gradle sync just started, pause our existing import if one is happening.
+      id.findProject()?.let { project ->
+        SqlDelightProjectService.getInstance(project).clearIndex()
+        FileIndexingNotification.getInstance(project).unconfiguredReason = GradleSyncing
+      }
+    }
+  }
+
   override fun onSuccess(id: ExternalSystemTaskId) {
-    if (id.projectSystemId == GRADLE_SYSTEM_ID) {
+    if (id.projectSystemId == GRADLE_SYSTEM_ID && id.type == RESOLVE_PROJECT) {
       // Gradle sync just finished, reset the file index.
       id.findProject()?.let { project ->
         SqlDelightProjectService.getInstance(project).resetIndex()


### PR DESCRIPTION
This beefs up the logic to be more resilient to gradle sync timing / if a gradle sync never needs to happen at all. Found problems with the previous logic where opening a project in intellij would never sync because only android projects force a gradle sync every open. Also realized if the user just manually syncs during a sqldelight import that would also cause issues, so this just ensures no matter when a gradle sync happens we cancel our import.