### PR TITLE
Postgres: Fix copy with same name in multiple tables

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/CopyMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/CopyMixin.kt
@@ -3,14 +3,13 @@ package app.cash.sqldelight.dialects.postgresql.grammar.mixins
 import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlCopyStdin
 import com.alecstrong.sql.psi.core.psi.QueryElement.QueryResult
 import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
+import com.alecstrong.sql.psi.core.psi.SqlTableName
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 
 internal abstract class CopyMixin(node: ASTNode) : SqlCompositeElementImpl(node), PostgreSqlCopyStdin {
   override fun queryAvailable(child: PsiElement): Collection<QueryResult> {
-    val tables = tablesAvailable(child)
-    return tables.map {
-      it.query
-    }
+    val tableName = child.parent.children.filterIsInstance<SqlTableName>().single()
+    return tableAvailable(child, tableName.name)
   }
 }

--- a/dialects/postgresql/src/test/fixtures_postgresql/copy/Sample.s
+++ b/dialects/postgresql/src/test/fixtures_postgresql/copy/Sample.s
@@ -2,6 +2,10 @@ CREATE TABLE person (
   name TEXT NOT NULL
 );
 
+CREATE TABLE group (
+  name TEXT NOT NULL
+);
+
 COPY person (name)
 FROM STDIN
 (


### PR DESCRIPTION
Old implementation: Error `Multiple columns found with name name`