### PR TITLE
Dont swallow process canceled exceptions

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SqlDelightCompiler.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SqlDelightCompiler.kt
@@ -27,6 +27,7 @@ import app.cash.sqldelight.dialect.api.SqlDelightDialect
 import com.alecstrong.sql.psi.core.psi.NamedElement
 import com.alecstrong.sql.psi.core.psi.SqlCreateViewStmt
 import com.intellij.openapi.module.Module
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.psi.PsiElement
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
@@ -215,6 +216,8 @@ internal fun <T> tryWithElement(
 ): T {
   try {
     return block()
+  } catch (e: ProcessCanceledException) {
+    throw e
   } catch (e: Throwable) {
     val exception = IllegalStateException("Failed to compile $element :\n${element.text}")
     exception.initCause(e)


### PR DESCRIPTION
See [here](https://plugins.jetbrains.com/docs/intellij/general-threading-rules.html?from=jetbrains.org#background-processes-and-processcanceledexception)

> All code working with PSI, or in other kinds of background processes, must be prepared for [ProcessCanceledException](https://upsource.jetbrains.com/idea-ce/file/idea-ce-4d741bc560dd19306d4624d7c8a88aea537f4e6f/platform/util/base/src/com/intellij/openapi/progress/ProcessCanceledException.java) being thrown from any point. This exception should never be logged but rethrown, and it'll be handled in the infrastructure that started the process.