### PR TITLE
Force build and run sqldelight-idea-plugin using Java 11

### DIFF
--- a/sqldelight-idea-plugin/build.gradle
+++ b/sqldelight-idea-plugin/build.gradle
@@ -63,6 +63,12 @@ compileKotlin {
   }
 }
 
+kotlin {
+  jvmToolchain {
+    languageVersion.set(JavaLanguageVersion.of(11))
+  }
+}
+
 def isReleaseBuild() {
   return VERSION_NAME.contains("SNAPSHOT") == false
 }


### PR DESCRIPTION
Without this, someone using e.g. Java 17 LTS to run Gradle will run into build failures.