### PR TITLE
updated paths to the sqlite3 libs

### DIFF
--- a/drivers/native-driver/build.gradle
+++ b/drivers/native-driver/build.gradle
@@ -81,7 +81,7 @@ kotlin {
     sourceSets.getByName("${name}Main").dependsOn(sourceSets.linuxMain)
     sourceSets.getByName("${name}Test").dependsOn(sourceSets.nativeTest)
     compilations.test {
-      kotlinOptions.freeCompilerArgs += ["-linker-options", "-lsqlite3 -L/usr/lib/x86_64-linux-gnu -L/usr/lib"]
+      kotlinOptions.freeCompilerArgs += ["-linker-options", "-lsqlite3 -L/usr/lib/x86_64-linux-gnu -L/usr/lib -L/usr/lib64"]
     }
   }
 

--- a/extensions/coroutines-extensions/build.gradle
+++ b/extensions/coroutines-extensions/build.gradle
@@ -103,7 +103,7 @@ kotlin {
     sourceSets.getByName("${name}Main").dependsOn(sourceSets.nativeMain)
     sourceSets.getByName("${name}Test").dependsOn(sourceSets.nativeTest)
     compilations.test {
-      kotlinOptions.freeCompilerArgs += ['-linker-options', '-lsqlite3 -L/usr/lib/x86_64-linux-gnu -L/usr/lib']
+      kotlinOptions.freeCompilerArgs += ['-linker-options', '-lsqlite3 -L/usr/lib/x86_64-linux-gnu -L/usr/lib -L/usr/lib64']
     }
   }
 


### PR DESCRIPTION
I wanted to compile it on a Linux Fedora distribution, but the compilation ended with an error that the sqlite3 library could not be found. After double-checking that indeed the correct development package is installed and that the correct file is in place on the system, I figured out that the problem is elsewhere.

The problem is that Fedora uses different paths for libraries than Ubuntu, for example, does.

Here is an example of how this can be worked around:
```kotlin
kotlin {
    linuxX64("native") {
        binaries {
            executable {
                entryPoint = "me.mira.main"
                // A hack for Fedora since Fedora has the libraries under /usr/lib64 compared to other distros
                freeCompilerArgs += listOf("-linker-options", "-lsqlite3 -L/usr/lib/x86_64-linux-gnu -L/usr/lib -L/usr/lib64")
            }
        }
    }
...
```
https://github.com/sobotkami/kotlin-native-sqldelight/blob/main/build.gradle.kts

So the change I made just expands the list of places where the library will be looked for on the system when compiled.