### PR TITLE
Remove suspend and await from `Query<T>.execute()` overrides

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/QueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/QueryGenerator.kt
@@ -246,8 +246,10 @@ abstract class QueryGenerator(
       binder = "%L"
     }
     if (generateAsync) {
-      binder += "%L"
-      arguments.add(".await()")
+      awaiting()?.let { (bind, arg) ->
+        binder += bind
+        arguments.add(arg)
+      }
     }
 
     val statementId = if (needsFreshStatement) "null" else "$id"
@@ -299,4 +301,6 @@ abstract class QueryGenerator(
   protected fun addJavadoc(builder: FunSpec.Builder) {
     if (query.javadoc != null) javadocText(query.javadoc)?.let { builder.addKdoc(it) }
   }
+
+  protected open fun awaiting(): Pair<String, String>? = "%L" to ".await()"
 }

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SelectQueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SelectQueryGenerator.kt
@@ -89,7 +89,6 @@ class SelectQueryGenerator(
       .build()
 
     return function
-      .apply { if (generateAsync) addModifiers(SUSPEND) }
       .addStatement(
         "return %L",
         CodeBlock
@@ -301,7 +300,6 @@ class SelectQueryGenerator(
     val genericResultType = TypeVariableName("R")
     val createStatementFunction = FunSpec.builder(EXECUTE_METHOD)
       .addModifiers(OVERRIDE)
-      .apply { if (generateAsync) addModifiers(SUSPEND) }
       .addTypeVariable(genericResultType)
       .addParameter(MAPPER_NAME, LambdaTypeName.get(parameters = arrayOf(CURSOR_TYPE), returnType = genericResultType))
       .returns(QUERY_RESULT_TYPE.parameterizedBy(genericResultType))
@@ -359,4 +357,6 @@ class SelectQueryGenerator(
       )
       .build()
   }
+
+  override fun awaiting(): Pair<String, String>? = null
 }

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SelectQueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SelectQueryGenerator.kt
@@ -41,7 +41,6 @@ import com.squareup.kotlinpoet.KModifier.INNER
 import com.squareup.kotlinpoet.KModifier.OUT
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
 import com.squareup.kotlinpoet.KModifier.PRIVATE
-import com.squareup.kotlinpoet.KModifier.SUSPEND
 import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.NameAllocator

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/async/AsyncQueryFunctionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/async/AsyncQueryFunctionTest.kt
@@ -35,7 +35,7 @@ class AsyncQueryFunctionTest {
     val generator = SelectQueryGenerator(file.namedQueries.first())
     Truth.assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo(
       """
-      |public suspend fun selectForId(id: kotlin.Long): app.cash.sqldelight.Query<com.example.Data_> = selectForId(id) { id_, value_ ->
+      |public fun selectForId(id: kotlin.Long): app.cash.sqldelight.Query<com.example.Data_> = selectForId(id) { id_, value_ ->
       |  com.example.Data_(
       |    id_,
       |    value_

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/async/AsyncSelectQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/async/AsyncSelectQueryTypeTest.kt
@@ -133,13 +133,13 @@ class AsyncSelectQueryTypeTest {
       |    driver.removeListener(listener, arrayOf("data"))
       |  }
       |
-      |  public override suspend fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${query.id}, ""${'"'}
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${query.id}, ""${'"'}
       |  |SELECT *
       |  |FROM data
       |  |WHERE id = ?
       |  ""${'"'}.trimMargin(), mapper, 1) {
       |    bindLong(0, id)
-      |  }.await()
+      |  }
       |
       |  public override fun toString(): kotlin.String = "Test.sq:selectForId"
       |}


### PR DESCRIPTION
This fixes some codegen that was missed in the last async PR.

The overridden `execute` method for `Query` classes shouldn't have a suspend modifier and the execute block should not be awaited in the generated async code. 