### PR TITLE
Declare dependency on shadowJar output to fix missing implicit task dependency

### DIFF
--- a/dialects/mysql/build.gradle
+++ b/dialects/mysql/build.gradle
@@ -40,6 +40,11 @@ tasks.getByName("shadowJar").configure {
   include 'META-INF/services/*'
 }
 
+tasks.jar.configure {
+  // Prevents shadowJar (with classifier = '') and this task from writing to the same path.
+  enabled = false
+}
+
 artifacts {
   runtimeOnly(shadowJar)
   archives(shadowJar)

--- a/dialects/mysql/build.gradle
+++ b/dialects/mysql/build.gradle
@@ -45,6 +45,13 @@ tasks.jar.configure {
   enabled = false
 }
 
+configurations {
+  [apiElements, runtimeElements].each {
+    it.outgoing.artifacts.removeIf { it.buildDependencies.getDependencies(null).contains(jar) }
+    it.outgoing.artifact(shadowJar)
+  }
+}
+
 artifacts {
   runtimeOnly(shadowJar)
   archives(shadowJar)

--- a/dialects/postgresql/build.gradle
+++ b/dialects/postgresql/build.gradle
@@ -40,6 +40,11 @@ tasks.getByName("shadowJar").configure {
   include 'META-INF/services/*'
 }
 
+tasks.jar.configure {
+  // Prevents shadowJar (with classifier = '') and this task from writing to the same path.
+  enabled = false
+}
+
 artifacts {
   runtimeOnly(shadowJar)
   archives(shadowJar)

--- a/dialects/postgresql/build.gradle
+++ b/dialects/postgresql/build.gradle
@@ -45,6 +45,13 @@ tasks.jar.configure {
   enabled = false
 }
 
+configurations {
+  [apiElements, runtimeElements].each {
+    it.outgoing.artifacts.removeIf { it.buildDependencies.getDependencies(null).contains(jar) }
+    it.outgoing.artifact(shadowJar)
+  }
+}
+
 artifacts {
   runtimeOnly(shadowJar)
   archives(shadowJar)

--- a/dialects/sqlite-3-24/build.gradle
+++ b/dialects/sqlite-3-24/build.gradle
@@ -36,6 +36,13 @@ tasks.jar.configure {
   enabled = false
 }
 
+configurations {
+  [apiElements, runtimeElements].each {
+    it.outgoing.artifacts.removeIf { it.buildDependencies.getDependencies(null).contains(jar) }
+    it.outgoing.artifact(shadowJar)
+  }
+}
+
 artifacts {
   runtimeOnly(shadowJar)
   archives(shadowJar)

--- a/dialects/sqlite-3-24/build.gradle
+++ b/dialects/sqlite-3-24/build.gradle
@@ -31,6 +31,11 @@ tasks.getByName("shadowJar").configure {
   include 'META-INF/services/*'
 }
 
+tasks.jar.configure {
+  // Prevents shadowJar (with classifier = '') and this task from writing to the same path.
+  enabled = false
+}
+
 artifacts {
   runtimeOnly(shadowJar)
   archives(shadowJar)

--- a/dialects/sqlite-3-25/build.gradle
+++ b/dialects/sqlite-3-25/build.gradle
@@ -36,6 +36,13 @@ tasks.jar.configure {
   enabled = false
 }
 
+configurations {
+  [apiElements, runtimeElements].each {
+    it.outgoing.artifacts.removeIf { it.buildDependencies.getDependencies(null).contains(jar) }
+    it.outgoing.artifact(shadowJar)
+  }
+}
+
 tasks.getByName("compileKotlin").configure {
   dependsOn(":dialects:sqlite-3-24:shadowJar")
 }

--- a/dialects/sqlite-3-25/build.gradle
+++ b/dialects/sqlite-3-25/build.gradle
@@ -31,6 +31,11 @@ tasks.getByName("shadowJar").configure {
   include 'META-INF/services/*'
 }
 
+tasks.jar.configure {
+  // Prevents shadowJar (with classifier = '') and this task from writing to the same path.
+  enabled = false
+}
+
 tasks.getByName("compileKotlin").configure {
   dependsOn(":dialects:sqlite-3-24:shadowJar")
 }

--- a/dialects/sqlite-3-30/build.gradle
+++ b/dialects/sqlite-3-30/build.gradle
@@ -36,6 +36,13 @@ tasks.jar.configure {
   enabled = false
 }
 
+configurations {
+  [apiElements, runtimeElements].each {
+    it.outgoing.artifacts.removeIf { it.buildDependencies.getDependencies(null).contains(jar) }
+    it.outgoing.artifact(shadowJar)
+  }
+}
+
 tasks.getByName("compileKotlin").configure {
   dependsOn(":dialects:sqlite-3-25:shadowJar")
 }

--- a/dialects/sqlite-3-30/build.gradle
+++ b/dialects/sqlite-3-30/build.gradle
@@ -31,6 +31,11 @@ tasks.getByName("shadowJar").configure {
   include 'META-INF/services/*'
 }
 
+tasks.jar.configure {
+  // Prevents shadowJar (with classifier = '') and this task from writing to the same path.
+  enabled = false
+}
+
 tasks.getByName("compileKotlin").configure {
   dependsOn(":dialects:sqlite-3-25:shadowJar")
 }

--- a/dialects/sqlite-3-35/build.gradle
+++ b/dialects/sqlite-3-35/build.gradle
@@ -31,6 +31,11 @@ tasks.getByName("shadowJar").configure {
   include 'META-INF/services/*'
 }
 
+tasks.jar.configure {
+  // Prevents shadowJar (with classifier = '') and this task from writing to the same path.
+  enabled = false
+}
+
 tasks.getByName("compileKotlin").configure {
   dependsOn(":dialects:sqlite-3-30:shadowJar")
 }

--- a/dialects/sqlite-3-35/build.gradle
+++ b/dialects/sqlite-3-35/build.gradle
@@ -36,6 +36,13 @@ tasks.jar.configure {
   enabled = false
 }
 
+configurations {
+  [apiElements, runtimeElements].each {
+    it.outgoing.artifacts.removeIf { it.buildDependencies.getDependencies(null).contains(jar) }
+    it.outgoing.artifact(shadowJar)
+  }
+}
+
 tasks.getByName("compileKotlin").configure {
   dependsOn(":dialects:sqlite-3-30:shadowJar")
 }

--- a/dialects/sqlite-3-38/build.gradle
+++ b/dialects/sqlite-3-38/build.gradle
@@ -31,6 +31,11 @@ tasks.getByName("shadowJar").configure {
   include 'META-INF/services/*'
 }
 
+tasks.jar.configure {
+  // Prevents shadowJar (with classifier = '') and this task from writing to the same path.
+  enabled = false
+}
+
 tasks.getByName("compileKotlin").configure {
   dependsOn(":dialects:sqlite-3-35:shadowJar")
 }

--- a/dialects/sqlite-3-38/build.gradle
+++ b/dialects/sqlite-3-38/build.gradle
@@ -36,6 +36,13 @@ tasks.jar.configure {
   enabled = false
 }
 
+configurations {
+  [apiElements, runtimeElements].each {
+    it.outgoing.artifacts.removeIf { it.buildDependencies.getDependencies(null).contains(jar) }
+    it.outgoing.artifact(shadowJar)
+  }
+}
+
 tasks.getByName("compileKotlin").configure {
   dependsOn(":dialects:sqlite-3-35:shadowJar")
 }

--- a/sqldelight-compiler/build.gradle
+++ b/sqldelight-compiler/build.gradle
@@ -48,8 +48,8 @@ dependencies {
   testImplementation deps.truth
   testImplementation project(':test-util')
   testImplementation project(':dialects:hsql')
-  testImplementation project(':dialects:mysql')
-  testImplementation project(':dialects:postgresql')
+  testImplementation project(path: ':dialects:mysql', configuration: 'shadowRuntimeElements')
+  testImplementation project(path: ':dialects:postgresql', configuration: 'shadowRuntimeElements')
   testImplementation project(':dialects:sqlite-3-18')
   testImplementation project(':dialects:sqlite-3-24')
   testImplementation project(':dialects:sqlite-3-25')

--- a/sqldelight-compiler/build.gradle
+++ b/sqldelight-compiler/build.gradle
@@ -51,11 +51,11 @@ dependencies {
   testImplementation project(path: ':dialects:mysql', configuration: 'shadowRuntimeElements')
   testImplementation project(path: ':dialects:postgresql', configuration: 'shadowRuntimeElements')
   testImplementation project(':dialects:sqlite-3-18')
-  testImplementation project(':dialects:sqlite-3-24')
-  testImplementation project(':dialects:sqlite-3-25')
-  testImplementation project(':dialects:sqlite-3-30')
-  testImplementation project(':dialects:sqlite-3-35')
-  testImplementation project(':dialects:sqlite-3-38')
+  testImplementation project(path: ':dialects:sqlite-3-24', configuration: 'shadowRuntimeElements')
+  testImplementation project(path: ':dialects:sqlite-3-25', configuration: 'shadowRuntimeElements')
+  testImplementation project(path: ':dialects:sqlite-3-30', configuration: 'shadowRuntimeElements')
+  testImplementation project(path: ':dialects:sqlite-3-35', configuration: 'shadowRuntimeElements')
+  testImplementation project(path: ':dialects:sqlite-3-38', configuration: 'shadowRuntimeElements')
 }
 
 task pluginVersion {

--- a/sqldelight-idea-plugin/build.gradle
+++ b/sqldelight-idea-plugin/build.gradle
@@ -125,3 +125,7 @@ internal val BUGSNAG_KEY = "${getBugsnagKey()}"
 tasks.named('compileKotlin').configure { dependsOn('bugsnagKey') }
 
 tasks.named('buildSearchableOptions').configure { enabled = false }
+
+afterEvaluate {
+  tasks.named('kspKotlin').configure { dependsOn('bugsnagKey') }
+}


### PR DESCRIPTION
Should fix these warnings:

```
> Task :sqldelight-compiler:compileTestKotlin
Execution optimizations have been disabled for task ':sqldelight-compiler:compileTestKotlin' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/home/runner/work/sqldelight/sqldelight/dialects/mysql/build/libs/mysql-2.1.0-SNAPSHOT.jar'. Reason: Task ':sqldelight-compiler:compileTestKotlin' uses this output of task ':dialects:mysql:shadowJar' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.4.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: '/home/runner/work/sqldelight/sqldelight/dialects/postgresql/build/libs/postgresql-2.1.0-SNAPSHOT.jar'. Reason: Task ':sqldelight-compiler:compileTestKotlin' uses this output of task ':dialects:postgresql:shadowJar' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.4.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```