### PR TITLE
Clean up JS worker exception handling

### DIFF
--- a/drivers/sqljs-driver/src/main/kotlin/app/cash/sqldelight/driver/sqljs/worker/JsWorkerException.kt
+++ b/drivers/sqljs-driver/src/main/kotlin/app/cash/sqldelight/driver/sqljs/worker/JsWorkerException.kt
@@ -1,0 +1,3 @@
+package app.cash.sqldelight.driver.sqljs.worker
+
+class JsWorkerException(message: String) : Throwable(message)

--- a/drivers/sqljs-driver/src/main/kotlin/app/cash/sqldelight/driver/sqljs/worker/JsWorkerSqlDriver.kt
+++ b/drivers/sqljs-driver/src/main/kotlin/app/cash/sqldelight/driver/sqljs/worker/JsWorkerSqlDriver.kt
@@ -6,7 +6,6 @@ import app.cash.sqldelight.async.db.AsyncSqlCursor
 import app.cash.sqldelight.async.db.AsyncSqlDriver
 import app.cash.sqldelight.async.db.AsyncSqlPreparedStatement
 import app.cash.sqldelight.driver.sqljs.QueryResults
-import kotlinx.coroutines.await
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.khronos.webgl.Int8Array
 import org.khronos.webgl.Uint8Array
@@ -16,7 +15,6 @@ import org.w3c.dom.events.Event
 import org.w3c.dom.events.EventListener
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
-import kotlin.js.Promise
 
 private fun <T> jsObject(block: T.() -> Unit): T {
   val o = js("{}").unsafeCast<T>()
@@ -24,12 +22,12 @@ private fun <T> jsObject(block: T.() -> Unit): T {
   return o
 }
 
-suspend fun initAsyncSqlDriver(workerPath: String = "/worker.sql-wasm.js", schema: AsyncSqlDriver.Schema? = null): AsyncSqlDriver {
-  val worker = Worker(workerPath)
-  return Promise<AsyncSqlDriver> { resolve, _ -> resolve(JsWorkerSqlDriver(worker)) }.withSchema(schema)
-}
+suspend fun initAsyncSqlDriver(
+  workerPath: String = "/worker.sql-wasm.js",
+  schema: AsyncSqlDriver.Schema? = null
+): AsyncSqlDriver = JsWorkerSqlDriver(Worker(workerPath)).withSchema(schema)
 
-suspend fun Promise<AsyncSqlDriver>.withSchema(schema: AsyncSqlDriver.Schema? = null): AsyncSqlDriver = await().also { schema?.create(it) }
+suspend fun AsyncSqlDriver.withSchema(schema: AsyncSqlDriver.Schema? = null): AsyncSqlDriver = this.also { schema?.create(it) }
 
 class JsWorkerSqlDriver(private val worker: Worker) : AsyncSqlDriver {
   private val listeners = mutableMapOf<String, MutableSet<AsyncQuery.Listener>>()
@@ -49,9 +47,6 @@ class JsWorkerSqlDriver(private val worker: Worker) : AsyncSqlDriver {
     }
 
     val data = worker.sendMessage(messageId, message).unsafeCast<WorkerData>()
-    if (data.error != null) {
-      throw data.error as Throwable
-    }
 
     val table = if (data.results.isNotEmpty()) {
       data.results[0]
@@ -59,8 +54,7 @@ class JsWorkerSqlDriver(private val worker: Worker) : AsyncSqlDriver {
       jsObject { values = arrayOf() }
     }
 
-    @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE") val cursor = JsWorkerSqlCursor(table)
-    return mapper(cursor)
+    return mapper(JsWorkerSqlCursor(table))
   }
 
   override suspend fun execute(identifier: Int?, sql: String, parameters: Int, binders: (AsyncSqlPreparedStatement.() -> Unit)?): Long {
@@ -75,10 +69,7 @@ class JsWorkerSqlDriver(private val worker: Worker) : AsyncSqlDriver {
       this.params = bound.parameters.toTypedArray()
     }
 
-    val data = worker.sendMessage(messageId, message)
-    if (data.error != null) {
-      throw data.error as Throwable
-    }
+    worker.sendMessage(messageId, message)
     return 0
   }
 
@@ -130,24 +121,29 @@ class JsWorkerSqlDriver(private val worker: Worker) : AsyncSqlDriver {
     }
   }
 
-  private suspend fun Worker.sendMessage(id: Int, message: dynamic): dynamic = suspendCancellableCoroutine { continuation ->
+  private suspend fun Worker.sendMessage(id: Int, message: dynamic): WorkerData = suspendCancellableCoroutine { continuation ->
     postMessage(message)
 
     val messageListener = object : EventListener {
       override fun handleEvent(event: Event) {
         check(event is MessageEvent)
 
-        if (event.data.asDynamic().id == id) {
-          continuation.resume(event.data)
-          removeEventListener("message", this)
+        val data = event.data.unsafeCast<WorkerData>()
+        if (data.id == id) {
+          if (data.error != null) {
+            continuation.resumeWithException(JsWorkerException(data.error!!))
+          } else {
+            removeEventListener("message", this)
+            continuation.resume(data)
+          }
         }
       }
     }
 
     val errorListener = object : EventListener {
       override fun handleEvent(event: Event) {
-        worker.removeEventListener("error", this)
-        continuation.resumeWithException(event.asDynamic().error as Throwable)
+        removeEventListener("error", this)
+        continuation.resumeWithException(JsWorkerException(event.toString()))
       }
     }
 

--- a/drivers/sqljs-driver/src/main/kotlin/app/cash/sqldelight/driver/sqljs/worker/WorkerMessages.kt
+++ b/drivers/sqljs-driver/src/main/kotlin/app/cash/sqldelight/driver/sqljs/worker/WorkerMessages.kt
@@ -35,7 +35,7 @@ internal external interface WorkerData {
   /**
    * An error returned by the worker, could be undefined.
    */
-  var error: dynamic
+  var error: String?
 
   /**
    * The id of the message that this data is in response to. Matches the value that was posted in [WorkerMessage.id].


### PR DESCRIPTION
For some reason the new exception handling test fails when running under the legacy compiler. In actual application builds the exception is thrown normally, but in the legacy tests the exception is completely ignored somehow.

So with the legacy compiler hopefully on the way out in the near future, I think it's best just to skip the legacy version of the test.