### PR TITLE
Set migration directory safely in MigrationSquashTask

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/squash/MigrationSquashTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/squash/MigrationSquashTask.kt
@@ -94,7 +94,7 @@ abstract class MigrationSquashTask : SqlDelightWorkerTask() {
       environment.forMigrationFiles { migrationFile ->
         if (migrationFile.version > topVersion) {
           topVersion = migrationFile.version
-          migrationDirectory = File(migrationFile.virtualFile!!.path.substringBeforeLast(File.separatorChar))
+          migrationDirectory = File(migrationFile.virtualFile!!.parent.path)
         }
 
         val migrations = migrationFile.sqlStmtList?.children


### PR DESCRIPTION
VirtualFile.getPath() returns a string with file separator chars replaced with '/', so returning the substring before File.separatorChar on Windows will fail (as it's matching on '\\')