### PR TITLE
Add a flag to ignore schema definitions during migration checks

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/VerifyMigrationTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/VerifyMigrationTask.kt
@@ -46,6 +46,8 @@ abstract class VerifyMigrationTask : SqlDelightWorkerTask() {
 
   @Input var verifyMigrations: Boolean = false
 
+  @Input var verifyDefinitions: Boolean = true
+
   /* Tasks without an output are never considered UP-TO-DATE by Gradle. Adding an output file that's created when the
    * task completes successfully works around the lack of an output for this task. There may be a better solution once
    * https://github.com/gradle/gradle/issues/14223 is resolved. */
@@ -62,6 +64,7 @@ abstract class VerifyMigrationTask : SqlDelightWorkerTask() {
         it.properties.set(properties)
         it.verifyMigrations.set(verifyMigrations)
         it.compilationUnit.set(compilationUnit)
+        it.verifyDefinitions.set(verifyDefinitions)
       }
       workQueue.await()
     }.onSuccess {
@@ -85,6 +88,7 @@ abstract class VerifyMigrationTask : SqlDelightWorkerTask() {
     val properties: Property<SqlDelightDatabaseProperties>
     val compilationUnit: Property<SqlDelightCompilationUnit>
     val verifyMigrations: Property<Boolean>
+    val verifyDefinitions: Property<Boolean>
   }
 
   abstract class VerifyMigrationAction : WorkAction<VerifyMigrationWorkParameters> {
@@ -141,6 +145,7 @@ abstract class VerifyMigrationTask : SqlDelightWorkerTask() {
     private fun checkMigration(dbFile: File, currentDb: CatalogDatabase) {
       val actualCatalog = createActualDb(dbFile)
       val databaseComparator = ObjectDifferDatabaseComparator(
+        ignoreDefinitions = !parameters.verifyDefinitions.get(),
         circularReferenceExceptionLogger = {
           logger.debug(it)
         }

--- a/sqlite-migrations/src/main/kotlin/app/cash/sqlite/migrations/ObjectDifferDatabaseComparator.kt
+++ b/sqlite-migrations/src/main/kotlin/app/cash/sqlite/migrations/ObjectDifferDatabaseComparator.kt
@@ -9,6 +9,7 @@ import de.danielbechler.diff.node.DiffNode.State.REMOVED
 import de.danielbechler.diff.node.DiffNode.State.UNTOUCHED
 
 class ObjectDifferDatabaseComparator(
+  private val ignoreDefinitions: Boolean,
   private val circularReferenceExceptionLogger: ((String) -> Unit)? = null
 ) : DatabaseComparator<CatalogDatabase> {
 
@@ -30,6 +31,8 @@ class ObjectDifferDatabaseComparator(
       propertyName("importedForeignKeys")
       propertyName("deferrable")
       propertyName("initiallyDeferred")
+
+      if (ignoreDefinitions) propertyName("definition")
     }
     // Partial columns are used for unresolved columns to avoid cycles. Matching based on string
     // is fine for our purposes.


### PR DESCRIPTION
Closes https://github.com/cashapp/sqldelight/issues/3115