### PR TITLE
Do not add kotlin-stdlib as a runtime dependency of the Gradle plugin

### DIFF
--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -23,7 +23,9 @@ configurations {
 }
 
 dependencies {
-  api deps.sqlPsi
+  api(deps.sqlPsi) {
+    exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jdk8'
+  }
 
   implementation deps.sqliteJdbc
   implementation deps.objectDiff

--- a/sqldelight-gradle-plugin/gradle.properties
+++ b/sqldelight-gradle-plugin/gradle.properties
@@ -2,3 +2,6 @@ POM_ARTIFACT_ID=gradle-plugin
 POM_NAME=SQLDelight Gradle Plugin
 POM_DESCRIPTION=Gradle plugin for generating kotlin interfaces for sqlite files
 POM_PACKAGING=jar
+
+# Do not add the stdlib as it will be provided by runtime by Gradle
+kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
Like for the Kotlin Gradle Plugin ([YouTrack comment](https://youtrack.jetbrains.com/issue/KT-41142)), there is no need to expose `kotlin-stdlib` as a runtime dependency as Gradle will provide its own version on the classpath. 

This fixes some `Runtime JAR files in the classpath should have the same version` warnings.

