### PR TITLE
Support PostgreSQL NUMERIC type

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlType.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlType.kt
@@ -26,6 +26,7 @@ internal enum class PostgreSqlType(override val javaType: TypeName) : DialectTyp
   TIMESTAMP_TIMEZONE(ClassName("java.time", "OffsetDateTime")),
   INTERVAL(ClassName("org.postgresql.util", "PGInterval")),
   UUID(ClassName("java.util", "UUID")),
+  NUMERIC(ClassName("java.math", "BigDecimal")),
   ;
 
   override fun prepareStatementBinder(columnIndex: String, value: CodeBlock): CodeBlock {
@@ -34,6 +35,7 @@ internal enum class PostgreSqlType(override val javaType: TypeName) : DialectTyp
         when (this) {
           SMALL_INT, INTEGER, BIG_INT -> "bindLong"
           DATE, TIME, TIMESTAMP, TIMESTAMP_TIMEZONE, INTERVAL, UUID -> "bindObject"
+          NUMERIC -> "bindBigDecimal"
         }
       )
       .add("($columnIndex, %L)\n", value)
@@ -45,6 +47,7 @@ internal enum class PostgreSqlType(override val javaType: TypeName) : DialectTyp
       when (this) {
         SMALL_INT, INTEGER, BIG_INT -> "$cursorName.getLong($columnIndex)"
         DATE, TIME, TIMESTAMP, TIMESTAMP_TIMEZONE, INTERVAL, UUID -> "$cursorName.getObject($columnIndex)"
+        NUMERIC -> "$cursorName.getBigDecimal($columnIndex)"
       }
     )
   }

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -32,7 +32,7 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
         smallIntDataType != null -> PostgreSqlType.SMALL_INT
         intDataType != null -> PostgreSqlType.INTEGER
         bigIntDataType != null -> PostgreSqlType.BIG_INT
-        numericDataType != null -> REAL
+        numericDataType != null -> PostgreSqlType.NUMERIC
         approximateNumericDataType != null -> REAL
         stringDataType != null -> TEXT
         uuidDataType != null -> PostgreSqlType.UUID


### PR DESCRIPTION
Closes https://github.com/cashapp/sqldelight/issues/1882

Everything online suggests that JDBC Postgres implementations all coerce NUMERIC types as BigDecimal, so just going with that instead of trying to be too complex