### PR TITLE
In-memory single-connection driver support for native

### DIFF
--- a/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/NativeDriverTest.kt
+++ b/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/NativeDriverTest.kt
@@ -3,6 +3,7 @@ package com.squareup.sqldelight.drivers.native
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
+import app.cash.sqldelight.driver.native.inMemoryDriver
 import co.touchlab.sqliter.DatabaseFileContext.deleteDatabase
 import com.squareup.sqldelight.driver.test.DriverTest
 
@@ -11,5 +12,11 @@ class NativeDriverTest : DriverTest() {
     val name = "testdb"
     deleteDatabase(name)
     return NativeSqliteDriver(schema, name)
+  }
+}
+
+class NativeDriverMemoryTest : DriverTest() {
+  override fun setupDatabase(schema: SqlSchema): SqlDriver {
+    return inMemoryDriver(schema)
   }
 }

--- a/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/NativeQueryTest.kt
+++ b/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/NativeQueryTest.kt
@@ -3,6 +3,7 @@ package com.squareup.sqldelight.drivers.native
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
+import app.cash.sqldelight.driver.native.inMemoryDriver
 import co.touchlab.sqliter.DatabaseFileContext
 import com.squareup.sqldelight.driver.test.QueryTest
 
@@ -11,5 +12,11 @@ class NativeQueryTest : QueryTest() {
     val name = "testdb"
     DatabaseFileContext.deleteDatabase(name)
     return NativeSqliteDriver(schema, name)
+  }
+}
+
+class NativeQueryMemoryTest : QueryTest() {
+  override fun setupDatabase(schema: SqlSchema): SqlDriver {
+    return inMemoryDriver(schema)
   }
 }

--- a/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/NativeTransacterTest.kt
+++ b/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/NativeTransacterTest.kt
@@ -3,6 +3,7 @@ package com.squareup.sqldelight.drivers.native
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
+import app.cash.sqldelight.driver.native.inMemoryDriver
 import co.touchlab.sqliter.DatabaseFileContext.deleteDatabase
 import com.squareup.sqldelight.driver.test.TransacterTest
 
@@ -11,5 +12,11 @@ class NativeTransacterTest : TransacterTest() {
     val name = "testdb"
     deleteDatabase(name)
     return NativeSqliteDriver(schema, name)
+  }
+}
+
+class NativeTransacterMemoryTest : TransacterTest() {
+  override fun setupDatabase(schema: SqlSchema): SqlDriver {
+    return inMemoryDriver(schema)
   }
 }


### PR DESCRIPTION
Native driver modified to support in-memory connections. Added a helper function to create the driver. Not sure if that would be preferred in a companion object, or try to rework the constructor instead.