### PR TITLE
Correctly add the dialect jar to the plugin class loader

### DIFF
--- a/sqldelight-idea-plugin/build.gradle
+++ b/sqldelight-idea-plugin/build.gradle
@@ -36,8 +36,6 @@ runIde {
 
 runPluginVerifier {
   ideVersions = [
-      "IC-2020.2.4",
-      "IC-2020.3.2",
       "IC-2021.1",
       "IC-2021.2.3",
       "IC-2021.3",

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/ProjectService.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/ProjectService.kt
@@ -121,10 +121,10 @@ class ProjectService(val project: Project) : SqlDelightProjectService, Disposabl
   override var dialect: SqlDelightDialect
     get() = _dialect ?: MissingDialect()
     set(value) {
-      Timber.i("Setting dialect from $_dialect to $value")
-      val invalidate = _dialect != value
+      val invalidate = _dialect == null || _dialect!!::class.java.name != value::class.java.name
       _dialect = value
       if (invalidate) {
+        Timber.i("Setting dialect from $_dialect to $value")
         val files = mutableListOf<VirtualFile>()
         ProjectRootManager.getInstance(project).fileIndex.iterateContent { vFile ->
           if (vFile.fileType != SqlDelightFileType) {

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/gradle/FileIndexMap.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/gradle/FileIndexMap.kt
@@ -116,7 +116,7 @@ internal class FileIndexMap {
 
               val database = value.databases.first()
               SqlDelightProjectService.getInstance(module.project).dialect =
-                ServiceLoader.load(SqlDelightDialect::class.java, pluginDescriptor.pluginClassLoader).findFirst().get()
+                ServiceLoader.load(SqlDelightDialect::class.java, pluginDescriptor.pluginClassLoader).single()
 
               return@mapValues FileIndex(database)
             }

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/gradle/FileIndexMap.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/gradle/FileIndexMap.kt
@@ -9,7 +9,10 @@ import app.cash.sqldelight.intellij.FileIndex
 import app.cash.sqldelight.intellij.SqlDelightFileIndexImpl
 import app.cash.sqldelight.intellij.notifications.FileIndexingNotification
 import app.cash.sqldelight.intellij.notifications.FileIndexingNotification.UnconfiguredReason.Syncing
+import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.extensions.PluginDescriptor
+import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.externalSystem.model.ExternalSystemException
 import com.intellij.openapi.externalSystem.service.execution.ExternalSystemJdkUtil
 import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil
@@ -19,13 +22,14 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.ui.EditorNotifications
+import com.intellij.util.lang.UrlClassLoader
 import org.jetbrains.plugins.gradle.service.execution.GradleExecutionHelper
 import org.jetbrains.plugins.gradle.settings.DistributionType
 import org.jetbrains.plugins.gradle.settings.GradleExecutionSettings
 import timber.log.Timber
 import java.io.File
-import java.net.URL
-import java.net.URLClassLoader
+import java.net.URI
+import java.nio.file.Path
 import java.util.ServiceLoader
 
 internal class FileIndexMap {
@@ -87,6 +91,8 @@ internal class FileIndexMap {
         fileIndices.putAll(
           GradleExecutionHelper().execute(projectPath, executionSettings) { connection ->
             fetchThread = Thread.currentThread()
+            if (!initialized) return@execute emptyMap()
+
             Timber.i("Fetching SQLDelight models")
             val javaHome =
               ExternalSystemJdkUtil.getJdk(project, ExternalSystemJdkUtil.USE_PROJECT_JDK)
@@ -105,13 +111,13 @@ internal class FileIndexMap {
                 return@mapValues defaultIndex
               }
 
-              val dialectJarLoader = URLClassLoader(
-                arrayOf<URL>(value.dialectJar.toURI().toURL()),
-                this.javaClass.classLoader
-              )
+              val pluginDescriptor = PluginManagerCore.getPlugin(PluginId.getId("com.squareup.sqldelight"))!!
+              pluginDescriptor.addDialect(value.dialectJar.toURI())
+
               val database = value.databases.first()
               SqlDelightProjectService.getInstance(module.project).dialect =
-                ServiceLoader.load(SqlDelightDialect::class.java, dialectJarLoader).findFirst().get()
+                ServiceLoader.load(SqlDelightDialect::class.java, pluginDescriptor.pluginClassLoader).findFirst().get()
+
               return@mapValues FileIndex(database)
             }
           }
@@ -129,5 +135,31 @@ internal class FileIndexMap {
 
   companion object {
     internal var defaultIndex: SqlDelightFileIndex = SqlDelightFileIndexImpl()
+
+    private var previouslyAddedDialect: Path? = null
+
+    @Suppress("UnstableApiUsage", "UNCHECKED_CAST") // Naughty method.
+    private fun PluginDescriptor.addDialect(uri: URI) {
+      val dialectPath = Path.of(uri)
+      val pluginClassLoader = pluginClassLoader as UrlClassLoader
+
+      // We need to remove the last loaded dialect as well as add our new one.
+      val files = UrlClassLoader::class.java.getDeclaredField("files").let { field ->
+        field.isAccessible = true
+        val result = field.get(pluginClassLoader) as MutableList<Path>
+        field.isAccessible = false
+        return@let result
+      }
+
+      // Remove the last loaded dialect.
+      previouslyAddedDialect?.let {
+        files.remove(it)
+      }
+      previouslyAddedDialect = dialectPath
+
+      // Add the new one in.
+      files.add(dialectPath)
+      pluginClassLoader.classPath.reset(files)
+    }
   }
 }

--- a/sqldelight-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/sqldelight-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -3,7 +3,7 @@
   <name>SQLDelight</name>
   <category>Custom Languages</category>
   <vendor url="https://github.com/square">Square, Inc.</vendor>
-  <idea-version since-build="202"/>
+  <idea-version since-build="211"/>
   <depends>com.intellij.modules.lang</depends>
   <depends>com.intellij.java</depends>
   <depends>org.jetbrains.kotlin</depends>


### PR DESCRIPTION
The plugin class loader is what gets used for any classes the plugin registers (like the type holder in this example).

I'm getting a little crazy with what I'm doing here, there are actual APIs that exist to add jars to the UrlClassLoader (intellij type), but there aren't any to _remove_ the jars, which makes sense I'm sure thats not happening anywhere at runtime. That said, the ClassPath does have a reset API which I'm calling and the usages of `files` which I reflectively change are all immutable (ie no one has a hard reference on that field that I would need to worry about not getting invalidated). So, hacky, but it works and after trying a bunch of other stuff is the thing I am happiest with.