### PR TITLE
Visualize the SQL schema

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ agp = "7.1.3"
 compileSdk = "31"
 minSdk = "14"
 sqlPsi = "0.4.1"
+jackson = "2.13.2"
 
 [libraries]
 kotlin-test-common = { module = "org.jetbrains.kotlin:kotlin-test-common", version.ref = "kotlin" }
@@ -56,7 +57,10 @@ rxJava2 = { module = "io.reactivex.rxjava2:rxjava", version = "2.2.21" }
 rxJava3 = { module = "io.reactivex.rxjava3:rxjava", version = "3.1.4" }
 
 schemaCrawler-tools = { module = "us.fatehi:schemacrawler-tools", version.ref = "schemaCrawler" }
+schemaCrawler-scripting = { module = "us.fatehi:schemacrawler-scripting", version.ref = "schemaCrawler" }
 schemaCrawler-sqlite = { module = "us.fatehi:schemacrawler-sqlite", version.ref = "schemaCrawler" }
+jackson = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
+jackson-time = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
 
 objectDiff = { module = "de.danielbechler:java-object-diff", version = "0.95" }
 sqliter = { module = "co.touchlab:sqliter-driver", version.ref = "sqliter" }

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/VerifyMigrationTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/VerifyMigrationTask.kt
@@ -58,6 +58,7 @@ abstract class VerifyMigrationTask : SqlDelightWorkerTask() {
   companion object {
     private const val schemaJson = "schema.json"
     private const val schema = "schema.schema"
+    private const val schemaMermaid = "schema.mermaid"
   }
 
   @TaskAction
@@ -75,6 +76,7 @@ abstract class VerifyMigrationTask : SqlDelightWorkerTask() {
     outputFolder.ensureParentDirsCreated()
     schema.moveDBSchema()
     schemaJson.moveDBSchema()
+    schemaMermaid.moveDBSchema()
     workingDirectory.deleteRecursively()
   }
 
@@ -149,6 +151,10 @@ abstract class VerifyMigrationTask : SqlDelightWorkerTask() {
       val schemaJsonFile = File(workingDirectory, schemaJson)
       schemaJsonFile.createNewFile()
       catalog.toJson(schemaJsonFile)
+
+      val mermaidFile = File(workingDirectory, schemaMermaid)
+      mermaidFile.createNewFile()
+      catalog.mermaidDiagram(mermaidFile)
     }
 
     private fun createCurrentDb(): CatalogDatabase {

--- a/sqlite-migrations/build.gradle
+++ b/sqlite-migrations/build.gradle
@@ -10,6 +10,9 @@ dependencies {
   compileOnly deps.objectDiff
   compileOnly deps.schemaCrawler.tools
   compileOnly deps.schemaCrawler.sqlite
+  implementation deps.schemaCrawler.scripting
+  runtimeOnly deps.jackson
+  runtimeOnly deps.jackson.time
 
   implementation deps.sqlPsi
 

--- a/sqlite-migrations/src/main/kotlin/app/cash/sqlite/migrations/CatalogDatabase.kt
+++ b/sqlite-migrations/src/main/kotlin/app/cash/sqlite/migrations/CatalogDatabase.kt
@@ -5,7 +5,10 @@ import schemacrawler.schemacrawler.LimitOptionsBuilder
 import schemacrawler.schemacrawler.LoadOptionsBuilder
 import schemacrawler.schemacrawler.SchemaCrawlerOptionsBuilder
 import schemacrawler.schemacrawler.SchemaInfoLevelBuilder
+import schemacrawler.tools.formatter.serialize.JsonSerializedCatalog
 import schemacrawler.tools.utility.SchemaCrawlerUtility
+import java.io.File
+import java.io.ObjectOutputStream
 import java.sql.Connection
 import java.sql.DriverManager
 import java.sql.SQLException
@@ -13,6 +16,19 @@ import java.sql.SQLException
 class CatalogDatabase private constructor(
   internal val catalog: Catalog
 ) : Database() {
+
+  fun serialize(output: File) {
+    output.outputStream().use {
+      ObjectOutputStream(it).use { it.writeObject(catalog) }
+    }
+  }
+
+  fun toJson(output: File) {
+    output.outputStream().use {
+      val jsonCatalog = JsonSerializedCatalog(catalog)
+      jsonCatalog.save(it)
+    }
+  }
 
   companion object {
 


### PR DESCRIPTION
Related to #2874

After reading the docs from SchemaCrawler, we could do two things to process the schema for the plugin/custom processing (https://www.schemacrawler.com/serialize.html): 
1. IDEA plugin:
Export the Java serialized catalog in a local file inside the build folder. The plugin could deserialize this catalog file and show the diagram by creating it only when the user wants to see it.
Because Java Serialization is used, the version of schemacrawler during creating the file and reading by the plugin must match!
Alternative we could create a png at each gradle execution.

2. custom processing:
Export the catalog as json file. This requires another dependency (Jackson), and the schema is not stable. But other tasks/tools could use this file, if necessary. If not, we could drop Jackson dependency.

Originally, I want to get the current schema as Mermaid diagram inside the KDoc of the generated `DB` file only. 
This would require to move the schemacrawler and all its logic/execution/dependencies to the compiler. At the moment, this schema creation is only executed during `verifyMigration`.

But how does the compiler know the attributes of the table during generating the DB file? What is the purpose of schema crawler? If we only focus on mermaid diagrams, do we need to use schema crawlers at all?