### PR TITLE
Stop publishing with insecure checksums

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,6 @@ POM_DEVELOPER_NAME=Square, Inc.
 
 SONATYPE_HOST=DEFAULT
 
-systemProp.org.gradle.internal.publish.checksums.insecure=true
-
 android.useAndroidX=true
 
 # Compile JS for legacy backend and new IR backend.


### PR DESCRIPTION
My understanding this would only have been required for two reasons:
1. If publishing using the `maven` plugin - which was removed in Gradle 7, so no longer relevant
2. If external repository being published to does not support the newer checksums - I believe artifacts are only published to Maven Central, JetBrains Marketplace, Gradle Plugin Portal & Sonatype's snapshots repo, which I assume all support these checksums by now.