### PR TITLE
Use managed & lazy properties in Gradle plugin extension

### DIFF
--- a/docs/common/gradle-dependencies.md
+++ b/docs/common/gradle-dependencies.md
@@ -7,9 +7,11 @@ You can specify schema dependencies on another module:
     // project-a/build.gradle.kts
 
     sqldelight {
-      database("MyDatabase") {
-        packageName = "com.example.projecta"
-        dependency(project(":ProjectB"))
+      databases {
+        create("MyDatabase") {
+          packageName.set("com.example.projecta")
+          dependency(project(":ProjectB"))
+        }
       }
     }
     ```
@@ -18,9 +20,11 @@ You can specify schema dependencies on another module:
     // project-a/build.gradle
 
     sqldelight {
-      MyDatabase {
-        packageName = "com.example.projecta"
-        dependency project(":ProjectB")
+      databases {
+        MyDatabase {
+          packageName = "com.example.projecta"
+          dependency project(":ProjectB")
+        }
       }
     }
     ```
@@ -34,9 +38,11 @@ different package, so here is what `ProjectB`'s gradle might look like:
     // project-b/build.gradle.kts
 
     sqldelight {
-      // Same database name
-      database("MyDatabase") {
-        package = "com.example.projectb"
+      databases {
+        // Same database name
+        create("MyDatabase") {
+          package = "com.example.projectb"
+        }
       }
     }
     ```
@@ -45,9 +51,11 @@ different package, so here is what `ProjectB`'s gradle might look like:
     // project-b/build.gradle
 
     sqldelight {
-      // Same database name
-      MyDatabase {
-        package = "com.example.projectb"
+      databases {
+        // Same database name
+        MyDatabase {
+          package = "com.example.projectb"
+        }
       }
     }
     ```

--- a/docs/common/gradle.md
+++ b/docs/common/gradle.md
@@ -4,23 +4,27 @@ For greater customization, you can declare databases explicitly using the Gradle
 
 ## SQLDelight Configuration
 
-### `database`
+### `databases`
 
-Configures SQLDelight to create a database with the given name.
+Container for databases. Configures SQLDelight to create each one with the given name.
 
 === "Kotlin"
     ```kotlin
     sqldelight {
-      database("MyDatabase") {
-        // Database configuration here
+      databases {
+        create("MyDatabase") {
+          // Database configuration here
+        }
       }
     }
     ```
 === "Groovy"
     ```groovy
     sqldelight {
-      MyDatabase {
-        // Database configuration here
+      databases {
+        MyDatabase {
+          // Database configuration here
+        }
       }
     }
     ```
@@ -29,26 +33,32 @@ Configures SQLDelight to create a database with the given name.
 
 ### `linkSqlite`
 
-Type: `Boolean`
+Type: `Property<Boolean>`
 
 For native targets. Whether sqlite should be automatically linked.
 
-Defaults to true.
+Defaults to `true`.
 
-```kotlin
-linkSqlite = true
-```
+=== "Kotlin"
+    ```kotlin
+    linkSqlite.set(true)
+    ```
+=== "Groovy"
+    ```groovy
+    linkSqlite = true
+    ```
 
 ## Database Configuration
 
 ### `packageName`
 
-Type: `String`
+Type: `Property<String>`
 
 Package name used for the database class.
+
 === "Kotlin"
     ```kotlin
-    packageName = "com.example.db"
+    packageName.set("com.example.db")
     ```
 === "Groovy"
     ```groovy
@@ -59,7 +69,7 @@ Package name used for the database class.
 
 ### `sourceFolders`
 
-Type: `Collection<String>`
+Type: `ListProperty<String>`
 
 An collection of folders that the plugin will look in for your `.sq` and `.sqm` files.
 These folder paths are relative to your existing source set, so if you specify `listOf("db")`
@@ -69,7 +79,7 @@ Defaults to `listOf("sqldelight")`.
 
 === "Kotlin"
     ```kotlin
-    sourceFolders = listOf("db")
+    sourceFolders.set(listOf("db"))
     ```
 === "Groovy"
     ```groovy
@@ -79,7 +89,7 @@ Defaults to `listOf("sqldelight")`.
 
 ### `schemaOutputDirectory`
 
-Type: `File`
+Type: `DirectoryProperty`
 
 The directory where `.db` schema files should be stored, relative to the project root.
 These files are used to verify that migrations yield a database with the latest schema.
@@ -89,7 +99,7 @@ If `null`, the migration verification tasks will not be created.
 
 === "Kotlin"
     ```kotlin
-    schemaOutputDirectory = file("src/main/sqldelight/databases")
+    schemaOutputDirectory.set(file("src/main/sqldelight/databases"))
     ```
 === "Groovy"
     ```groovy
@@ -152,7 +162,7 @@ Available dialects:
 
 ### `verifyMigrations`
 
-Type: `Boolean`
+Type: `Property<Boolean>`
 
 If set to true, migration files will fail during the build process if there are any errors in them.
 
@@ -160,7 +170,7 @@ Defaults to `false`.
 
 === "Kotlin"
     ```kotlin
-    verifyMigrations = true
+    verifyMigrations.set(true)
     ```
 === "Groovy"
     ```groovy
@@ -171,7 +181,7 @@ Defaults to `false`.
 
 ### `treatNullAsUnknownForEquality`
 
-Type: `Boolean`
+Type: `Property<Boolean>`
 
 If set to true, SQLDelight will not replace an equality comparison with a nullable typed value when using `IS`.
 
@@ -179,7 +189,7 @@ Defaults to `false`.
 
 === "Kotlin"
     ```kotlin
-    treatNullAsUnknownForEquality = true
+    treatNullAsUnknownForEquality.set(true)
     ```
 === "Groovy"
     ```groovy
@@ -190,13 +200,15 @@ Defaults to `false`.
 
 ### `generateAsync`
 
-Type: `Boolean`
+Type: `Property<Boolean>`
 
 If set to true, SQLDelight will generate suspending query methods for us with asynchronous drivers.
 
+Defaults to `false`.
+
 === "Kotlin"
     ```kotlin
-    generateAsync = true
+    generateAsync.set(true)
     ```
 === "Groovy"
     ```groovy
@@ -207,16 +219,16 @@ If set to true, SQLDelight will generate suspending query methods for us with as
 
 ### `deriveSchemaFromMigrations`
 
-Type: `Boolean`
+Type: `Property<Boolean>`
 
 If set to true, the schema for your database will be derived from your `.sqm` files as if each migration had been applied.
 If false, your schema is defined in `.sq` files.
 
-Defaults to false.
+Defaults to `false`.
 
 === "Kotlin"
     ```kotlin
-    deriveSchemaFromMigrations = true
+    deriveSchemaFromMigrations.set(true)
     ```
 === "Groovy"
     ```groovy

--- a/docs/common/gradle.md
+++ b/docs/common/gradle.md
@@ -6,14 +6,14 @@ For greater customization, you can declare databases explicitly using the Gradle
 
 ### `databases`
 
-Container for databases. Configures SQLDelight to create each one with the given name.
+Container for databases. Configures SQLDelight to create each database with the given name.
 
 === "Kotlin"
     ```kotlin
     sqldelight {
       databases {
         create("MyDatabase") {
-          // Database configuration here
+          // Database configuration here.
         }
       }
     }
@@ -23,7 +23,7 @@ Container for databases. Configures SQLDelight to create each one with the given
     sqldelight {
       databases {
         MyDatabase {
-          // Database configuration here
+          // Database configuration here.
         }
       }
     }

--- a/docs/common/index_gradle_database.md
+++ b/docs/common/index_gradle_database.md
@@ -12,9 +12,11 @@ First apply the gradle plugin in your project.
     }
     
     sqldelight {
-      database("Database") {
-        packageName = "com.example"{% if dialect %}
-        dialect = "{{ dialect }}:{{ versions.sqldelight }}"{% endif %}
+      databases {
+        create("Database") {
+          packageName.set("com.example"){% if dialect %}
+          dialect = "{{ dialect }}:{{ versions.sqldelight }}"{% endif %}
+        }
       }
     }
     ```
@@ -30,9 +32,11 @@ First apply the gradle plugin in your project.
     }
 
     sqldelight {
-      Database { // This will be the name of the generated database class.
-        packageName = "com.example"{% if dialect %}
-        dialect = "{{ dialect }}:{{ versions.sqldelight }}"{% endif %}
+      databases {
+        Database { // This will be the name of the generated database class.
+          packageName = "com.example"{% if dialect %}
+          dialect = "{{ dialect }}:{{ versions.sqldelight }}"{% endif %}
+        }
       }
     }
     ```

--- a/docs/common/index_server.md
+++ b/docs/common/index_server.md
@@ -21,20 +21,24 @@ First, configure gradle to use migrations to assemble the schema:
 === "Kotlin"
     ```kotlin
     sqldelight {
-      database("Database") {
-        ...
-        sourceFolders = listOf("sqldelight")
-        deriveSchemaFromMigrations = true
+      databases {
+        create("Database") {
+          ...
+          sourceFolders = listOf("sqldelight")
+          deriveSchemaFromMigrations = true
+        }
       }
     }
     ```
 === "Groovy"
     ```groovy
     sqldelight {
-      Database {
-        ...
-        sourceFolders = ["sqldelight"]
-        deriveSchemaFromMigrations = true
+      databases {
+        Database {
+          ...
+          sourceFolders = ["sqldelight"]
+          deriveSchemaFromMigrations = true
+        }
       }
     }
     ```

--- a/docs/common/migrations_server.md
+++ b/docs/common/migrations_server.md
@@ -6,9 +6,10 @@ services to read from:
 
 ```groovy
 sqldelight {
-  Database {
-    migrationOutputDirectory = file("$buildDir/resources/main/migrations")
-    migrationOutputFileFormat = ".sql" // Defaults to .sql
+  databases {
+    Database {
+      migrationOutputDirectory = file("$buildDir/resources/main/migrations")
+      migrationOutputFileFormat = ".sql" // Defaults to .sql
   }
 }
 ```

--- a/docs/common/multiplatform.md
+++ b/docs/common/multiplatform.md
@@ -7,8 +7,10 @@ apply plugin: "org.jetbrains.kotlin.multiplatform"
 apply plugin: "app.cash.sqldelight"
 
 sqldelight {
-  MyDatabase {
-    packageName = "com.example.hockey"
+  databases {
+    MyDatabase {
+      packageName = "com.example.hockey"
+    }
   }
 }
 ```

--- a/docs/js_sqlite/worker.md
+++ b/docs/js_sqlite/worker.md
@@ -5,10 +5,12 @@ to generate asynchronous SQLDelight interfaces.
 
 ```groovy
 sqldelight {
+  databases {
     Database {
-        packageName = "com.example"
-        generateAsync = true
+      packageName = "com.example"
+      generateAsync = true
     }
+  }
 }
 ```
 

--- a/sample/common/build.gradle
+++ b/sample/common/build.gradle
@@ -7,8 +7,10 @@ plugins {
 archivesBaseName = 'sample-common'
 
 sqldelight {
-  HockeyDb {
-    packageName = "com.example.sqldelight.hockey"
+  databases {
+    HockeyDb {
+      packageName = "com.example.sqldelight.hockey"
+    }
   }
   linkSqlite = true
 }

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
@@ -20,7 +20,7 @@ import javax.inject.Inject
 
 abstract class SqlDelightDatabase @Inject constructor(
   val project: Project,
-  var name: String,
+  val name: String,
 ) {
 
   init {

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
@@ -14,18 +14,19 @@ import org.gradle.api.internal.catalog.DelegatingProjectDependency
 import org.gradle.api.provider.Provider
 import java.io.File
 
-class SqlDelightDatabase(
+open class SqlDelightDatabase(
   val project: Project,
   var name: String,
-  var packageName: String? = null,
-  var schemaOutputDirectory: File? = null,
-  var sourceFolders: Collection<String>? = null,
-  var deriveSchemaFromMigrations: Boolean = false,
-  var verifyMigrations: Boolean = false,
-  var migrationOutputDirectory: File? = null,
-  var migrationOutputFileFormat: String = ".sql",
-  var generateAsync: Boolean = false,
 ) {
+  var packageName: String? = null
+  var schemaOutputDirectory: File? = null
+  var sourceFolders: Collection<String>? = null
+  var deriveSchemaFromMigrations: Boolean = false
+  var verifyMigrations: Boolean = false
+  var migrationOutputDirectory: File? = null
+  var migrationOutputFileFormat: String = ".sql"
+  var generateAsync: Boolean = false
+
   internal val configuration = project.configurations.create("${name}DialectClasspath").apply {
     isCanBeConsumed = false
     isVisible = false

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
@@ -22,6 +22,16 @@ abstract class SqlDelightDatabase @Inject constructor(
   val project: Project,
   var name: String,
 ) {
+
+  init {
+    sourceFolders.convention(listOf("sqldelight"))
+    deriveSchemaFromMigrations.convention(false)
+    verifyMigrations.convention(false)
+    migrationOutputFileFormat.convention(".sql")
+    generateAsync.convention(false)
+    treatNullAsUnknownForEquality.convention(false)
+  }
+
   abstract val packageName: Property<String>
   abstract val schemaOutputDirectory: DirectoryProperty
   abstract val sourceFolders: ListProperty<String>

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightExtension.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightExtension.kt
@@ -2,14 +2,15 @@ package app.cash.sqldelight.gradle
 
 import groovy.lang.Closure
 import org.gradle.api.Project
+import org.gradle.api.provider.Property
 import org.gradle.util.ConfigureUtil
 
-open class SqlDelightExtension {
+abstract class SqlDelightExtension {
   internal val databases = mutableListOf<SqlDelightDatabase>()
   internal var configuringDatabase: SqlDelightDatabase? = null
   internal lateinit var project: Project
 
-  var linkSqlite = true
+  abstract val linkSqlite: Property<Boolean>
 
   fun methodMissing(name: String, args: Any): Any {
     configuringDatabase?.methodMissing(name, args)?.let { return it }

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightExtension.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightExtension.kt
@@ -1,61 +1,9 @@
 package app.cash.sqldelight.gradle
 
-import groovy.lang.Closure
 import org.gradle.api.NamedDomainObjectContainer
-import org.gradle.api.Project
 import org.gradle.api.provider.Property
-import org.gradle.util.ConfigureUtil
 
-abstract class SqlDelightExtension {
-  abstract val databases: NamedDomainObjectContainer<SqlDelightDatabase>
-  internal var configuringDatabase: SqlDelightDatabase? = null
-  internal lateinit var project: Project
-
-  abstract val linkSqlite: Property<Boolean>
-
-  fun methodMissing(name: String, args: Any): Any {
-    configuringDatabase?.methodMissing(name, args)?.let { return it }
-
-    val closure = (args as? Array<*>)?.getOrNull(0) as? Closure<*>
-      ?: throw IllegalStateException(
-        """
-        |Expected a closure for database names:
-        |
-        |sqldelight {
-        |  $name {
-        |    packageName = "com.sample"
-        |    sourceSet = files("src/main/sqldelight")
-        |  }
-        |}
-        """.trimMargin(),
-      )
-
-    val database = SqlDelightDatabase(project, name = name)
-    configuringDatabase = database
-    ConfigureUtil.configure(closure, database)
-    configuringDatabase = null
-
-    check(!databases.any { it.name == database.name }) { "There is already a database defined for ${database.name}" }
-
-    databases.add(database)
-    return Unit
-  }
-
-  /**
-   * Supports configuration in Kotlin script build files.
-   *
-   * sqldelight {
-   *   database("MyDatabase") {
-   *     packageName = "com.example"
-   *     sourceSet = files("src/main/sqldelight")
-   *   }
-   * }
-   */
-  fun database(name: String, config: SqlDelightDatabase.() -> Unit) {
-    val database = SqlDelightDatabase(project, name = name).apply(config)
-
-    check(!databases.any { it.name == database.name }) { "There is already a database defined for ${database.name}" }
-
-    databases.add(database)
-  }
+interface SqlDelightExtension {
+  val databases: NamedDomainObjectContainer<SqlDelightDatabase>
+  val linkSqlite: Property<Boolean>
 }

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightExtension.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightExtension.kt
@@ -1,12 +1,13 @@
 package app.cash.sqldelight.gradle
 
 import groovy.lang.Closure
+import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
 import org.gradle.util.ConfigureUtil
 
 abstract class SqlDelightExtension {
-  internal val databases = mutableListOf<SqlDelightDatabase>()
+  abstract val databases: NamedDomainObjectContainer<SqlDelightDatabase>
   internal var configuringDatabase: SqlDelightDatabase? = null
   internal lateinit var project: Project
 

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
@@ -48,7 +48,6 @@ abstract class SqlDelightPlugin : Plugin<Project> {
     }
 
     extension = project.extensions.create("sqldelight", SqlDelightExtension::class.java)
-    extension.project = project
 
     val androidPluginHandler = { _: Plugin<*> ->
       android.set(true)

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
@@ -112,7 +112,7 @@ abstract class SqlDelightPlugin : Plugin<Project> {
       }
     }
 
-    if (extension.linkSqlite) {
+    if (extension.linkSqlite.getOrElse(true)) {
       project.linkSqlite()
     }
 

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
@@ -48,14 +48,6 @@ abstract class SqlDelightPlugin : Plugin<Project> {
     }
 
     extension = project.extensions.create("sqldelight", SqlDelightExtension::class.java)
-    extension.databases.all {
-      it.sourceFolders.convention(listOf("sqldelight"))
-      it.deriveSchemaFromMigrations.convention(false)
-      it.verifyMigrations.convention(false)
-      it.migrationOutputFileFormat.convention(".sql")
-      it.generateAsync.convention(false)
-      it.treatNullAsUnknownForEquality.convention(false)
-    }
 
     val androidPluginHandler = { _: Plugin<*> ->
       android.set(true)

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
@@ -123,8 +123,8 @@ abstract class SqlDelightPlugin : Plugin<Project> {
           SqlDelightDatabase(
             project = project,
             name = "Database",
-            packageName = project.packageName(),
           ).apply {
+            packageName = project.packageName()
             project.sqliteVersion()?.let(::dialect)
           },
         )

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
@@ -48,6 +48,14 @@ abstract class SqlDelightPlugin : Plugin<Project> {
     }
 
     extension = project.extensions.create("sqldelight", SqlDelightExtension::class.java)
+    extension.databases.all {
+      it.sourceFolders.convention(listOf("sqldelight"))
+      it.deriveSchemaFromMigrations.convention(false)
+      it.verifyMigrations.convention(false)
+      it.migrationOutputFileFormat.convention(".sql")
+      it.generateAsync.convention(false)
+      it.treatNullAsUnknownForEquality.convention(false)
+    }
 
     val androidPluginHandler = { _: Plugin<*> ->
       android.set(true)
@@ -84,7 +92,7 @@ abstract class SqlDelightPlugin : Plugin<Project> {
     val isMultiplatform = project.plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")
     val isJsOnly = if (isMultiplatform) false else project.plugins.hasPlugin("org.jetbrains.kotlin.js")
 
-    val needsAsyncRuntime = extension.databases.any { it.generateAsync }
+    val needsAsyncRuntime = extension.databases.any { it.generateAsync.get() }
     val runtimeDependencies = mutableListOf<Dependency>().apply {
       add(project.dependencies.create("app.cash.sqldelight:runtime:$VERSION"))
       if (needsAsyncRuntime) add(project.dependencies.create("app.cash.sqldelight:async-extensions:$VERSION"))
@@ -119,11 +127,8 @@ abstract class SqlDelightPlugin : Plugin<Project> {
       if (databases.isEmpty() && android.get() && !isMultiplatform) {
         // Default to a database for android named "Database" to keep things simple.
         databases.add(
-          SqlDelightDatabase(
-            project = project,
-            name = "Database",
-          ).apply {
-            packageName = project.packageName()
+          objects.newInstance(SqlDelightDatabase::class.java, project, "Database").apply {
+            packageName.set(project.packageName())
             project.sqliteVersion()?.let(::dialect)
           },
         )
@@ -142,8 +147,8 @@ abstract class SqlDelightPlugin : Plugin<Project> {
       }
 
       databases.forEach { database ->
-        if (database.packageName == null && android.get() && !isMultiplatform) {
-          database.packageName = project.packageName()
+        if (database.packageName.getOrNull() == null && android.get() && !isMultiplatform) {
+          database.packageName.set(project.packageName())
         }
         if (!database.addedDialect && android.get() && !isMultiplatform) {
           project.sqliteVersion()?.let(database::dialect)

--- a/sqldelight-gradle-plugin/src/test/adapter-questionmark/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/adapter-questionmark/build.gradle
@@ -13,8 +13,10 @@ repositories {
 }
 
 sqldelight {
-  AdapterQuestionmark {
-    packageName = "app.cash.sqldelight.adapterquestionmark"
+  databases {
+    AdapterQuestionmark {
+      packageName = "app.cash.sqldelight.adapterquestionmark"
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/custom-dialect/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/custom-dialect/build.gradle
@@ -13,9 +13,11 @@ repositories {
 }
 
 sqldelight {
-  customDialect {
-    packageName = "app.cash.sqldelight.customdialect"
-    dialect(project(":dialect"))
+  databases {
+    customDialect {
+      packageName = "app.cash.sqldelight.customdialect"
+      dialect(project(":dialect"))
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/dependency-adapter-migration/bottom/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/dependency-adapter-migration/bottom/build.gradle
@@ -2,11 +2,13 @@ apply plugin: 'kotlin'
 apply plugin: 'app.cash.sqldelight'
 
 sqldelight {
-  Database {
-    packageName = "com.example.bottom"
-    dialect("app.cash.sqldelight:mysql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
-    deriveSchemaFromMigrations = true
-    verifyMigrations = true
+  databases {
+    Database {
+      packageName = "com.example.bottom"
+      dialect("app.cash.sqldelight:mysql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+      deriveSchemaFromMigrations = true
+      verifyMigrations = true
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/dependency-adapter-migration/moduleA/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/dependency-adapter-migration/moduleA/build.gradle
@@ -7,11 +7,13 @@ dependencies {
 }
 
 sqldelight {
-  Database {
-    packageName = "com.example.modulea"
-    dialect("app.cash.sqldelight:mysql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
-    deriveSchemaFromMigrations = true
-    verifyMigrations = true
-    dependency project(":bottom")
+  databases {
+    Database {
+      packageName = "com.example.modulea"
+      dialect("app.cash.sqldelight:mysql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+      deriveSchemaFromMigrations = true
+      verifyMigrations = true
+      dependency project(":bottom")
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/dependency-adapter/bottom/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/dependency-adapter/bottom/build.gradle
@@ -2,7 +2,9 @@ apply plugin: 'kotlin'
 apply plugin: 'app.cash.sqldelight'
 
 sqldelight {
-  Database {
-    packageName = "com.example.bottom"
+  databases {
+    Database {
+      packageName = "com.example.bottom"
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/dependency-adapter/moduleA/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/dependency-adapter/moduleA/build.gradle
@@ -6,8 +6,10 @@ dependencies {
 }
 
 sqldelight {
-  Database {
-    packageName = "com.example.modulea"
-    dependency project(":bottom")
+  databases {
+    Database {
+      packageName = "com.example.modulea"
+      dependency project(":bottom")
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/derive-schema-no-queries/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/derive-schema-no-queries/build.gradle
@@ -13,9 +13,11 @@ repositories {
 }
 
 sqldelight {
-  NoQueries {
-    packageName = "app.cash.sqldelight.derive.schema.from.migrations.no.queries"
-    deriveSchemaFromMigrations = true
+  databases {
+    NoQueries {
+      packageName = "app.cash.sqldelight.derive.schema.from.migrations.no.queries"
+      deriveSchemaFromMigrations = true
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/diamond-dependency/app/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/diamond-dependency/app/build.gradle
@@ -2,9 +2,11 @@ apply plugin: 'kotlin'
 apply plugin: 'app.cash.sqldelight'
 
 sqldelight {
-  Database {
-    packageName = "com.example.app"
-    dependency project(":middleA")
-    dependency project(":middleB")
+  databases {
+    Database {
+      packageName = "com.example.app"
+      dependency project(":middleA")
+      dependency project(":middleB")
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/diamond-dependency/bottom/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/diamond-dependency/bottom/build.gradle
@@ -2,7 +2,9 @@ apply plugin: 'kotlin'
 apply plugin: 'app.cash.sqldelight'
 
 sqldelight {
-  Database {
-    packageName = "com.example.bottom"
+  databases {
+    Database {
+      packageName = "com.example.bottom"
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/diamond-dependency/middleA/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/diamond-dependency/middleA/build.gradle
@@ -2,8 +2,10 @@ apply plugin: 'kotlin'
 apply plugin: 'app.cash.sqldelight'
 
 sqldelight {
-  Database {
-    packageName = "com.example.middlea"
-    dependency project(":bottom")
+  databases {
+    Database {
+      packageName = "com.example.middlea"
+      dependency project(":bottom")
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/diamond-dependency/middleB/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/diamond-dependency/middleB/build.gradle
@@ -2,8 +2,10 @@ apply plugin: 'kotlin'
 apply plugin: 'app.cash.sqldelight'
 
 sqldelight {
-  Database {
-    packageName = "com.example.middleb"
-    dependency project(":bottom")
+  databases {
+    Database {
+      packageName = "com.example.middleb"
+      dependency project(":bottom")
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/integration-android-library/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-android-library/build.gradle
@@ -25,8 +25,10 @@ dependencies {
 }
 
 sqldelight {
-  QueryWrapper {
-    
+  databases {
+    QueryWrapper {
+
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/integration-android-variants/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-android-variants/build.gradle
@@ -21,8 +21,10 @@ dependencies {
 }
 
 sqldelight {
-  QueryWrapper {
-    
+  databases {
+    QueryWrapper {
+
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/integration-android/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-android/build.gradle
@@ -25,8 +25,10 @@ dependencies {
 }
 
 sqldelight {
-  QueryWrapper {
-    
+  databases {
+    QueryWrapper {
+
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/integration-catalog/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-catalog/build.gradle
@@ -6,9 +6,11 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'app.cash.sqldelight'
 
 sqldelight {
-  MyDatabase {
-    packageName = "app.cash.sqldelight.mysql.integration"
-    dialect(libs.sqldelight.mysql)
+  databases {
+    MyDatabase {
+      packageName = "app.cash.sqldelight.mysql.integration"
+      dialect(libs.sqldelight.mysql)
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/integration-hsql/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-hsql/build.gradle
@@ -6,10 +6,12 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'app.cash.sqldelight'
 
 sqldelight {
+  databases {
     MyDatabase {
         packageName = "app.cash.sqldelight.hsql.integration"
         dialect("app.cash.sqldelight:hsql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
     }
+  }
 }
 
 repositories {

--- a/sqldelight-gradle-plugin/src/test/integration-migration-callbacks/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-migration-callbacks/build.gradle
@@ -13,9 +13,11 @@ repositories {
 }
 
 sqldelight {
-  QueryWrapper {
-    packageName = "app.cash.sqldelight.integration"
-    deriveSchemaFromMigrations = true
+  databases {
+    QueryWrapper {
+      packageName = "app.cash.sqldelight.integration"
+      deriveSchemaFromMigrations = true
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/integration-module/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-module/build.gradle
@@ -13,10 +13,12 @@ repositories {
 }
 
 sqldelight {
-  QueryWrapper {
-    packageName = "app.cash.sqldelight.integration"
-    dialect("app.cash.sqldelight:sqlite-3-18-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
-    module("app.cash.sqldelight:sqlite-json-module:${app.cash.sqldelight.VersionKt.VERSION}")
+  databases {
+    QueryWrapper {
+      packageName = "app.cash.sqldelight.integration"
+      dialect("app.cash.sqldelight:sqlite-3-18-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+      module("app.cash.sqldelight:sqlite-json-module:${app.cash.sqldelight.VersionKt.VERSION}")
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/integration-multi-dialect-modules/mysql-module/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-multi-dialect-modules/mysql-module/build.gradle
@@ -2,9 +2,11 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'app.cash.sqldelight'
 
 sqldelight {
-  TestDb {
-    packageName = "com.example.sqlite.module"
-    dialect("app.cash.sqldelight:mysql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+  databases {
+    TestDb {
+      packageName = "com.example.sqlite.module"
+      dialect("app.cash.sqldelight:mysql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/integration-multi-dialect-modules/sqlite-module/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-multi-dialect-modules/sqlite-module/build.gradle
@@ -2,8 +2,10 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'app.cash.sqldelight'
 
 sqldelight {
-  TestDb {
-    packageName = "com.example.sqlite.module"
-    dialect("app.cash.sqldelight:sqlite-3-35-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+  databases {
+    TestDb {
+      packageName = "com.example.sqlite.module"
+      dialect("app.cash.sqldelight:sqlite-3-35-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/integration-multiplatform/android-build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-multiplatform/android-build.gradle
@@ -31,8 +31,10 @@ android {
 }
 
 sqldelight {
-  QueryWrapper {
-    packageName = "app.cash.sqldelight.integration"
+  databases {
+    QueryWrapper {
+      packageName = "app.cash.sqldelight.integration"
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/integration-multiplatform/ios-build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-multiplatform/ios-build.gradle
@@ -13,8 +13,10 @@ repositories {
 }
 
 sqldelight {
-  QueryWrapper {
-    packageName = "app.cash.sqldelight.integration"
+  databases {
+    QueryWrapper {
+      packageName = "app.cash.sqldelight.integration"
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/integration-mysql-async/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-mysql-async/build.gradle
@@ -6,10 +6,12 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'app.cash.sqldelight'
 
 sqldelight {
-  MyDatabase {
-    packageName = "app.cash.sqldelight.mysql.integration.async"
-    dialect("app.cash.sqldelight:mysql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
-    generateAsync = true
+  databases {
+    MyDatabase {
+      packageName = "app.cash.sqldelight.mysql.integration.async"
+      dialect("app.cash.sqldelight:mysql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+      generateAsync = true
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/integration-mysql-schema/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-mysql-schema/build.gradle
@@ -6,10 +6,12 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'app.cash.sqldelight'
 
 sqldelight {
-  MyDatabase {
-    packageName = "app.cash.sqldelight.mysql.integration"
-    dialect("app.cash.sqldelight:mysql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
-    deriveSchemaFromMigrations = true
+  databases {
+    MyDatabase {
+      packageName = "app.cash.sqldelight.mysql.integration"
+      dialect("app.cash.sqldelight:mysql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+      deriveSchemaFromMigrations = true
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/integration-mysql/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-mysql/build.gradle
@@ -6,9 +6,11 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'app.cash.sqldelight'
 
 sqldelight {
-  MyDatabase {
-    packageName = "app.cash.sqldelight.mysql.integration"
-    dialect("app.cash.sqldelight:mysql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+  databases {
+    MyDatabase {
+      packageName = "app.cash.sqldelight.mysql.integration"
+      dialect("app.cash.sqldelight:mysql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql-async/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql-async/build.gradle
@@ -6,10 +6,12 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'app.cash.sqldelight'
 
 sqldelight {
-  MyDatabase {
-    packageName = "app.cash.sqldelight.postgresql.integration.async"
-    dialect("app.cash.sqldelight:postgresql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
-    generateAsync = true
+  databases {
+    MyDatabase {
+      packageName = "app.cash.sqldelight.postgresql.integration.async"
+      dialect("app.cash.sqldelight:postgresql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+      generateAsync = true
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql-migrations/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql-migrations/build.gradle
@@ -6,10 +6,12 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'app.cash.sqldelight'
 
 sqldelight {
-  MyDatabase {
-    packageName = "app.cash.sqldelight.postgresql.integration"
-    dialect("app.cash.sqldelight:postgresql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
-    deriveSchemaFromMigrations = true
+  databases {
+    MyDatabase {
+      packageName = "app.cash.sqldelight.postgresql.integration"
+      dialect("app.cash.sqldelight:postgresql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+      deriveSchemaFromMigrations = true
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/build.gradle
@@ -6,9 +6,11 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'app.cash.sqldelight'
 
 sqldelight {
-  MyDatabase {
-    packageName = "app.cash.sqldelight.postgresql.integration"
-    dialect("app.cash.sqldelight:postgresql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+  databases {
+    MyDatabase {
+      packageName = "app.cash.sqldelight.postgresql.integration"
+      dialect("app.cash.sqldelight:postgresql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/integration-sqlite-3-24/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-sqlite-3-24/build.gradle
@@ -13,9 +13,11 @@ repositories {
 }
 
 sqldelight {
-  QueryWrapper {
-    packageName = "app.cash.sqldelight.integration"
-    dialect("app.cash.sqldelight:sqlite-3-24-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+  databases {
+    QueryWrapper {
+      packageName = "app.cash.sqldelight.integration"
+      dialect("app.cash.sqldelight:sqlite-3-24-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/integration-sqlite-3-35/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-sqlite-3-35/build.gradle
@@ -13,9 +13,11 @@ repositories {
 }
 
 sqldelight {
-  QueryWrapper {
-    packageName = "app.cash.sqldelight.integration"
-    dialect("app.cash.sqldelight:sqlite-3-35-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+  databases {
+    QueryWrapper {
+      packageName = "app.cash.sqldelight.integration"
+      dialect("app.cash.sqldelight:sqlite-3-35-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/integration-sqlite-json/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-sqlite-json/build.gradle
@@ -13,10 +13,12 @@ repositories {
 }
 
 sqldelight {
-  QueryWrapper {
-    packageName = "app.cash.sqldelight.integration"
-    dialect("app.cash.sqldelight:sqlite-3-18-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
-    module("app.cash.sqldelight:sqlite-json-module:${app.cash.sqldelight.VersionKt.VERSION}")
+  databases {
+    QueryWrapper {
+      packageName = "app.cash.sqldelight.integration"
+      dialect("app.cash.sqldelight:sqlite-3-18-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+      module("app.cash.sqldelight:sqlite-json-module:${app.cash.sqldelight.VersionKt.VERSION}")
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/integration/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration/build.gradle
@@ -13,8 +13,10 @@ repositories {
 }
 
 sqldelight {
-  QueryWrapper {
-    packageName = "app.cash.sqldelight.integration"
+  databases {
+    QueryWrapper {
+      packageName = "app.cash.sqldelight.integration"
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/kotlin-js/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/kotlin-js/build.gradle
@@ -21,7 +21,9 @@ kotlin {
 }
 
 sqldelight {
-  Database {
-    packageName = "com.sample"
+  databases {
+    Database {
+      packageName = "com.sample"
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/kotlin-mpp-1.3.20/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/kotlin-mpp-1.3.20/build.gradle
@@ -13,8 +13,10 @@ repositories {
 }
 
 sqldelight {
-  Database {
-    packageName = "com.sample"
+  databases {
+    Database {
+      packageName = "com.sample"
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/kotlin-mpp-configure-on-demand/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/kotlin-mpp-configure-on-demand/build.gradle
@@ -13,8 +13,10 @@ repositories {
 }
 
 sqldelight {
-  Database {
-    packageName = "com.sample"
+  databases {
+    Database {
+      packageName = "com.sample"
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/kotlin-mpp/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/kotlin-mpp/build.gradle
@@ -13,8 +13,10 @@ repositories {
 }
 
 sqldelight {
-  Database {
-    packageName = "com.sample"
+  databases {
+    Database {
+      packageName = "com.sample"
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/properties/PropertiesFileTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/properties/PropertiesFileTest.kt
@@ -76,8 +76,10 @@ class PropertiesFileTest {
         |}
         |
         |sqldelight {
-        |  CashDatabase {
-        |    packageName = "app.cash.sqldelight.sample"
+        |  databases {
+        |    CashDatabase {
+        |      packageName = "app.cash.sqldelight.sample"
+        |    }
         |  }
         |}
         |

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/CompilationUnitTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/CompilationUnitTests.kt
@@ -29,8 +29,10 @@ class CompilationUnitTests {
         |}
         |
         |sqldelight {
-        |  CommonDb {
-        |    packageName = "com.sample"
+        |  databases {
+        |    CommonDb {
+        |      packageName = "com.sample"
+        |    }
         |  }
         |}
         """.trimMargin(),
@@ -73,14 +75,16 @@ class CompilationUnitTests {
         |}
         |
         |sqldelight {
-        |  CommonDb {
-        |    packageName = "com.sample"
-        |  }
+        |  databases {
+        |    CommonDb {
+        |      packageName = "com.sample"
+        |    }
         |
-        |  OtherDb {
-        |    packageName = "com.sample.otherdb"
-        |    sourceFolders = ["sqldelight", "otherdb"]
-        |    treatNullAsUnknownForEquality = true
+        |    OtherDb {
+        |      packageName = "com.sample.otherdb"
+        |      sourceFolders = ["sqldelight", "otherdb"]
+        |      treatNullAsUnknownForEquality = true
+        |    }
         |  }
         |}
         """.trimMargin(),
@@ -143,8 +147,10 @@ class CompilationUnitTests {
         |}
         |
         |sqldelight {
-        |  CommonDb {
-        |    packageName = "com.sample"
+        |  databases {
+        |    CommonDb {
+        |      packageName = "com.sample"
+        |    }
         |  }
         |}
         |
@@ -197,8 +203,10 @@ class CompilationUnitTests {
         |}
         |
         |sqldelight {
-        |  CommonDb {
-        |    packageName = "com.sample"
+        |  databases {
+        |    CommonDb {
+        |      packageName = "com.sample"
+        |    }
         |  }
         |}
         |
@@ -275,8 +283,10 @@ class CompilationUnitTests {
         |}
         |
         |sqldelight {
-        |  CommonDb {
-        |    packageName = "com.sample"
+        |  databases {
+        |    CommonDb {
+        |      packageName = "com.sample"
+        |    }
         |  }
         |}
         |

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/GradlePluginCombinationTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/GradlePluginCombinationTests.kt
@@ -25,8 +25,10 @@ class GradlePluginCombinationTests {
         |}
         |
         |sqldelight {
-        |  CommonDb {
-        |    packageName = "com.sample"
+        |  databases {
+        |    CommonDb {
+        |      packageName = "com.sample"
+        |    }
         |  }
         |}
         |
@@ -68,8 +70,10 @@ class GradlePluginCombinationTests {
     |
     |sqldelight {
     |  linkSqlite = false
-    |  CommonDb {
-    |    packageName = "com.sample"
+    |  databases {
+    |    CommonDb {
+    |      packageName = "com.sample"
+    |    }
     |  }
     |}
     |

--- a/sqldelight-gradle-plugin/src/test/migration-definition-failure/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/migration-definition-failure/build.gradle
@@ -13,8 +13,10 @@ repositories {
 }
 
 sqldelight {
-  Database {
-    packageName = "com.example"
-    verifyMigrations = true
+  databases {
+    Database {
+      packageName = "com.example"
+      verifyMigrations = true
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/migration-failure-name/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/migration-failure-name/build.gradle
@@ -13,7 +13,9 @@ repositories {
 }
 
 sqldelight {
-  Database {
-    packageName = "com.example"
+  databases {
+    Database {
+      packageName = "com.example"
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/migration-failure/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/migration-failure/build.gradle
@@ -13,7 +13,9 @@ repositories {
 }
 
 sqldelight {
-  Database {
-    packageName = "com.example"
+  databases {
+    Database {
+      packageName = "com.example"
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/migration-gap-failure/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/migration-gap-failure/build.gradle
@@ -13,7 +13,9 @@ repositories {
 }
 
 sqldelight {
-  Database {
-    packageName = "com.example"
+  databases {
+    Database {
+      packageName = "com.example"
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/migration-incomplete-verification-disabled/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/migration-incomplete-verification-disabled/build.gradle
@@ -13,7 +13,9 @@ repositories {
 }
 
 sqldelight {
-  Database {
-    packageName = "com.example"
+  databases {
+    Database {
+      packageName = "com.example"
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/migration-incomplete/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/migration-incomplete/build.gradle
@@ -13,8 +13,10 @@ repositories {
 }
 
 sqldelight {
-  Database {
-    packageName = "com.example"
-    verifyMigrations = true
+  databases {
+    Database {
+      packageName = "com.example"
+      verifyMigrations = true
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/migration-schema-failure/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/migration-schema-failure/build.gradle
@@ -13,8 +13,10 @@ repositories {
 }
 
 sqldelight {
-  Database {
-    packageName = "com.example"
-    deriveSchemaFromMigrations = true
+  databases {
+    Database {
+      packageName = "com.example"
+      deriveSchemaFromMigrations = true
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/migration-squash/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/migration-squash/build.gradle
@@ -6,23 +6,25 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'app.cash.sqldelight'
 
 sqldelight {
-  mysqlDatabase {
-    sourceFolders = ["sqldelight/mysql"]
-    packageName = "app.cash.sqldelight.mysql.integration"
-    dialect("app.cash.sqldelight:mysql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
-    deriveSchemaFromMigrations = true
-  }
-  postgresDatabase {
-    sourceFolders = ["sqldelight/postgres"]
-    packageName = "app.cash.sqldelight.postgres.integration"
-    dialect("app.cash.sqldelight:postgresql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
-    deriveSchemaFromMigrations = true
-  }
-  sqliteDatabase {
-    sourceFolders = ["sqldelight/sqlite"]
-    packageName = "app.cash.sqldelight.sqlite.integration"
-    dialect("app.cash.sqldelight:sqlite-3-35-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
-    deriveSchemaFromMigrations = true
+  databases {
+    mysqlDatabase {
+      sourceFolders = ["sqldelight/mysql"]
+      packageName = "app.cash.sqldelight.mysql.integration"
+      dialect("app.cash.sqldelight:mysql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+      deriveSchemaFromMigrations = true
+    }
+    postgresDatabase {
+      sourceFolders = ["sqldelight/postgres"]
+      packageName = "app.cash.sqldelight.postgres.integration"
+      dialect("app.cash.sqldelight:postgresql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+      deriveSchemaFromMigrations = true
+    }
+    sqliteDatabase {
+      sourceFolders = ["sqldelight/sqlite"]
+      packageName = "app.cash.sqldelight.sqlite.integration"
+      dialect("app.cash.sqldelight:sqlite-3-35-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+      deriveSchemaFromMigrations = true
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/migration-success-db-directory-name/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/migration-success-db-directory-name/build.gradle
@@ -13,8 +13,10 @@ repositories {
 }
 
 sqldelight {
-  Database {
-    packageName = "com.example"
-    verifyMigrations = true
+  databases {
+    Database {
+      packageName = "com.example"
+      verifyMigrations = true
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/migration-success/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/migration-success/build.gradle
@@ -13,8 +13,10 @@ repositories {
 }
 
 sqldelight {
-  Database {
-    packageName = "com.example"
-    verifyMigrations = true
+  databases {
+    Database {
+      packageName = "com.example"
+      verifyMigrations = true
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/migration-syntax-failure/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/migration-syntax-failure/build.gradle
@@ -13,7 +13,9 @@ repositories {
 }
 
 sqldelight {
-  Database {
-    packageName = "com.example"
+  databases {
+    Database {
+      packageName = "com.example"
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/missing-database-file-verification-disabled/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/missing-database-file-verification-disabled/build.gradle
@@ -13,8 +13,10 @@ repositories {
 }
 
 sqldelight {
-  Database {
-    packageName = "com.example"
-    verifyMigrations = false
+  databases {
+    Database {
+      packageName = "com.example"
+      verifyMigrations = false
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/missing-database-file-verification-enabled/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/missing-database-file-verification-enabled/build.gradle
@@ -13,8 +13,10 @@ repositories {
 }
 
 sqldelight {
-  Database {
-    packageName = "com.example"
-    verifyMigrations = true
+  databases {
+    Database {
+      packageName = "com.example"
+      verifyMigrations = true
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/multi-module/AndroidProject/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/multi-module/AndroidProject/build.gradle
@@ -3,9 +3,11 @@ apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'app.cash.sqldelight'
 
 sqldelight {
-  CommonDb {
-    packageName = "com.sample.android"
-    dependency project(":MultiplatformProject")
+  databases {
+    CommonDb {
+      packageName = "com.sample.android"
+      dependency project(":MultiplatformProject")
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/multi-module/MultiplatformProject/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/multi-module/MultiplatformProject/build.gradle
@@ -3,8 +3,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'app.cash.sqldelight'
 
 sqldelight {
-  CommonDb {
-    packageName = "com.sample"
+  databases {
+    CommonDb {
+      packageName = "com.sample"
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/multi-module/ProjectA/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/multi-module/ProjectA/build.gradle
@@ -2,10 +2,12 @@ apply plugin: 'kotlin'
 apply plugin: 'app.cash.sqldelight'
 
 sqldelight {
-  Database {
-    packageName = "com.example"
-    schemaOutputDirectory = file('src/main/sqldelight/databases')
-    dependency project(':ProjectB')
+  databases {
+    Database {
+      packageName = "com.example"
+      schemaOutputDirectory = file('src/main/sqldelight/databases')
+      dependency project(':ProjectB')
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/multi-module/ProjectB/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/multi-module/ProjectB/build.gradle
@@ -2,8 +2,10 @@ apply plugin: 'kotlin'
 apply plugin: 'app.cash.sqldelight'
 
 sqldelight {
-  Database {
-    packageName = "com.projectb.example"
-    schemaOutputDirectory = file('src/main/sqldelight/databases')
+  databases {
+    Database {
+      packageName = "com.projectb.example"
+      schemaOutputDirectory = file('src/main/sqldelight/databases')
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/multiple-project-migration-success/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/multiple-project-migration-success/build.gradle
@@ -13,14 +13,16 @@ repositories {
 }
 
 sqldelight {
-  DatabaseA {
-    packageName = "com.example"
-    sourceFolders = ["projectA"]
-    verifyMigrations = true
-  }
-  DatabaseB {
-    packageName = "com.example"
-    sourceFolders = ["projectB"]
-    verifyMigrations = true
+  databases {
+    DatabaseA {
+      packageName = "com.example"
+      sourceFolders = ["projectA"]
+      verifyMigrations = true
+    }
+    DatabaseB {
+      packageName = "com.example"
+      sourceFolders = ["projectB"]
+      verifyMigrations = true
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/multithreaded-sqlite/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/multithreaded-sqlite/build.gradle
@@ -19,9 +19,11 @@ dependencies {
 }
 
 sqldelight {
-  Database {
-    packageName = "com.example.db"
-    schemaOutputDirectory = file("src/main/sqldelight/databases")
-    dialect("app.cash.sqldelight:sqlite-3-24-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+  databases {
+    Database {
+      packageName = "com.example.db"
+      schemaOutputDirectory = file("src/main/sqldelight/databases")
+      dialect("app.cash.sqldelight:sqlite-3-24-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/no-kotlin-android/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/no-kotlin-android/build.gradle
@@ -21,7 +21,9 @@ android {
 }
 
 sqldelight {
-  Database {
-    schemaOutputDirectory = file('src/main/sqldelight/databases')
+  databases {
+    Database {
+      schemaOutputDirectory = file('src/main/sqldelight/databases')
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/no-package/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/no-package/build.gradle
@@ -13,7 +13,9 @@ repositories {
 }
 
 sqldelight {
-  Database {
-    packageName = "com.example"
+  databases {
+    Database {
+      packageName = "com.example"
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/properties-file/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/properties-file/build.gradle
@@ -13,7 +13,9 @@ repositories {
 }
 
 sqldelight {
-  Database {
-    packageName = "com.example"
+  databases {
+    Database {
+      packageName = "com.example"
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/schema-file-android/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/schema-file-android/build.gradle
@@ -24,7 +24,9 @@ android {
 }
 
 sqldelight {
-  Database {
-    schemaOutputDirectory = file('src/main/sqldelight/databases')
+  databases {
+    Database {
+      schemaOutputDirectory = file('src/main/sqldelight/databases')
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/schema-file-sqm/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/schema-file-sqm/build.gradle
@@ -13,8 +13,10 @@ repositories {
 }
 
 sqldelight {
-  Database {
-    packageName = "com.example"
-    schemaOutputDirectory = file('src/main/sqldelight/databases')
+  databases {
+    Database {
+      packageName = "com.example"
+      schemaOutputDirectory = file('src/main/sqldelight/databases')
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/schema-file/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/schema-file/build.gradle
@@ -13,8 +13,10 @@ repositories {
 }
 
 sqldelight {
-  Database {
-    packageName = "com.example"
-    schemaOutputDirectory = file('src/main/sqldelight/databases')
+  databases {
+    Database {
+      packageName = "com.example"
+      schemaOutputDirectory = file('src/main/sqldelight/databases')
+    }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/schema-output/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/schema-output/build.gradle
@@ -6,11 +6,13 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'app.cash.sqldelight'
 
 sqldelight {
-  MyDatabase {
-    packageName = "app.cash.sqldelight.mysql.integration"
-    dialect("app.cash.sqldelight:mysql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
-    migrationOutputDirectory = file("build/resources/migrations")
-    migrationOutputFileFormat = ".sql"
+  databases {
+    MyDatabase {
+      packageName = "app.cash.sqldelight.mysql.integration"
+      dialect("app.cash.sqldelight:mysql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+      migrationOutputDirectory = file("build/resources/migrations")
+      migrationOutputFileFormat = ".sql"
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/selectWithoutFrom/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/selectWithoutFrom/build.gradle
@@ -6,9 +6,11 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'app.cash.sqldelight'
 
 sqldelight {
-  MyDatabase {
-    packageName = "com.sample"
-    dialect("app.cash.sqldelight:postgresql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+  databases {
+    MyDatabase {
+      packageName = "com.sample"
+      dialect("app.cash.sqldelight:postgresql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/task-dependencies/build.gradle.kts
+++ b/sqldelight-gradle-plugin/src/test/task-dependencies/build.gradle.kts
@@ -13,9 +13,11 @@ repositories {
 }
 
 configure<SqlDelightExtension> {
-  database("Database") {
-    packageName = "com.example"
-    schemaOutputDirectory = file("src/main/sqldelight/databases")
+  databases {
+    create("Database") {
+      packageName = "com.example"
+      schemaOutputDirectory = file("src/main/sqldelight/databases")
+    }
   }
 }
 

--- a/sqldelight-gradle-plugin/src/test/task-dependencies/build.gradle.kts
+++ b/sqldelight-gradle-plugin/src/test/task-dependencies/build.gradle.kts
@@ -15,8 +15,8 @@ repositories {
 configure<SqlDelightExtension> {
   databases {
     create("Database") {
-      packageName = "com.example"
-      schemaOutputDirectory = file("src/main/sqldelight/databases")
+      packageName.set("com.example")
+      schemaOutputDirectory.set(file("src/main/sqldelight/databases"))
     }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/verify-migration-disabled-no-errors/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/verify-migration-disabled-no-errors/build.gradle
@@ -13,9 +13,11 @@ repositories {
 }
 
 sqldelight {
-  Database {
-    packageName = "com.example"
-    dialect("app.cash.sqldelight:hsql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
-    verifyMigrations = false
+  databases {
+    Database {
+      packageName = "com.example"
+      dialect("app.cash.sqldelight:hsql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+      verifyMigrations = false
+    }
   }
 }


### PR DESCRIPTION
This is an opportunity for SQLDelight 2.0.0 IMHO.

Configuration for the Gradle plugin is currently managed entirely with the extension (as opposed to the task), which I've updated in two ways:
1. Simplified the implementation. This is a breaking change for Kotlin & Groovy DSL users, but a mechanical update to build scripts. Resolves a planned Gradle 9 deprecation (no more [`ConfigureUtil`](https://docs.gradle.org/8.0-rc-1/javadoc/org/gradle/util/ConfigureUtil.html)).
2. Switched to the lazy property API in the extension and `SqlDelightDatabase`. This is a breaking change for Kotlin DSL users, but not Groovy. [Gradle is encouraging its use](https://docs.gradle.org/7.4.2/userguide/custom_gradle_types.html#java_bean_properties) and considers use of getter/setter methods (including those generated by Kotlin) to be legacy. Again, a simple update to build scripts is required.

All users will have have to wrap database declarations in a `databases {}` block. Kotlin users will have to use `create("databaseName")` to create a database, and use `.set` on properties:

```groovy
sqldelight {
  databases { // new wrapper
    Database {
      packageName = "com.sample"
    }
  }
}
```

```kotlin
sqldelight {
  databases { // new wrapper
    create("Database") {
      packageName.set("com.sample") // packageName is now a Property<String>
    }
  }
}
```

I started going further by migrating to lazy properties in the tasks as well, but as these are not documented APIs, and it's more complex to achieve, I think this can be done after 2.0.0 is released as time and motivation allows.

If this is acceptable I will update docs & generated code snippets such as this, as part of this PR: https://github.com/cashapp/sqldelight/blob/d21d2ee310a9e96f5227f10d4920eafa27806914/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/android/PackageName.kt#L20-L24