### PR TITLE
Same adapter type from different tables causing a compilation error in 2.0 alpha

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/IntermediateType.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/IntermediateType.kt
@@ -16,6 +16,7 @@
 package app.cash.sqldelight.core.lang
 
 import app.cash.sqldelight.core.compiler.integration.adapterName
+import app.cash.sqldelight.core.compiler.integration.adapterProperty
 import app.cash.sqldelight.core.lang.psi.ColumnTypeMixin
 import app.cash.sqldelight.core.lang.util.isArrayParameter
 import app.cash.sqldelight.dialect.api.IntermediateType
@@ -23,6 +24,7 @@ import com.alecstrong.sql.psi.core.psi.Queryable
 import com.intellij.psi.util.PsiTreeUtil
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.asClassName
 
 internal fun IntermediateType.argumentType() = if (bindArg?.isArrayParameter() == true) {
@@ -111,4 +113,10 @@ internal fun IntermediateType.cursorGetter(columnIndex: Int): CodeBlock {
       decodedType
     }
   }
+}
+
+internal fun IntermediateType.parentAdapter(): PropertySpec? {
+  if ((column?.columnType as? ColumnTypeMixin)?.adapter() == null) return null
+
+  return PsiTreeUtil.getParentOfType(column, Queryable::class.java)!!.tableExposed().adapterProperty()
 }

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/SelectQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/SelectQueryTypeTest.kt
@@ -1128,6 +1128,43 @@ class SelectQueryTypeTest {
   }
 
   @Test
+  fun `equivalent adapters from different tables are all required`(dialect: TestDialect) {
+    val file = FixtureCompiler.compileSql(
+      """
+      |CREATE TABLE children(
+      |  birthday ${dialect.textType} AS java.time.LocalDate NOT NULL,
+      |  age ${dialect.textType} NOT NULL
+      |);
+      |
+      |CREATE TABLE teenagers(
+      |  birthday ${dialect.textType} AS java.time.LocalDate NOT NULL,
+      |  age ${dialect.textType} NOT NULL
+      |);
+      |
+      |CREATE TABLE adults(
+      |  birthday ${dialect.textType} AS java.time.LocalDate,
+      |  age ${dialect.textType}
+      |);
+      |
+      |birthdays:
+      |SELECT birthday, age
+      |FROM children
+      |UNION
+      |SELECT birthday, age
+      |FROM teenagers
+      |UNION
+      |SELECT birthday, age
+      |FROM adults;
+      |""".trimMargin(),
+      tempFolder,
+      overrideDialect = dialect.dialect
+    )
+
+    val requiredAdapters = file.compiledFile.requiredAdapters.joinToString { it.type.toString() }
+    assertThat(requiredAdapters).isEqualTo("com.example.Children.Adapter, com.example.Teenagers.Adapter, com.example.Adults.Adapter")
+  }
+
+  @Test
   fun `proper exposure of month and year functions`(dialect: TestDialect) {
     assumeTrue(dialect in listOf(TestDialect.MYSQL))
     val file = FixtureCompiler.parseSql(


### PR DESCRIPTION
The following results in generated code that doesn't compile. This PR has a failing test that highlights the problem, and I will look into fixing it.

What would be the right place to add a test for something like this?

```
Test.sq

CREATE TABLE Table1(
  id TEXT PRIMARY KEY NOT NULL,
  status TEXT AS Status NOT NULL
);

CREATE TABLE Table2(
  id TEXT PRIMARY KEY NOT NULL,
  status TEXT AS Status NOT NULL
);

findAllStatus:
SELECT id, status FROM Table1
UNION ALL
SELECT id, status FROM Table2
ORDER BY id DESC;
```

Results in:

```kotlin
public class TestQueries(
  private val driver: SqlDriver,
  private val Table1Adapter: Table1.Adapter
) : TransacterImpl(driver) {
  public fun <T : Any> findAllStatus(mapper: (status: Status) -> T): Query<T> {
    check(setOf(Table1Adapter.statusAdapter, Table2Adapter.statusAdapter).size == 1) { // compilation error because there is no Table2Adapter
        "Adapter types are expected to be identical."
    }
    return Query...
  }
}
```