### PR TITLE
Restrict the full tree search to sql types so i stop shooting myself in the foot

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/SqlDelightEnvironment.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/SqlDelightEnvironment.kt
@@ -25,7 +25,7 @@ import app.cash.sqldelight.core.lang.SqlDelightFile
 import app.cash.sqldelight.core.lang.SqlDelightFileType
 import app.cash.sqldelight.core.lang.SqlDelightParserDefinition
 import app.cash.sqldelight.core.lang.SqlDelightQueriesFile
-import app.cash.sqldelight.core.lang.util.findChildrenOfType
+import app.cash.sqldelight.core.lang.util.migrationFiles
 import app.cash.sqldelight.core.lang.util.sqFile
 import app.cash.sqldelight.core.lang.validation.OptimisticLockValidator
 import app.cash.sqldelight.core.psi.SqlDelightImportStmt
@@ -188,7 +188,7 @@ class SqlDelightEnvironment(
     val migrationFiles: Collection<MigrationFile> = sourceFolders
       .map { localFileSystem.findFileByPath(it.absolutePath)!! }
       .map { psiManager.findDirectory(it)!! }
-      .flatMap { directory: PsiDirectory -> directory.findChildrenOfType<MigrationFile>().asIterable() }
+      .flatMap { directory: PsiDirectory -> directory.migrationFiles() }
     migrationFiles.sortedBy { it.version }
       .forEach {
         val errorElements = ArrayList<PsiErrorElement>()

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/psi/ImportStmtMixin.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/psi/ImportStmtMixin.kt
@@ -4,12 +4,12 @@ import app.cash.sqldelight.core.psi.SqlDelightImportStmt
 import app.cash.sqldelight.core.psi.SqlDelightImportStmtList
 import com.alecstrong.sql.psi.core.SqlAnnotationHolder
 import com.alecstrong.sql.psi.core.psi.SqlAnnotatedElement
-import com.intellij.extapi.psi.ASTWrapperPsiElement
+import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
 import com.intellij.lang.ASTNode
 
 abstract class ImportStmtMixin(
   node: ASTNode
-) : ASTWrapperPsiElement(node),
+) : SqlCompositeElementImpl(node),
   SqlDelightImportStmt,
   SqlAnnotatedElement {
   private fun type(): String {

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/sqldelight.bnf
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/sqldelight.bnf
@@ -67,8 +67,12 @@ insert_stmt_values ::= ( VALUES ( {bind_expr} | {values_expression}
 // New rules.
 import_stmt ::= 'import' java_type ';' {
   extends="app.cash.sqldelight.core.lang.psi.ImportStmtMixin"
+  implements="com.alecstrong.sql.psi.core.psi.SqlCompositeElement"
 }
-import_stmt_list ::= import_stmt *
+import_stmt_list ::= import_stmt * {
+  extends="com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl"
+  implements="com.alecstrong.sql.psi.core.psi.SqlCompositeElement"
+}
 stmt_identifier ::= [ JAVADOC ] [ {identifier} ':' ] {
   extends="app.cash.sqldelight.core.lang.psi.StmtIdentifierMixin"
   implements="app.cash.sqldelight.core.lang.psi.StmtIdentifier"

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/SqlDelightClassNameElementAnnotator.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/SqlDelightClassNameElementAnnotator.kt
@@ -18,7 +18,6 @@ package app.cash.sqldelight.intellij
 import app.cash.sqldelight.core.lang.SqlDelightFile
 import app.cash.sqldelight.core.lang.psi.JavaTypeMixin
 import app.cash.sqldelight.core.lang.util.findChildOfType
-import app.cash.sqldelight.core.lang.util.findChildrenOfType
 import app.cash.sqldelight.core.psi.SqlDelightImportStmt
 import app.cash.sqldelight.core.psi.SqlDelightImportStmtList
 import app.cash.sqldelight.intellij.intentions.AddImportIntention
@@ -85,7 +84,7 @@ internal class SqlDelightClassNameElementAnnotator : Annotator {
     val className = classes.map { clazz -> findMissingNestedClassName(clazz, elementText) }
       .maxBy { it.length }
       ?.substringBefore(".") ?: return javaTypeMixin.firstChild
-    return javaTypeMixin.findChildrenOfType<PsiElement>().first { it.textMatches(className) }
+    return javaTypeMixin.children.first { it.textMatches(className) }
   }
 
   private fun findMissingNestedClassName(psiClass: ImportableType, className: String): String {

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/SqlDelightGotoDeclarationHandler.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/SqlDelightGotoDeclarationHandler.kt
@@ -20,7 +20,6 @@ import app.cash.sqldelight.core.lang.QUERIES_SUFFIX_NAME
 import app.cash.sqldelight.core.lang.SqlDelightFile
 import app.cash.sqldelight.core.lang.SqlDelightFileType
 import app.cash.sqldelight.core.lang.queriesName
-import app.cash.sqldelight.core.lang.util.findChildrenOfType
 import app.cash.sqldelight.core.psi.SqlDelightStmtIdentifier
 import app.cash.sqldelight.intellij.util.isAncestorOf
 import com.alecstrong.sql.psi.core.psi.QueryElement
@@ -50,6 +49,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getChildOfType
 import org.jetbrains.kotlin.psi.psiUtil.getNextSiblingIgnoringWhitespaceAndComments
 import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstance
+import org.jetbrains.plugins.groovy.lang.psi.util.childrenOfType
 
 class SqlDelightGotoDeclarationHandler : GotoDeclarationHandler {
   override fun getGotoDeclarationTargets(
@@ -88,7 +88,7 @@ class SqlDelightGotoDeclarationHandler : GotoDeclarationHandler {
         .filter { it.sqlStmtList != null }
         .forEach inner@{ sqlDelightFile ->
           val identifier = sqlDelightFile.sqlStmtList!!
-            .findChildrenOfType<SqlDelightStmtIdentifier>()
+            .childrenOfType<SqlDelightStmtIdentifier>()
             .mapNotNull { it.identifier() }
             .firstOrNull { it.textMatches(function.name!!) } ?: return@inner
           result = if (targetData.parameter != null) {

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/inspections/SchemaNeedsMigrationInspection.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/inspections/SchemaNeedsMigrationInspection.kt
@@ -5,6 +5,7 @@ import app.cash.sqldelight.core.SqlDelightProjectService
 import app.cash.sqldelight.core.lang.MigrationFile
 import app.cash.sqldelight.core.lang.SqlDelightQueriesFile
 import app.cash.sqldelight.core.lang.psi.parameterValue
+import app.cash.sqldelight.core.lang.util.migrationFiles
 import app.cash.sqldelight.intellij.refactoring.SqlDelightSignatureBuilder
 import app.cash.sqldelight.intellij.refactoring.SqlDelightSuggestedRefactoringExecution
 import app.cash.sqldelight.intellij.refactoring.SqlDelightSuggestedRefactoringExecution.SuggestedMigrationData
@@ -15,7 +16,6 @@ import com.intellij.codeInspection.LocalQuickFixOnPsiElement
 import com.intellij.codeInspection.ProblemHighlightType.GENERIC_ERROR
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiFile
@@ -33,16 +33,6 @@ internal class SchemaNeedsMigrationInspection : LocalInspectionTool() {
     override fun visitCreateTableStmt(createTable: SqlCreateTableStmt) {
       val file = createTable.containingFile as? SqlDelightQueriesFile ?: return
       val module = file.module ?: return
-
-      fun PsiDirectory.migrationFiles(): Sequence<MigrationFile> {
-        return children.asSequence().flatMap {
-          when (it) {
-            is PsiDirectory -> it.migrationFiles()
-            is MigrationFile -> sequenceOf(it)
-            else -> emptySequence()
-          }
-        }
-      }
 
       val dbFile = file.findDbFile() ?: return
       val fileIndex = SqlDelightFileIndex.getInstance(module)

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/inspections/UnusedImportInspection.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/inspections/UnusedImportInspection.kt
@@ -14,6 +14,7 @@ import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
 
 internal class UnusedImportInspection : LocalInspectionTool() {
 
@@ -59,7 +60,8 @@ internal class UnusedImportInspection : LocalInspectionTool() {
 fun PsiFile.columnJavaTypes(): Set<String> =
   findChildrenOfType<SqlDelightColumnType>()
     .flatMap { columnType ->
-      columnType.findChildrenOfType<SqlDelightJavaType>() + columnType.findChildrenOfType<SqlDelightJavaTypeName>()
+      PsiTreeUtil.collectElements(columnType) { it is SqlDelightJavaType || it is SqlDelightJavaTypeName }
+        .asList()
     }
     .mapNotNull { it.text.substringBefore(".") }
     .toSet()

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/inspections/UnusedQueryInspection.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/inspections/UnusedQueryInspection.kt
@@ -4,7 +4,6 @@ import app.cash.sqldelight.core.lang.SqlDelightFile
 import app.cash.sqldelight.core.lang.psi.StmtIdentifierMixin
 import app.cash.sqldelight.core.lang.queriesName
 import app.cash.sqldelight.core.lang.util.findChildOfType
-import app.cash.sqldelight.core.lang.util.findChildrenOfType
 import app.cash.sqldelight.core.psi.SqlDelightStmtIdentifier
 import app.cash.sqldelight.core.psi.SqlDelightVisitor
 import com.alecstrong.sql.psi.core.psi.SqlStmtList
@@ -28,7 +27,7 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.kotlin.asJava.toLightMethods
-import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtFile
 
 internal class UnusedQueryInspection : LocalInspectionTool() {
 
@@ -43,8 +42,8 @@ internal class UnusedQueryInspection : LocalInspectionTool() {
     val fileName = "${sqlDelightFile.virtualFile?.queriesName}.kt"
     val generatedFile = FilenameIndex.getFilesByName(
       sqlDelightFile.project, fileName, GlobalSearchScope.moduleScope(module)
-    ).firstOrNull() ?: return PsiElementVisitor.EMPTY_VISITOR
-    val allMethods = generatedFile.findChildrenOfType<KtNamedFunction>()
+    ).firstOrNull() as KtFile? ?: return PsiElementVisitor.EMPTY_VISITOR
+    val allMethods = generatedFile.classes[0].methods
     return object : SqlDelightVisitor() {
       override fun visitStmtIdentifier(o: SqlDelightStmtIdentifier) {
         if (o !is StmtIdentifierMixin || o.identifier() == null) {

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/lang/SqlDelightFileViewProviderFactory.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/lang/SqlDelightFileViewProviderFactory.kt
@@ -25,8 +25,8 @@ import app.cash.sqldelight.core.lang.SqlDelightQueriesFile
 import app.cash.sqldelight.core.lang.util.findChildrenOfType
 import app.cash.sqldelight.intellij.util.GeneratedVirtualFile
 import com.alecstrong.sql.psi.core.SqlAnnotationHolder
-import com.alecstrong.sql.psi.core.psi.Queryable
 import com.alecstrong.sql.psi.core.psi.SqlAnnotatedElement
+import com.alecstrong.sql.psi.core.psi.TableElement
 import com.intellij.lang.Language
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
@@ -134,7 +134,7 @@ private class SqlDelightFileViewProvider(
     threadPool.schedule(
       {
         ReadAction.nonBlocking {
-          file.findChildrenOfType<Queryable>().forEach { queryable ->
+          file.findChildrenOfType<TableElement>().forEach { queryable ->
             val affectedFiles = ReferencesSearch.search(queryable.tableExposed().tableName)
               .mapNotNull { it.element.containingFile as? SqlDelightFile }
               .distinct()

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/refactoring/SqlDelightSuggestedRefactoringExecution.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/refactoring/SqlDelightSuggestedRefactoringExecution.kt
@@ -6,7 +6,7 @@ import app.cash.sqldelight.core.lang.MigrationFile
 import app.cash.sqldelight.core.lang.MigrationFileType
 import app.cash.sqldelight.core.lang.SqlDelightFile
 import app.cash.sqldelight.core.lang.psi.ColumnConstraints
-import app.cash.sqldelight.core.lang.util.findChildrenOfType
+import app.cash.sqldelight.core.lang.util.migrationFiles
 import com.intellij.ide.util.DirectoryUtil
 import com.intellij.ide.util.EditorHelper
 import com.intellij.openapi.command.WriteCommandAction
@@ -40,7 +40,7 @@ internal class SqlDelightSuggestedRefactoringExecution {
 
     val fileIndex = SqlDelightFileIndex.getInstance(file.module ?: return null)
     val migrationFile = fileIndex.sourceFolders(file)
-      .flatMap { it.findChildrenOfType<MigrationFile>() }
+      .flatMap { it.migrationFiles() }
       .maxByOrNull { it.version }
 
     var oldList = oldSignature.parameters
@@ -198,7 +198,7 @@ internal class SqlDelightSuggestedRefactoringExecution {
         document.insertString(document.textLength, migration)
       } else {
         fileIndex.sourceFolders(element.containingFile as SqlDelightFile)
-          .flatMap { it.findChildrenOfType<MigrationFile>() }
+          .flatMap { it.migrationFiles() }
           .firstOrNull { it.name == migrationFile.name }
           ?.let { EditorHelper.openInEditor(it) }
       }

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/util/PsiClassSearchHelper.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/util/PsiClassSearchHelper.kt
@@ -1,12 +1,12 @@
 package app.cash.sqldelight.intellij.util
 
-import app.cash.sqldelight.core.lang.util.findChildrenOfType
 import app.cash.sqldelight.intellij.util.PsiClassSearchHelper.ImportableType.JavaType
 import app.cash.sqldelight.intellij.util.PsiClassSearchHelper.ImportableType.KotlinType
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiClass
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.PsiShortNamesCache
+import com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.kotlin.idea.stubindex.KotlinClassShortNameIndex
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import javax.swing.Icon
@@ -38,7 +38,7 @@ internal object PsiClassSearchHelper {
     class KotlinType(val type: KtClassOrObject) : ImportableType {
       override val qualifiedName = type.fqName?.asString()
       override val name = type.name
-      override val innerClasses = type.findChildrenOfType<KtClassOrObject>().map(::KotlinType)
+      override val innerClasses = PsiTreeUtil.findChildrenOfType(type, KtClassOrObject::class.java).map(::KotlinType)
 
       override fun getIcon(flags: Int) = type.getIcon(flags)
     }

--- a/sqldelight-idea-plugin/src/test/kotlin/app/cash/sqldelight/intellij/ReferenceContrubutorTest.kt
+++ b/sqldelight-idea-plugin/src/test/kotlin/app/cash/sqldelight/intellij/ReferenceContrubutorTest.kt
@@ -1,10 +1,10 @@
 package app.cash.sqldelight.intellij
 
 import app.cash.sqldelight.core.lang.SqlDelightFileType
-import app.cash.sqldelight.core.lang.util.findChildOfType
 import com.google.common.truth.Truth.assertThat
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtTypeAlias
+import org.jetbrains.plugins.groovy.lang.psi.util.childrenOfType
 
 class ReferenceContrubutorTest : SqlDelightFixtureTestCase() {
 
@@ -126,8 +126,8 @@ class ReferenceContrubutorTest : SqlDelightFixtureTestCase() {
       """.trimMargin()
     )
     val reference = myFixture.getReferenceAtCaretPositionWithAssertion()
-    val psiClass = psiFile.findChildOfType<KtClassOrObject>()
-    assertThat(reference.isReferenceTo(psiClass!!)).isTrue()
+    val psiClass = psiFile.childrenOfType<KtClassOrObject>().single()
+    assertThat(reference.isReferenceTo(psiClass)).isTrue()
   }
 
   fun testImportedExpectClassResolvesCorrectly() {
@@ -150,8 +150,8 @@ class ReferenceContrubutorTest : SqlDelightFixtureTestCase() {
       """.trimMargin()
     )
     val reference = myFixture.getReferenceAtCaretPositionWithAssertion()
-    val psiClass = file.findChildOfType<KtClassOrObject>()
-    assertThat(reference.isReferenceTo(psiClass!!)).isTrue()
+    val psiClass = file.childrenOfType<KtClassOrObject>().single()
+    assertThat(reference.isReferenceTo(psiClass)).isTrue()
   }
 
   fun testKotlinPrimitiveTypeImportResolvesCorrectly() {
@@ -174,8 +174,8 @@ class ReferenceContrubutorTest : SqlDelightFixtureTestCase() {
       """.trimMargin()
     )
     val reference = myFixture.getReferenceAtCaretPositionWithAssertion()
-    val psiClass = file.findChildOfType<KtClassOrObject>()
-    assertThat(reference.isReferenceTo(psiClass!!)).isTrue()
+    val psiClass = file.childrenOfType<KtClassOrObject>().single()
+    assertThat(reference.isReferenceTo(psiClass)).isTrue()
   }
 
   fun testImportedPrimitiveTypeResolvesCorrectly() {
@@ -198,8 +198,8 @@ class ReferenceContrubutorTest : SqlDelightFixtureTestCase() {
       """.trimMargin()
     )
     val reference = myFixture.getReferenceAtCaretPositionWithAssertion()
-    val psiClass = file.findChildOfType<KtClassOrObject>()
-    assertThat(reference.isReferenceTo(psiClass!!)).isTrue()
+    val psiClass = file.childrenOfType<KtClassOrObject>().single()
+    assertThat(reference.isReferenceTo(psiClass)).isTrue()
   }
 
   fun testSamePackageClassResolvesWithoutImport() {
@@ -220,8 +220,8 @@ class ReferenceContrubutorTest : SqlDelightFixtureTestCase() {
       """.trimMargin()
     )
     val reference = myFixture.getReferenceAtCaretPositionWithAssertion()
-    val psiClass = file.findChildOfType<KtClassOrObject>()
-    assertThat(reference.isReferenceTo(psiClass!!)).isTrue()
+    val psiClass = file.childrenOfType<KtClassOrObject>().single()
+    assertThat(reference.isReferenceTo(psiClass)).isTrue()
   }
 
   fun testUnimportedClassDoesntResolve() {
@@ -290,7 +290,7 @@ class ReferenceContrubutorTest : SqlDelightFixtureTestCase() {
       |);
       """.trimMargin()
     )
-    val typeAlias = file.findChildOfType<KtTypeAlias>()!!.psiOrParent
+    val typeAlias = file.childrenOfType<KtTypeAlias>().single().psiOrParent
     val reference = myFixture.getReferenceAtCaretPositionWithAssertion()
     assertThat(reference.isReferenceTo(typeAlias)).isTrue()
   }


### PR DESCRIPTION
Apparently there were other places in the compiler doing this too, so this should speed up compilation