### PR TITLE
Put tests using Docker behind a flag

### DIFF
--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -6,7 +6,18 @@ plugins {
   alias(deps.plugins.publish)
   alias(deps.plugins.dokka)
   id("java-gradle-plugin")
+  id("jvm-test-suite")
 }
+
+testing {
+  suites {
+    dockerTest(JvmTestSuite) {
+      useJUnit()
+    }
+  }
+}
+
+configurations.dockerTestImplementation.extendsFrom(configurations.testImplementation)
 
 gradlePlugin {
   plugins {
@@ -15,6 +26,8 @@ gradlePlugin {
       implementationClass = 'app.cash.sqldelight.gradle.SqlDelightPlugin'
     }
   }
+
+  testSourceSets(sourceSets.test, sourceSets.dockerTest)
 }
 
 configurations {
@@ -105,6 +118,28 @@ test {
       excludeCategories 'app.cash.sqldelight.Instrumentation'
     }
   }
+}
+
+tasks.named('check') {
+  dependsOn(testing.suites.dockerTest)
+}
+
+tasks.dockerTest.configure {
+  dependsOn(
+      ":dialects:mysql:publishAllPublicationsToInstallLocallyRepository",
+      ":dialects:postgresql:publishAllPublicationsToInstallLocallyRepository",
+      ":sqldelight-compiler:dialect:publishAllPublicationsToInstallLocallyRepository",
+      ":runtime:runtime:publishKotlinMultiplatformPublicationToInstallLocallyRepository",
+      ":runtime:runtime:publishJvmPublicationToInstallLocallyRepository",
+      ":runtime:internal:publishKotlinMultiplatformPublicationToInstallLocallyRepository",
+      ":runtime:internal:publishJvmPublicationToInstallLocallyRepository",
+      ":runtime:shared:publishKotlinMultiplatformPublicationToInstallLocallyRepository",
+      ":runtime:shared:publishJvmPublicationToInstallLocallyRepository",
+      ":drivers:jdbc-driver:publishAllPublicationsToInstallLocallyRepository",
+      ":sqlite-migrations:publishAllPublicationsToInstallLocallyRepository",
+      ":sqldelight-compiler:publishAllPublicationsToInstallLocallyRepository",
+      ":sqldelight-gradle-plugin:publishAllPublicationsToInstallLocallyRepository",
+  )
 }
 
 validatePlugins {

--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -125,6 +125,7 @@ tasks.named('check') {
 }
 
 tasks.dockerTest.configure {
+  if (project.hasProperty("Instrumentation")) enabled = false
   dependsOn(
       ":dialects:mysql:publishAllPublicationsToInstallLocallyRepository",
       ":dialects:postgresql:publishAllPublicationsToInstallLocallyRepository",

--- a/sqldelight-gradle-plugin/src/dockerTest/kotlin/app/cash/sqldelight/dialect/DialectIntegrationTests.kt
+++ b/sqldelight-gradle-plugin/src/dockerTest/kotlin/app/cash/sqldelight/dialect/DialectIntegrationTests.kt
@@ -1,0 +1,46 @@
+package app.cash.sqldelight.dialect
+
+import com.google.common.truth.Truth
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Test
+import java.io.File
+
+class DialectIntegrationTests {
+
+  @Test fun integrationTestsMySql() {
+    val runner = GradleRunner.create()
+      .withCommonConfiguration(File("src/test/integration-mysql"))
+      .withArguments("clean", "check", "--stacktrace")
+
+    val result = runner.build()
+    Truth.assertThat(result.output).contains("BUILD SUCCESSFUL")
+  }
+
+  @Test fun integrationTestsMySqlSchemaDefinitions() {
+    val runner = GradleRunner.create()
+      .withCommonConfiguration(File("src/test/integration-mysql-schema"))
+      .withArguments("clean", "check", "--stacktrace")
+
+    val result = runner.build()
+    Truth.assertThat(result.output).contains("BUILD SUCCESSFUL")
+  }
+
+  @Test fun integrationTestsPostgreSql() {
+    val runner = GradleRunner.create()
+      .withCommonConfiguration(File("src/test/integration-postgresql"))
+      .withArguments("clean", "check", "--stacktrace")
+
+    val result = runner.build()
+    Truth.assertThat(result.output).contains("BUILD SUCCESSFUL")
+  }
+}
+
+private fun GradleRunner.withCommonConfiguration(projectRoot: File): GradleRunner {
+  File(projectRoot, "gradle.properties").writeText(
+    """
+      |org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
+      |
+    """.trimMargin()
+  )
+  return withProjectDir(projectRoot)
+}

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/dialect/DialectIntegrationTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/dialect/DialectIntegrationTests.kt
@@ -9,24 +9,6 @@ import java.io.File
 
 class DialectIntegrationTests {
 
-  @Test fun integrationTestsMySql() {
-    val runner = GradleRunner.create()
-      .withCommonConfiguration(File("src/test/integration-mysql"))
-      .withArguments("clean", "check", "--stacktrace")
-
-    val result = runner.build()
-    Truth.assertThat(result.output).contains("BUILD SUCCESSFUL")
-  }
-
-  @Test fun integrationTestsMySqlSchemaDefinitions() {
-    val runner = GradleRunner.create()
-      .withCommonConfiguration(File("src/test/integration-mysql-schema"))
-      .withArguments("clean", "check", "--stacktrace")
-
-    val result = runner.build()
-    Truth.assertThat(result.output).contains("BUILD SUCCESSFUL")
-  }
-
   @Test fun integrationTestsMySqlSchemaOutput() {
     val integrationRoot = File("src/test/schema-output")
 
@@ -39,15 +21,6 @@ class DialectIntegrationTests {
 
     FileSubject.assertThat(File(integrationRoot, "build"))
       .contentsAreEqualTo(File(integrationRoot, "expected-build"))
-  }
-
-  @Test fun integrationTestsPostgreSql() {
-    val runner = GradleRunner.create()
-      .withCommonConfiguration(File("src/test/integration-postgresql"))
-      .withArguments("clean", "check", "--stacktrace")
-
-    val result = runner.build()
-    Truth.assertThat(result.output).contains("BUILD SUCCESSFUL")
   }
 
   @Test fun integrationTestsHsql() {


### PR DESCRIPTION
There are three tests that fail when Docker isn't installed. I have searched but cannot find an easy to integrate runtime check to see if Docker is installed before running the tests, so I've put the tests behind a flag instead, defaulting to not run.

This makes things easier for casual contributors like myself who don't have Docker installed, but I can understand if this is knocked back.

If there are better solutions for this please provide pointers, thanks!