### PR TITLE
Add support for suspending transactions

### DIFF
--- a/drivers/android-driver/src/main/java/app/cash/sqldelight/driver/android/AndroidSqliteDriver.kt
+++ b/drivers/android-driver/src/main/java/app/cash/sqldelight/driver/android/AndroidSqliteDriver.kt
@@ -106,7 +106,7 @@ class AndroidSqliteDriver private constructor(
     listenersToNotify.forEach(Query.Listener::queryResultsChanged)
   }
 
-  override fun newTransaction(): Transacter.Transaction {
+  override fun newTransaction(): QueryResult<Transacter.Transaction> {
     val enclosing = transactions.get()
     val transaction = Transaction(enclosing)
     transactions.set(transaction)
@@ -115,7 +115,7 @@ class AndroidSqliteDriver private constructor(
       database.beginTransactionNonExclusive()
     }
 
-    return transaction
+    return QueryResult.Value(transaction)
   }
 
   override fun currentTransaction() = transactions.get()
@@ -123,7 +123,7 @@ class AndroidSqliteDriver private constructor(
   inner class Transaction(
     override val enclosingTransaction: Transacter.Transaction?
   ) : Transacter.Transaction() {
-    override fun endTransaction(successful: Boolean) {
+    override fun endTransaction(successful: Boolean): QueryResult<Unit> = QueryResult.Value {
       if (enclosingTransaction == null) {
         if (successful) {
           database.setTransactionSuccessful()

--- a/drivers/android-driver/src/main/java/app/cash/sqldelight/driver/android/AndroidSqliteDriver.kt
+++ b/drivers/android-driver/src/main/java/app/cash/sqldelight/driver/android/AndroidSqliteDriver.kt
@@ -123,7 +123,7 @@ class AndroidSqliteDriver private constructor(
   inner class Transaction(
     override val enclosingTransaction: Transacter.Transaction?
   ) : Transacter.Transaction() {
-    override fun endTransaction(successful: Boolean): QueryResult<Unit> = QueryResult.Value {
+    override fun endTransaction(successful: Boolean): QueryResult<Unit> {
       if (enclosingTransaction == null) {
         if (successful) {
           database.setTransactionSuccessful()
@@ -133,6 +133,7 @@ class AndroidSqliteDriver private constructor(
         }
       }
       transactions.set(enclosingTransaction)
+      return QueryResult.Unit
     }
   }
 

--- a/drivers/jdbc-driver/src/main/kotlin/app/cash/sqldelight/driver/jdbc/JdbcDriver.kt
+++ b/drivers/jdbc-driver/src/main/kotlin/app/cash/sqldelight/driver/jdbc/JdbcDriver.kt
@@ -58,7 +58,7 @@ interface ConnectionManager {
     private val connectionManager: ConnectionManager,
     val connection: Connection
   ) : Transacter.Transaction() {
-    override fun endTransaction(successful: Boolean) {
+    override fun endTransaction(successful: Boolean): QueryResult<Unit> = QueryResult.Value {
       if (enclosingTransaction == null) {
         if (successful) connectionManager.apply { connection.endTransaction() }
         else connectionManager.apply { connection.rollbackTransaction() }
@@ -152,7 +152,7 @@ abstract class JdbcDriver : SqlDriver, ConnectionManager {
     }
   }
 
-  override fun newTransaction(): Transacter.Transaction {
+  override fun newTransaction(): QueryResult<Transacter.Transaction> {
     val enclosing = transaction
     val connection = enclosing?.connection ?: getConnection()
     val transaction = Transaction(enclosing, this, connection)
@@ -162,7 +162,7 @@ abstract class JdbcDriver : SqlDriver, ConnectionManager {
       connection.beginTransaction()
     }
 
-    return transaction
+    return QueryResult.Value(transaction)
   }
 
   override fun currentTransaction(): Transacter.Transaction? = transaction

--- a/drivers/jdbc-driver/src/main/kotlin/app/cash/sqldelight/driver/jdbc/JdbcDriver.kt
+++ b/drivers/jdbc-driver/src/main/kotlin/app/cash/sqldelight/driver/jdbc/JdbcDriver.kt
@@ -58,12 +58,13 @@ interface ConnectionManager {
     private val connectionManager: ConnectionManager,
     val connection: Connection
   ) : Transacter.Transaction() {
-    override fun endTransaction(successful: Boolean): QueryResult<Unit> = QueryResult.Value {
+    override fun endTransaction(successful: Boolean): QueryResult<Unit> {
       if (enclosingTransaction == null) {
         if (successful) connectionManager.apply { connection.endTransaction() }
         else connectionManager.apply { connection.rollbackTransaction() }
       }
       connectionManager.transaction = enclosingTransaction
+      return QueryResult.Unit
     }
   }
 }

--- a/drivers/native-driver/src/nativeMain/kotlin/app/cash/sqldelight/driver/native/NativeSqlDatabase.kt
+++ b/drivers/native-driver/src/nativeMain/kotlin/app/cash/sqldelight/driver/native/NativeSqlDatabase.kt
@@ -195,9 +195,9 @@ class NativeSqliteDriver(
     return borrowedConnectionThread.get()?.value?.transaction?.value
   }
 
-  override fun newTransaction(): QueryResult<Transacter.Transaction> = QueryResult.Value {
+  override fun newTransaction(): QueryResult<Transacter.Transaction> {
     val alreadyBorrowed = borrowedConnectionThread.get()
-    return@Value if (alreadyBorrowed == null) {
+    val transaction = if (alreadyBorrowed == null) {
       val borrowed = transactionPool.borrowEntry()
 
       try {
@@ -213,6 +213,8 @@ class NativeSqliteDriver(
     } else {
       alreadyBorrowed.value.newTransaction()
     }
+
+    return QueryResult.Value(transaction)
   }
 
   /**
@@ -388,7 +390,7 @@ internal class ThreadConnection(
       ensureNeverFrozen()
     }
 
-    override fun endTransaction(successful: Boolean): QueryResult<Unit> = QueryResult.Value {
+    override fun endTransaction(successful: Boolean): QueryResult<Unit> {
       transaction.value = enclosingTransaction
 
       if (enclosingTransaction == null) {
@@ -403,6 +405,7 @@ internal class ThreadConnection(
           onEndTransaction(this@ThreadConnection)
         }
       }
+      return QueryResult.Unit
     }
   }
 }

--- a/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
+++ b/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
@@ -51,15 +51,23 @@ class R2dbcDriver(private val connection: Connection) : SqlDriver {
     }
   }
 
-  private val transactions = ThreadLocal<Transaction>()
-  private var transaction: Transaction?
+  private val transactions = ThreadLocal<Transacter.Transaction>()
+  private var transaction: Transacter.Transaction?
     get() = transactions.get()
     set(value) {
       transactions.set(value)
     }
 
-  override fun newTransaction(): Transacter.Transaction {
-    throw NotImplementedError("Begin transaction manually using execute()")
+  override fun newTransaction(): QueryResult<Transacter.Transaction> = QueryResult.AsyncValue {
+    val enclosing = transaction
+    val transaction = Transaction(enclosing, connection)
+    this.transaction = transaction
+
+    if (enclosing == null) {
+      connection.beginTransaction().awaitSingle()
+    }
+
+    return@AsyncValue transaction
   }
 
   override fun currentTransaction(): Transacter.Transaction? = transaction
@@ -73,12 +81,19 @@ class R2dbcDriver(private val connection: Connection) : SqlDriver {
     connection.close()
   }
 
-  private class Transaction(
+  private inner class Transaction(
     override val enclosingTransaction: Transacter.Transaction?,
     private val connection: Connection
   ) : Transacter.Transaction() {
-    override fun endTransaction(successful: Boolean) {
-      throw NotImplementedError("End transaction manually using execute()")
+    override fun endTransaction(successful: Boolean): QueryResult<Unit> = QueryResult.AsyncValue {
+      if (enclosingTransaction == null) {
+        if (successful) {
+          connection.commitTransaction().awaitSingle()
+        } else {
+          connection.rollbackTransaction().awaitSingle()
+        }
+      }
+      transaction = enclosingTransaction
     }
   }
 }

--- a/drivers/sqljs-driver/src/main/kotlin/app/cash/sqldelight/driver/sqljs/JsSqlDriver.kt
+++ b/drivers/sqljs-driver/src/main/kotlin/app/cash/sqldelight/driver/sqljs/JsSqlDriver.kt
@@ -105,7 +105,7 @@ class JsSqlDriver(private val db: Database) : SqlDriver {
   private inner class Transaction(
     override val enclosingTransaction: Transacter.Transaction?
   ) : Transacter.Transaction() {
-    override fun endTransaction(successful: Boolean): QueryResult<Unit> = QueryResult.Value {
+    override fun endTransaction(successful: Boolean): QueryResult<Unit> {
       if (enclosingTransaction == null) {
         if (successful) {
           db.run("END TRANSACTION")
@@ -114,6 +114,7 @@ class JsSqlDriver(private val db: Database) : SqlDriver {
         }
       }
       transaction = enclosingTransaction
+      return QueryResult.Unit
     }
   }
 }

--- a/drivers/sqljs-driver/src/main/kotlin/app/cash/sqldelight/driver/sqljs/JsSqlDriver.kt
+++ b/drivers/sqljs-driver/src/main/kotlin/app/cash/sqldelight/driver/sqljs/JsSqlDriver.kt
@@ -88,14 +88,14 @@ class JsSqlDriver(private val db: Database) : SqlDriver {
     statements.getOrPut(identifier, { db.prepare(sql) }).apply { reset() }
   }
 
-  override fun newTransaction(): Transacter.Transaction {
+  override fun newTransaction(): QueryResult<Transacter.Transaction> {
     val enclosing = transaction
     val transaction = Transaction(enclosing)
     this.transaction = transaction
     if (enclosing == null) {
       db.run("BEGIN TRANSACTION")
     }
-    return transaction
+    return QueryResult.Value(transaction)
   }
 
   override fun currentTransaction() = transaction
@@ -105,7 +105,7 @@ class JsSqlDriver(private val db: Database) : SqlDriver {
   private inner class Transaction(
     override val enclosingTransaction: Transacter.Transaction?
   ) : Transacter.Transaction() {
-    override fun endTransaction(successful: Boolean) {
+    override fun endTransaction(successful: Boolean): QueryResult<Unit> = QueryResult.Value {
       if (enclosingTransaction == null) {
         if (successful) {
           db.run("END TRANSACTION")

--- a/drivers/sqljs-driver/src/test/kotlin/com/squareup/sqldelight/drivers/sqljs/JsWorkerTransacterTest.kt
+++ b/drivers/sqljs-driver/src/test/kotlin/com/squareup/sqldelight/drivers/sqljs/JsWorkerTransacterTest.kt
@@ -1,0 +1,188 @@
+package com.squareup.sqldelight.drivers.sqljs
+
+import app.cash.sqldelight.Transacter
+import app.cash.sqldelight.TransacterImpl
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlSchema
+import app.cash.sqldelight.driver.sqljs.worker.initAsyncSqlDriver
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+class JsWorkerTransacterTest {
+  private val schema = object : SqlSchema {
+    override val version = 1
+    override fun create(driver: SqlDriver) = QueryResult.Unit
+    override fun migrate(
+      driver: SqlDriver,
+      oldVersion: Int,
+      newVersion: Int
+    ): QueryResult<Unit> = QueryResult.Unit
+  }
+
+  private fun runTest(block: suspend (SqlDriver, Transacter) -> Unit) = kotlinx.coroutines.test.runTest {
+    val driver = initAsyncSqlDriver(schema = schema)
+    val transacter = object : TransacterImpl(driver) {}
+    block(driver, transacter)
+
+    driver.close()
+  }
+
+  @Test fun afterCommit_runs_after_transaction_commits() = runTest { _, transacter ->
+    var counter = 0
+    transacter.suspendingTransaction {
+      afterCommit { counter++ }
+      assertEquals(0, counter)
+    }
+
+    assertEquals(1, counter)
+  }
+
+  @Test fun afterCommit_does_not_run_after_transaction_rollbacks() = runTest { _, transacter ->
+    var counter = 0
+    transacter.suspendingTransaction {
+      afterCommit { counter++ }
+      assertEquals(0, counter)
+      rollback()
+    }
+
+    assertEquals(0, counter)
+  }
+
+  @Test fun afterCommit_runs_after_enclosing_transaction_commits() = runTest { _, transacter ->
+    var counter = 0
+    transacter.suspendingTransaction {
+      afterCommit { counter++ }
+      assertEquals(0, counter)
+
+      transactionWithResult {
+        afterCommit { counter++ }
+        assertEquals(0, counter)
+      }
+
+      assertEquals(0, counter)
+    }
+
+    assertEquals(2, counter)
+  }
+
+  @Test fun afterCommit_does_not_run_in_nested_transaction_when_enclosing_rolls_back() = runTest { _, transacter ->
+    var counter = 0
+    transacter.suspendingTransaction {
+      afterCommit { counter++ }
+      assertEquals(0, counter)
+
+      transactionWithResult {
+        afterCommit { counter++ }
+      }
+
+      rollback()
+    }
+
+    assertEquals(0, counter)
+  }
+
+  @Test fun afterCommit_does_not_run_in_nested_transaction_when_nested_rolls_back() = runTest { _, transacter ->
+    var counter = 0
+    transacter.suspendingTransaction {
+      afterCommit { counter++ }
+      assertEquals(0, counter)
+
+      transactionWithResult {
+        afterCommit { counter++ }
+        rollback()
+      }
+
+      throw AssertionError()
+    }
+
+    assertEquals(0, counter)
+  }
+
+  @Test fun afterRollback_no_ops_if_the_transaction_never_rolls_back() = runTest { _, transacter ->
+    var counter = 0
+    transacter.suspendingTransaction {
+      afterRollback { counter++ }
+    }
+
+    assertEquals(0, counter)
+  }
+
+  @Test fun afterRollback_runs_after_a_rollback_occurs() = runTest { _, transacter ->
+    var counter = 0
+    transacter.suspendingTransaction {
+      afterRollback { counter++ }
+      rollback()
+    }
+
+    assertEquals(1, counter)
+  }
+
+  @Test fun afterRollback_runs_after_an_inner_transaction_rolls_back() = runTest { _, transacter ->
+    var counter = 0
+    transacter.suspendingTransaction {
+      afterRollback { counter++ }
+      transactionWithResult {
+        rollback()
+      }
+      throw AssertionError()
+    }
+
+    assertEquals(1, counter)
+  }
+
+  @Test fun afterRollback_runs_in_an_inner_transaction_when_the_outer_transaction_rolls_back() = runTest { _, transacter ->
+    var counter = 0
+    transacter.suspendingTransaction {
+      transactionWithResult {
+        afterRollback { counter++ }
+      }
+      rollback()
+    }
+
+    assertEquals(1, counter)
+  }
+
+  @Test fun transactions_close_themselves_out_properly() = runTest { _, transacter ->
+    var counter = 0
+    transacter.suspendingTransaction {
+      afterCommit { counter++ }
+    }
+
+    transacter.suspendingTransaction {
+      afterCommit { counter++ }
+    }
+
+    assertEquals(2, counter)
+  }
+
+  @Test fun setting_no_enclosing_fails_if_there_is_a_currently_running_transaction() = runTest { _, transacter ->
+    transacter.suspendingTransaction(noEnclosing = true) {
+      assertFailsWith<IllegalStateException> {
+        transacter.suspendingTransaction(noEnclosing = true) {
+          throw AssertionError()
+        }
+      }
+    }
+  }
+
+  @Test fun an_exception_thrown_in_postRollback_function_is_combined_with_the_exception_in_the_main_body() = runTest { _, transacter ->
+    class ExceptionA : RuntimeException()
+    class ExceptionB : RuntimeException()
+    try {
+      transacter.suspendingTransaction {
+        afterRollback {
+          throw ExceptionA()
+        }
+        throw ExceptionB()
+      }
+      fail("Should have thrown!")
+    } catch (e: Throwable) {
+      assertTrue("Exception thrown in body not in message($e)") { e.toString().contains("ExceptionA") }
+      assertTrue("Exception thrown in rollback not in message($e)") { e.toString().contains("ExceptionB") }
+    }
+  }
+}

--- a/drivers/sqljs-driver/src/test/kotlin/com/squareup/sqldelight/drivers/sqljs/JsWorkerTransacterTest.kt
+++ b/drivers/sqljs-driver/src/test/kotlin/com/squareup/sqldelight/drivers/sqljs/JsWorkerTransacterTest.kt
@@ -1,7 +1,7 @@
 package com.squareup.sqldelight.drivers.sqljs
 
-import app.cash.sqldelight.Transacter
-import app.cash.sqldelight.TransacterImpl
+import app.cash.sqldelight.SuspendingTransacter
+import app.cash.sqldelight.SuspendingTransacterImpl
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
@@ -23,9 +23,9 @@ class JsWorkerTransacterTest {
     ): QueryResult<Unit> = QueryResult.Unit
   }
 
-  private fun runTest(block: suspend (SqlDriver, Transacter) -> Unit) = kotlinx.coroutines.test.runTest {
+  private fun runTest(block: suspend (SqlDriver, SuspendingTransacter) -> Unit) = kotlinx.coroutines.test.runTest {
     val driver = initAsyncSqlDriver(schema = schema)
-    val transacter = object : TransacterImpl(driver) {}
+    val transacter = object : SuspendingTransacterImpl(driver) {}
     block(driver, transacter)
 
     driver.close()
@@ -33,7 +33,7 @@ class JsWorkerTransacterTest {
 
   @Test fun afterCommit_runs_after_transaction_commits() = runTest { _, transacter ->
     var counter = 0
-    transacter.suspendingTransaction {
+    transacter.transaction {
       afterCommit { counter++ }
       assertEquals(0, counter)
     }
@@ -43,7 +43,7 @@ class JsWorkerTransacterTest {
 
   @Test fun afterCommit_does_not_run_after_transaction_rollbacks() = runTest { _, transacter ->
     var counter = 0
-    transacter.suspendingTransaction {
+    transacter.transaction {
       afterCommit { counter++ }
       assertEquals(0, counter)
       rollback()
@@ -54,7 +54,7 @@ class JsWorkerTransacterTest {
 
   @Test fun afterCommit_runs_after_enclosing_transaction_commits() = runTest { _, transacter ->
     var counter = 0
-    transacter.suspendingTransaction {
+    transacter.transaction {
       afterCommit { counter++ }
       assertEquals(0, counter)
 
@@ -71,7 +71,7 @@ class JsWorkerTransacterTest {
 
   @Test fun afterCommit_does_not_run_in_nested_transaction_when_enclosing_rolls_back() = runTest { _, transacter ->
     var counter = 0
-    transacter.suspendingTransaction {
+    transacter.transaction {
       afterCommit { counter++ }
       assertEquals(0, counter)
 
@@ -87,7 +87,7 @@ class JsWorkerTransacterTest {
 
   @Test fun afterCommit_does_not_run_in_nested_transaction_when_nested_rolls_back() = runTest { _, transacter ->
     var counter = 0
-    transacter.suspendingTransaction {
+    transacter.transaction {
       afterCommit { counter++ }
       assertEquals(0, counter)
 
@@ -104,7 +104,7 @@ class JsWorkerTransacterTest {
 
   @Test fun afterRollback_no_ops_if_the_transaction_never_rolls_back() = runTest { _, transacter ->
     var counter = 0
-    transacter.suspendingTransaction {
+    transacter.transaction {
       afterRollback { counter++ }
     }
 
@@ -113,7 +113,7 @@ class JsWorkerTransacterTest {
 
   @Test fun afterRollback_runs_after_a_rollback_occurs() = runTest { _, transacter ->
     var counter = 0
-    transacter.suspendingTransaction {
+    transacter.transaction {
       afterRollback { counter++ }
       rollback()
     }
@@ -123,7 +123,7 @@ class JsWorkerTransacterTest {
 
   @Test fun afterRollback_runs_after_an_inner_transaction_rolls_back() = runTest { _, transacter ->
     var counter = 0
-    transacter.suspendingTransaction {
+    transacter.transaction {
       afterRollback { counter++ }
       transactionWithResult {
         rollback()
@@ -136,7 +136,7 @@ class JsWorkerTransacterTest {
 
   @Test fun afterRollback_runs_in_an_inner_transaction_when_the_outer_transaction_rolls_back() = runTest { _, transacter ->
     var counter = 0
-    transacter.suspendingTransaction {
+    transacter.transaction {
       transactionWithResult {
         afterRollback { counter++ }
       }
@@ -148,11 +148,11 @@ class JsWorkerTransacterTest {
 
   @Test fun transactions_close_themselves_out_properly() = runTest { _, transacter ->
     var counter = 0
-    transacter.suspendingTransaction {
+    transacter.transaction {
       afterCommit { counter++ }
     }
 
-    transacter.suspendingTransaction {
+    transacter.transaction {
       afterCommit { counter++ }
     }
 
@@ -160,9 +160,9 @@ class JsWorkerTransacterTest {
   }
 
   @Test fun setting_no_enclosing_fails_if_there_is_a_currently_running_transaction() = runTest { _, transacter ->
-    transacter.suspendingTransaction(noEnclosing = true) {
+    transacter.transaction(noEnclosing = true) {
       assertFailsWith<IllegalStateException> {
-        transacter.suspendingTransaction(noEnclosing = true) {
+        transacter.transaction(noEnclosing = true) {
           throw AssertionError()
         }
       }
@@ -173,7 +173,7 @@ class JsWorkerTransacterTest {
     class ExceptionA : RuntimeException()
     class ExceptionB : RuntimeException()
     try {
-      transacter.suspendingTransaction {
+      transacter.transaction {
         afterRollback {
           throw ExceptionA()
         }

--- a/runtime/src/commonMain/kotlin/app/cash/sqldelight/db/QueryResult.kt
+++ b/runtime/src/commonMain/kotlin/app/cash/sqldelight/db/QueryResult.kt
@@ -17,6 +17,8 @@ sealed interface QueryResult<T> {
   suspend fun await(): T
 
   data class Value<T>(override val value: T) : QueryResult<T> {
+    constructor(block: () -> T) : this(block())
+
     override suspend fun await() = value
   }
 

--- a/runtime/src/commonMain/kotlin/app/cash/sqldelight/db/QueryResult.kt
+++ b/runtime/src/commonMain/kotlin/app/cash/sqldelight/db/QueryResult.kt
@@ -17,8 +17,6 @@ sealed interface QueryResult<T> {
   suspend fun await(): T
 
   data class Value<T>(override val value: T) : QueryResult<T> {
-    constructor(block: () -> T) : this(block())
-
     override suspend fun await() = value
   }
 

--- a/runtime/src/commonMain/kotlin/app/cash/sqldelight/db/SqlDriver.kt
+++ b/runtime/src/commonMain/kotlin/app/cash/sqldelight/db/SqlDriver.kt
@@ -72,7 +72,7 @@ interface SqlDriver : Closeable {
    *
    * It's up to the implementor how this method behaves for different connection/threading patterns.
    */
-  fun newTransaction(): Transacter.Transaction
+  fun newTransaction(): QueryResult<Transacter.Transaction>
 
   /**
    * The currently open [Transacter.Transaction] on the database.

--- a/runtime/src/commonMain/kotlin/app/cash/sqldelight/logs/LogSqliteDriver.kt
+++ b/runtime/src/commonMain/kotlin/app/cash/sqldelight/logs/LogSqliteDriver.kt
@@ -54,12 +54,12 @@ class LogSqliteDriver(
     return sqlDriver.executeQuery(identifier, sql, mapper, parameters, binders)
   }
 
-  override fun newTransaction(): Transacter.Transaction {
+  override fun newTransaction(): QueryResult<Transacter.Transaction> {
     logger("TRANSACTION BEGIN")
-    val transaction = sqlDriver.newTransaction()
+    val transaction = sqlDriver.newTransaction().value
     transaction.afterCommit { logger("TRANSACTION COMMIT") }
     transaction.afterRollback { logger("TRANSACTION ROLLBACK") }
-    return transaction
+    return QueryResult.Value(transaction)
   }
 
   override fun close() {

--- a/runtime/src/commonTest/kotlin/com/squareup/sqldelight/logs/LogSqliteDriverTest.kt
+++ b/runtime/src/commonTest/kotlin/com/squareup/sqldelight/logs/LogSqliteDriverTest.kt
@@ -107,8 +107,8 @@ class FakeSqlDriver : SqlDriver {
     return QueryResult.Value(0)
   }
 
-  override fun newTransaction(): Transaction {
-    return FakeTransaction()
+  override fun newTransaction(): QueryResult<Transaction> {
+    return QueryResult.Value(FakeTransaction())
   }
 
   override fun currentTransaction(): Transaction? {
@@ -157,6 +157,5 @@ class FakeSqlCursor : SqlCursor {
 class FakeTransaction : Transaction() {
   override val enclosingTransaction: Transaction? = null
 
-  override fun endTransaction(successful: Boolean) {
-  }
+  override fun endTransaction(successful: Boolean): QueryResult<Unit> = QueryResult.Unit
 }

--- a/sample/kotlin-js-store/yarn.lock
+++ b/sample/kotlin-js-store/yarn.lock
@@ -28,17 +28,47 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@types/body-parser@*":
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.2.tgz#aea2059e28b7658639081347ac4fab3de166e6f0"
+  integrity sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
+"@types/bonjour@^3.5.9":
+  version "3.5.10"
+  resolved "https://registry.yarnpkg.com/@types/bonjour/-/bonjour-3.5.10.tgz#0f6aadfe00ea414edc86f5d106357cda9701e275"
+  integrity sha512-p7ienRMiS41Nu2/igbJxxLDWrSZ0WxM8UQgCeO9KhoVF7cOVFkrKsiDr1EsJIla8vV3oEEjGcz11jc5yimhzZw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/component-emitter@^1.2.10":
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/@types/component-emitter/-/component-emitter-1.2.11.tgz#50d47d42b347253817a39709fef03ce66a108506"
   integrity sha512-SRXjM+tfsSlA9VuG8hGO2nft2p8zjXCK1VcC6N4NXbBbYbSia9kzCChYQajIjzIqOOOuh5Ock6MmV2oux4jDZQ==
 
-"@types/cookie@^0.4.0":
+"@types/connect-history-api-fallback@^1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz#d1f7a8a09d0ed5a57aee5ae9c18ab9b803205dae"
+  integrity sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==
+  dependencies:
+    "@types/express-serve-static-core" "*"
+    "@types/node" "*"
+
+"@types/connect@*":
+  version "3.4.35"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1"
+  integrity sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/cookie@^0.4.0", "@types/cookie@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
   integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
 
-"@types/cors@^2.8.8":
+"@types/cors@^2.8.12", "@types/cors@^2.8.8":
   version "2.8.12"
   resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.12.tgz#6b2c510a7ad7039e98e7b8d3d6598f4359e5c080"
   integrity sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==
@@ -47,6 +77,14 @@
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.2.tgz#11e96a868c67acf65bf6f11d10bb89ea71d5e473"
   integrity sha512-TzgYCWoPiTeRg6RQYgtuW7iODtVoKu3RVL72k3WohqhjfaOLK5Mg2T4Tg1o2bSfu0vPkoI48wdQFv5b/Xe04wQ==
+  dependencies:
+    "@types/eslint" "*"
+    "@types/estree" "*"
+
+"@types/eslint-scope@^3.7.3":
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.3.tgz#125b88504b61e3c8bc6f870882003253005c3224"
+  integrity sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==
   dependencies:
     "@types/eslint" "*"
     "@types/estree" "*"
@@ -64,6 +102,30 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
   integrity sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
 
+"@types/estree@^0.0.51":
+  version "0.0.51"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
+  integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
+
+"@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.18":
+  version "4.17.29"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.29.tgz#2a1795ea8e9e9c91b4a4bbe475034b20c1ec711c"
+  integrity sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+
+"@types/express@*", "@types/express@^4.17.13":
+  version "4.17.13"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.13.tgz#a76e2995728999bab51a33fabce1d705a3709034"
+  integrity sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "^4.17.18"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
+
 "@types/http-proxy@^1.17.5":
   version "1.17.8"
   resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.8.tgz#968c66903e7e42b483608030ee85800f22d03f55"
@@ -76,15 +138,59 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
+"@types/mime@^1":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
+  integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
+
 "@types/node@*", "@types/node@>=10.0.0":
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.2.tgz#a4c07d47ff737e8ee7e586fe636ff0e1ddff070a"
   integrity sha512-JepeIUPFDARgIs0zD/SKPgFsJEAF0X5/qO80llx59gOxFTboS9Amv3S+QfB7lqBId5sFXJ99BN0J6zFRvL9dDA==
 
+"@types/qs@*":
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
+  integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
+
+"@types/range-parser@*":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
+  integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
+
 "@types/retry@^0.12.0":
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.1.tgz#d8f1c0d0dc23afad6dc16a9e993a0865774b4065"
   integrity sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==
+
+"@types/serve-index@^1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@types/serve-index/-/serve-index-1.9.1.tgz#1b5e85370a192c01ec6cec4735cf2917337a6278"
+  integrity sha512-d/Hs3nWDxNL2xAczmOVZNj92YZCS6RGxfBPjKzuu/XirCgXdpKEb88dYNbrYGint6IVWLNP+yonwVAuRC0T2Dg==
+  dependencies:
+    "@types/express" "*"
+
+"@types/serve-static@*":
+  version "1.13.10"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"
+  integrity sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==
+  dependencies:
+    "@types/mime" "^1"
+    "@types/node" "*"
+
+"@types/sockjs@^0.3.33":
+  version "0.3.33"
+  resolved "https://registry.yarnpkg.com/@types/sockjs/-/sockjs-0.3.33.tgz#570d3a0b99ac995360e3136fd6045113b1bd236f"
+  integrity sha512-f0KEEe05NvUnat+boPTZ0dgaLZ4SfSouXUgv5noUiefG2ajgKjmETo9ZJyuqsl7dfl2aHlLJUiki6B4ZYldiiw==
+  dependencies:
+    "@types/node" "*"
+
+"@types/ws@^8.2.2":
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.3.tgz#7d25a1ffbecd3c4f2d35068d0b283c037003274d"
+  integrity sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==
+  dependencies:
+    "@types/node" "*"
 
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
@@ -217,6 +323,11 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-1.1.0.tgz#8342bef0badfb7dfd3b576f2574ab80c725be043"
   integrity sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==
 
+"@webpack-cli/configtest@^1.1.1":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-1.2.0.tgz#7b20ce1c12533912c3b217ea68262365fa29a6f5"
+  integrity sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==
+
 "@webpack-cli/info@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-1.4.0.tgz#b9179c3227ab09cbbb149aa733475fcf99430223"
@@ -224,10 +335,22 @@
   dependencies:
     envinfo "^7.7.3"
 
+"@webpack-cli/info@^1.4.1":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-1.5.0.tgz#6c78c13c5874852d6e2dd17f08a41f3fe4c261b1"
+  integrity sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==
+  dependencies:
+    envinfo "^7.7.3"
+
 "@webpack-cli/serve@^1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.6.0.tgz#2c275aa05c895eccebbfc34cfb223c6e8bd591a2"
   integrity sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==
+
+"@webpack-cli/serve@^1.6.1":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.7.0.tgz#e1993689ac42d2b16e9194376cfb6753f6254db1"
+  integrity sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -516,6 +639,21 @@ chokidar@3.5.2, chokidar@^3.5.1:
   optionalDependencies:
     fsevents "~2.3.2"
 
+chokidar@3.5.3, chokidar@^3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
+  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 chrome-trace-event@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
@@ -561,7 +699,7 @@ colorette@^2.0.10, colorette@^2.0.14:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.16.tgz#713b9af84fdb000139f04546bd4a93f62a5085da"
   integrity sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==
 
-colors@^1.4.0:
+colors@1.4.0, colors@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
@@ -692,6 +830,11 @@ date-format@^3.0.0:
   resolved "https://registry.yarnpkg.com/date-format/-/date-format-3.0.0.tgz#eb8780365c7d2b1511078fb491e6479780f3ad95"
   integrity sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w==
 
+date-format@^4.0.10:
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/date-format/-/date-format-4.0.11.tgz#ae0d1e069d7f0687938fd06f98c12f3a6276e526"
+  integrity sha512-VS20KRyorrbMCQmpdl2hg5KaOUsda1RbnsJg461FfrcyCUg+pkd0b40BSW4niQyTheww4DBXQnS7HwSrKkipLw==
+
 dateformat@3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
@@ -711,6 +854,13 @@ debug@4.3.2:
   dependencies:
     ms "2.1.2"
 
+debug@4.3.3, debug@^4.1.0, debug@^4.1.1, debug@~4.3.1:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
+  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+  dependencies:
+    ms "2.1.2"
+
 debug@^3.1.1:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
@@ -718,10 +868,10 @@ debug@^3.1.1:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.1.0, debug@^4.1.1, debug@~4.3.1:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
-  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+debug@^4.3.4, debug@~4.3.2:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
 
@@ -742,7 +892,7 @@ deep-equal@^1.0.1:
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
 
-default-gateway@^6.0.0:
+default-gateway@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/default-gateway/-/default-gateway-6.0.3.tgz#819494c888053bdb743edbf343d6cdf7f2943a71"
   integrity sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==
@@ -872,6 +1022,11 @@ engine.io-parser@~4.0.0:
   dependencies:
     base64-arraybuffer "0.1.4"
 
+engine.io-parser@~5.0.3:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.0.4.tgz#0b13f704fa9271b3ec4f33112410d8f3f41d0fc0"
+  integrity sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg==
+
 engine.io@~4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-4.1.1.tgz#9a8f8a5ac5a5ea316183c489bf7f5b6cf91ace5b"
@@ -884,6 +1039,22 @@ engine.io@~4.1.0:
     debug "~4.3.1"
     engine.io-parser "~4.0.0"
     ws "~7.4.2"
+
+engine.io@~6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-6.2.0.tgz#003bec48f6815926f2b1b17873e576acd54f41d0"
+  integrity sha512-4KzwW3F3bk+KlzSOY57fj/Jx6LyRQ1nbcyIadehl+AnXjKT7gDO0ORdRi/84ixvMKTym6ZKuxvbzN62HDDU1Lg==
+  dependencies:
+    "@types/cookie" "^0.4.1"
+    "@types/cors" "^2.8.12"
+    "@types/node" ">=10.0.0"
+    accepts "~1.3.4"
+    base64id "2.0.0"
+    cookie "~0.4.1"
+    cors "~2.8.5"
+    debug "~4.3.1"
+    engine.io-parser "~5.0.3"
+    ws "~8.2.3"
 
 enhanced-resolve@^5.8.3:
   version "5.8.3"
@@ -1105,6 +1276,11 @@ flatted@^2.0.1:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
+flatted@^3.2.5:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
+  integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
+
 follow-redirects@^1.0.0:
   version "1.14.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.6.tgz#8cfb281bbc035b3c067d6cd975b0f6ade6e855cd"
@@ -1124,6 +1300,15 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
+
+fs-extra@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
+  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-extra@^8.1.0:
   version "8.1.0"
@@ -1204,7 +1389,7 @@ glob@7.1.7:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.3, glob@^7.1.7:
+glob@7.2.0, glob@^7.1.3, glob@^7.1.7:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -1237,6 +1422,11 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, 
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
+
+graceful-fs@^4.2.9:
+  version "4.2.10"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
+  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
 growl@1.10.5:
   version "1.10.5"
@@ -1355,7 +1545,7 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.6.2:
+iconv-lite@^0.6.2, iconv-lite@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
@@ -1398,32 +1588,17 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-internal-ip@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-6.2.0.tgz#d5541e79716e406b74ac6b07b856ef18dc1621c1"
-  integrity sha512-D8WGsR6yDt8uq7vDMu7mjcR+yRMm3dW8yufyChmszWRjcSHuxLBkR3GdS2HZAjodsaGuCvXeEJpueisXJULghg==
-  dependencies:
-    default-gateway "^6.0.0"
-    ipaddr.js "^1.9.1"
-    is-ip "^3.1.0"
-    p-event "^4.2.0"
-
 interpret@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
-
-ip-regex@^4.0.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.3.0.tgz#687275ab0f57fa76978ff8f4dddc8a23d5990db5"
-  integrity sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==
 
 ip@^1.1.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
   integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
 
-ipaddr.js@1.9.1, ipaddr.js@^1.9.1:
+ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
@@ -1483,13 +1658,6 @@ is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
-
-is-ip@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/is-ip/-/is-ip-3.1.0.tgz#2ae5ddfafaf05cb8008a62093cf29734f657c5d8"
-  integrity sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==
-  dependencies:
-    ip-regex "^4.0.0"
 
 is-number@^7.0.0:
   version "7.0.0"
@@ -1606,6 +1774,15 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 karma-chrome-launcher@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/karma-chrome-launcher/-/karma-chrome-launcher-3.1.0.tgz#805a586799a4d05f4e54f72a204979f3f3066738"
@@ -1635,6 +1812,36 @@ karma-webpack@5.0.0:
     glob "^7.1.3"
     minimatch "^3.0.4"
     webpack-merge "^4.1.5"
+
+karma@6.3.16:
+  version "6.3.16"
+  resolved "https://registry.yarnpkg.com/karma/-/karma-6.3.16.tgz#76d1a705fd1cf864ee5ed85270b572641e0958ef"
+  integrity sha512-nEU50jLvDe5yvXqkEJRf8IuvddUkOY2x5Xc4WXHz6dxINgGDrgD2uqQWeVrJs4hbfNaotn+HQ1LZJ4yOXrL7xQ==
+  dependencies:
+    body-parser "^1.19.0"
+    braces "^3.0.2"
+    chokidar "^3.5.1"
+    colors "1.4.0"
+    connect "^3.7.0"
+    di "^0.0.1"
+    dom-serialize "^2.2.1"
+    glob "^7.1.7"
+    graceful-fs "^4.2.6"
+    http-proxy "^1.18.1"
+    isbinaryfile "^4.0.8"
+    lodash "^4.17.21"
+    log4js "^6.4.1"
+    mime "^2.5.2"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.5"
+    qjobs "^1.2.0"
+    range-parser "^1.2.1"
+    rimraf "^3.0.2"
+    socket.io "^4.2.0"
+    source-map "^0.6.1"
+    tmp "^0.2.1"
+    ua-parser-js "^0.7.30"
+    yargs "^16.1.1"
 
 karma@6.3.4:
   version "6.3.4"
@@ -1713,15 +1920,26 @@ log4js@^6.3.0:
     rfdc "^1.1.4"
     streamroller "^2.2.4"
 
+log4js@^6.4.1:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/log4js/-/log4js-6.5.2.tgz#9ae371e5b3cb3a3a209c24686e5547f8670834e5"
+  integrity sha512-DXtpNtt+KDOMT7RHUDIur/WsSA3rntlUh9Zg4XCdV42wUuMmbFkl38+LZ92Z5QvQA7mD5kAVkLiBSEH/tvUB8A==
+  dependencies:
+    date-format "^4.0.10"
+    debug "^4.3.4"
+    flatted "^3.2.5"
+    rfdc "^1.3.0"
+    streamroller "^3.1.1"
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
-memfs@^3.2.2:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.4.0.tgz#8bc12062b973be6b295d4340595736a656f0a257"
-  integrity sha512-o/RfP0J1d03YwsAxyHxAYs2kyJp55AFkMazlFAZFR2I2IXkxiUTXRabJ6RmNNCQ83LAD2jy52Khj0m3OffpNdA==
+memfs@^3.4.3:
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.4.4.tgz#e8973cd8060548916adcca58a248e7805c715e89"
+  integrity sha512-W4gHNUE++1oSJVn8Y68jPXi+mkx3fXR5ITE/Ubz6EQ3xRpCN5k2CQ4AUR8094Z7211F876TyoBACGsIveqgiGA==
   dependencies:
     fs-monkey "1.0.3"
 
@@ -1834,6 +2052,36 @@ mocha@9.1.2:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
+mocha@9.2.1:
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-9.2.1.tgz#a1abb675aa9a8490798503af57e8782a78f1338e"
+  integrity sha512-T7uscqjJVS46Pq1XDXyo9Uvey9gd3huT/DD9cYBb4K2Xc/vbKRPUWK067bxDQRK0yIz6Jxk73IrnimvASzBNAQ==
+  dependencies:
+    "@ungap/promise-all-settled" "1.1.2"
+    ansi-colors "4.1.1"
+    browser-stdout "1.3.1"
+    chokidar "3.5.3"
+    debug "4.3.3"
+    diff "5.0.0"
+    escape-string-regexp "4.0.0"
+    find-up "5.0.0"
+    glob "7.2.0"
+    growl "1.10.5"
+    he "1.2.0"
+    js-yaml "4.1.0"
+    log-symbols "4.1.0"
+    minimatch "3.0.4"
+    ms "2.1.3"
+    nanoid "3.2.0"
+    serialize-javascript "6.0.0"
+    strip-json-comments "3.1.1"
+    supports-color "8.1.1"
+    which "2.0.2"
+    workerpool "6.2.0"
+    yargs "16.2.0"
+    yargs-parser "20.2.4"
+    yargs-unparser "2.0.0"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -1867,6 +2115,11 @@ nanoid@3.1.25:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.25.tgz#09ca32747c0e543f0e1814b7d3793477f9c8e152"
   integrity sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==
 
+nanoid@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.2.0.tgz#62667522da6673971cca916a6d3eff3f415ff80c"
+  integrity sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==
+
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -1877,10 +2130,10 @@ neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-node-forge@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
-  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
+node-forge@^1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
+  integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
 
 node-releases@^2.0.1:
   version "2.0.1"
@@ -1957,18 +2210,6 @@ open@^8.0.9:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
-p-event@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/p-event/-/p-event-4.2.0.tgz#af4b049c8acd91ae81083ebd1e6f5cae2044c1b5"
-  integrity sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==
-  dependencies:
-    p-timeout "^3.1.0"
-
-p-finally@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
-  integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
-
 p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
@@ -2011,13 +2252,6 @@ p-retry@^4.5.0:
   dependencies:
     "@types/retry" "^0.12.0"
     retry "^0.13.1"
-
-p-timeout@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
-  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
-  dependencies:
-    p-finally "^1.0.0"
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -2098,11 +2332,6 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
-punycode@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
-  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
-
 punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
@@ -2117,11 +2346,6 @@ qs@6.9.6:
   version "6.9.6"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.6.tgz#26ed3c8243a431b2924aca84cc90471f35d5a0ee"
   integrity sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==
-
-querystring@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
-  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -2239,7 +2463,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rfdc@^1.1.4:
+rfdc@^1.1.4, rfdc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
   integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
@@ -2297,12 +2521,12 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=
 
-selfsigned@^1.10.11:
-  version "1.10.11"
-  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.11.tgz#24929cd906fe0f44b6d01fb23999a739537acbe9"
-  integrity sha512-aVmbPOfViZqOZPgRBT0+3u4yZFHpmnIghLMlAcb5/xhp5ZtB/RVnKhz5vl2M32CLXAqR4kha9zfhNg0Lf/sxKA==
+selfsigned@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-2.0.1.tgz#8b2df7fa56bf014d19b6007655fff209c0ef0a56"
+  integrity sha512-LmME957M1zOsUhG+67rAjKfiWFox3SBxE/yymatMZsAx+oMrJ0YQ8AToOnyCm7xbeg2ep37IHLxdu0o2MavQOQ==
   dependencies:
-    node-forge "^0.10.0"
+    node-forge "^1"
 
 send@0.17.2:
   version "0.17.2"
@@ -2397,7 +2621,12 @@ socket.io-adapter@~2.1.0:
   resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-2.1.0.tgz#edc5dc36602f2985918d631c1399215e97a1b527"
   integrity sha512-+vDov/aTsLjViYTwS9fPy5pEtTkrbEKsw2M+oVSoFGw6OD1IpvlV1VPhUzNbofCQ8oyMbdYJqDtGdmHQK6TdPg==
 
-socket.io-parser@~4.0.3:
+socket.io-adapter@~2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz#b50a4a9ecdd00c34d4c8c808224daa1a786152a6"
+  integrity sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg==
+
+socket.io-parser@~4.0.3, socket.io-parser@~4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.0.4.tgz#9ea21b0d61508d18196ef04a2c6b9ab630f4c2b0"
   integrity sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==
@@ -2421,6 +2650,18 @@ socket.io@^3.1.0:
     socket.io-adapter "~2.1.0"
     socket.io-parser "~4.0.3"
 
+socket.io@^4.2.0:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-4.5.1.tgz#aa7e73f8a6ce20ee3c54b2446d321bbb6b1a9029"
+  integrity sha512-0y9pnIso5a9i+lJmsCdtmTTgJFFSvNQKDnPQRz28mGNnxbmqYg2QPtJTLFxhymFZhAIn50eHAKzJeiNaKr+yUQ==
+  dependencies:
+    accepts "~1.3.4"
+    base64id "~2.0.0"
+    debug "~4.3.2"
+    engine.io "~6.2.0"
+    socket.io-adapter "~2.4.0"
+    socket.io-parser "~4.0.4"
+
 sockjs@^0.3.21:
   version "0.3.24"
   resolved "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.24.tgz#c9bc8995f33a111bea0395ec30aa3206bdb5ccce"
@@ -2435,6 +2676,11 @@ source-map-js@^0.6.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
   integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
 
+source-map-js@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
+
 source-map-loader@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-3.0.0.tgz#f2a04ee2808ad01c774dea6b7d2639839f3b3049"
@@ -2444,6 +2690,15 @@ source-map-loader@3.0.0:
     iconv-lite "^0.6.2"
     source-map-js "^0.6.2"
 
+source-map-loader@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-3.0.1.tgz#9ae5edc7c2d42570934be4c95d1ccc6352eba52d"
+  integrity sha512-Vp1UsfyPvgujKQzi4pyDiTOnE3E4H+yHvkVRN3c/9PJmQS4CQJExvcDvaX/D+RV+xQben9HJ56jMJS3CgUeWyA==
+  dependencies:
+    abab "^2.0.5"
+    iconv-lite "^0.6.3"
+    source-map-js "^1.0.1"
+
 source-map-support@0.5.20:
   version "0.5.20"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.20.tgz#12166089f8f5e5e8c56926b377633392dd2cb6c9"
@@ -2452,7 +2707,7 @@ source-map-support@0.5.20:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map-support@~0.5.20:
+source-map-support@0.5.21, source-map-support@~0.5.20:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
@@ -2511,6 +2766,15 @@ streamroller@^2.2.4:
     date-format "^2.1.0"
     debug "^4.1.1"
     fs-extra "^8.1.0"
+
+streamroller@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/streamroller/-/streamroller-3.1.1.tgz#679aae10a4703acdf2740755307df0a05ad752e6"
+  integrity sha512-iPhtd9unZ6zKdWgMeYGfSBuqCngyJy1B/GPi/lTpwGpa3bajuX30GjUVd0/Tn/Xhg0mr4DOSENozz9Y06qyonQ==
+  dependencies:
+    date-format "^4.0.10"
+    debug "^4.3.4"
+    fs-extra "^10.1.0"
 
 string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.3"
@@ -2635,7 +2899,7 @@ typescript@3.9.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
   integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
 
-ua-parser-js@^0.7.28:
+ua-parser-js@^0.7.28, ua-parser-js@^0.7.30:
   version "0.7.31"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.31.tgz#649a656b191dffab4f21d5e053e27ca17cbff5c6"
   integrity sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==
@@ -2644,6 +2908,11 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
@@ -2656,14 +2925,6 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
-
-url@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
-  integrity sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
-  dependencies:
-    punycode "1.3.2"
-    querystring "0.2.0"
 
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
@@ -2703,6 +2964,14 @@ watchpack@^2.2.0:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
+watchpack@^2.3.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz#fa33032374962c78113f93c7f2fb4c54c9862a5d"
+  integrity sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==
+  dependencies:
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.1.2"
+
 wbuf@^1.1.0, wbuf@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df"
@@ -2729,47 +2998,70 @@ webpack-cli@4.9.0:
     v8-compile-cache "^2.2.0"
     webpack-merge "^5.7.3"
 
-webpack-dev-middleware@^5.2.1:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-5.3.0.tgz#8fc02dba6e72e1d373eca361623d84610f27be7c"
-  integrity sha512-MouJz+rXAm9B1OTOYaJnn6rtD/lWZPy2ufQCH3BPs8Rloh/Du6Jze4p7AeLYHkVi0giJnYLaSGDC7S+GM9arhg==
+webpack-cli@4.9.2:
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-4.9.2.tgz#77c1adaea020c3f9e2db8aad8ea78d235c83659d"
+  integrity sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==
+  dependencies:
+    "@discoveryjs/json-ext" "^0.5.0"
+    "@webpack-cli/configtest" "^1.1.1"
+    "@webpack-cli/info" "^1.4.1"
+    "@webpack-cli/serve" "^1.6.1"
+    colorette "^2.0.14"
+    commander "^7.0.0"
+    execa "^5.0.0"
+    fastest-levenshtein "^1.0.12"
+    import-local "^3.0.2"
+    interpret "^2.2.0"
+    rechoir "^0.7.0"
+    webpack-merge "^5.7.3"
+
+webpack-dev-middleware@^5.3.1:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz#efae67c2793908e7311f1d9b06f2a08dcc97e51f"
+  integrity sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==
   dependencies:
     colorette "^2.0.10"
-    memfs "^3.2.2"
+    memfs "^3.4.3"
     mime-types "^2.1.31"
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
-webpack-dev-server@4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.3.1.tgz#759d3337f0fbea297fbd1e433ab04ccfc000076b"
-  integrity sha512-qNXQCVYo1kYhH9pgLtm8LRNkXX3XzTfHSj/zqzaqYzGPca+Qjr+81wj1jgPMCHhIhso9WEQ+kX9z23iG9PzQ7w==
+webpack-dev-server@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.7.4.tgz#d0ef7da78224578384e795ac228d8efb63d5f945"
+  integrity sha512-nfdsb02Zi2qzkNmgtZjkrMOcXnYZ6FLKcQwpxT7MvmHKc+oTtDsBju8j+NMyAygZ9GW1jMEUpy3itHtqgEhe1A==
   dependencies:
+    "@types/bonjour" "^3.5.9"
+    "@types/connect-history-api-fallback" "^1.3.5"
+    "@types/express" "^4.17.13"
+    "@types/serve-index" "^1.9.1"
+    "@types/sockjs" "^0.3.33"
+    "@types/ws" "^8.2.2"
     ansi-html-community "^0.0.8"
     bonjour "^3.5.0"
-    chokidar "^3.5.1"
+    chokidar "^3.5.3"
     colorette "^2.0.10"
     compression "^1.7.4"
     connect-history-api-fallback "^1.6.0"
+    default-gateway "^6.0.3"
     del "^6.0.0"
     express "^4.17.1"
     graceful-fs "^4.2.6"
     html-entities "^2.3.2"
     http-proxy-middleware "^2.0.0"
-    internal-ip "^6.2.0"
     ipaddr.js "^2.0.1"
     open "^8.0.9"
     p-retry "^4.5.0"
     portfinder "^1.0.28"
-    schema-utils "^3.1.0"
-    selfsigned "^1.10.11"
+    schema-utils "^4.0.0"
+    selfsigned "^2.0.0"
     serve-index "^1.9.1"
     sockjs "^0.3.21"
     spdy "^4.0.2"
     strip-ansi "^7.0.0"
-    url "^0.11.0"
-    webpack-dev-middleware "^5.2.1"
-    ws "^8.1.0"
+    webpack-dev-middleware "^5.3.1"
+    ws "^8.4.2"
 
 webpack-merge@^4.1.5:
   version "4.2.2"
@@ -2790,6 +3082,11 @@ webpack-sources@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.2.tgz#d88e3741833efec57c4c789b6010db9977545260"
   integrity sha512-cp5qdmHnu5T8wRg2G3vZZHoJPN14aqQ89SyQ11NpGH5zEMDCclt49rzo+MaRazk7/UeILhAI+/sEtcM+7Fr0nw==
+
+webpack-sources@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
+  integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
 webpack@5.57.1:
   version "5.57.1"
@@ -2820,6 +3117,36 @@ webpack@5.57.1:
     terser-webpack-plugin "^5.1.3"
     watchpack "^2.2.0"
     webpack-sources "^3.2.0"
+
+webpack@5.69.1:
+  version "5.69.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.69.1.tgz#8cfd92c192c6a52c99ab00529b5a0d33aa848dc5"
+  integrity sha512-+VyvOSJXZMT2V5vLzOnDuMz5GxEqLk7hKWQ56YxPW/PQRUuKimPqmEIJOx8jHYeyo65pKbapbW464mvsKbaj4A==
+  dependencies:
+    "@types/eslint-scope" "^3.7.3"
+    "@types/estree" "^0.0.51"
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/wasm-edit" "1.11.1"
+    "@webassemblyjs/wasm-parser" "1.11.1"
+    acorn "^8.4.1"
+    acorn-import-assertions "^1.7.6"
+    browserslist "^4.14.5"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^5.8.3"
+    es-module-lexer "^0.9.0"
+    eslint-scope "5.1.1"
+    events "^3.2.0"
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.2.9"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^4.2.0"
+    mime-types "^2.1.27"
+    neo-async "^2.6.2"
+    schema-utils "^3.1.0"
+    tapable "^2.1.1"
+    terser-webpack-plugin "^5.1.3"
+    watchpack "^2.3.1"
+    webpack-sources "^3.2.3"
 
 websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
   version "0.7.4"
@@ -2859,6 +3186,11 @@ workerpool@6.1.5:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.1.5.tgz#0f7cf076b6215fd7e1da903ff6f22ddd1886b581"
   integrity sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==
 
+workerpool@6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.0.tgz#827d93c9ba23ee2019c3ffaff5c27fccea289e8b"
+  integrity sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==
+
 wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
@@ -2873,15 +3205,20 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-ws@^8.1.0:
-  version "8.4.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.4.0.tgz#f05e982a0a88c604080e8581576e2a063802bed6"
-  integrity sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==
+ws@^8.4.2:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.0.tgz#8e71c75e2f6348dbf8d78005107297056cb77769"
+  integrity sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==
 
 ws@~7.4.2:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+
+ws@~8.2.3:
+  version "8.2.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.2.3.tgz#63a56456db1b04367d0b721a0b80cae6d8becbba"
+  integrity sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==
 
 y18n@^5.0.5:
   version "5.0.8"

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/GroupQueries.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/GroupQueries.kt
@@ -6,7 +6,7 @@ import app.cash.sqldelight.db.SqlDriver
 import kotlin.Long
 
 public class GroupQueries(
-  private val driver: SqlDriver,
+  driver: SqlDriver,
 ) : TransacterImpl(driver) {
   public fun selectAll(): Query<Long> = Query(165688501, arrayOf("group"), driver, "Group.sq",
       "selectAll", "SELECT `index` FROM `group`") { cursor ->

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
@@ -16,7 +16,7 @@ import kotlin.Unit
 import kotlin.collections.Collection
 
 public class PlayerQueries(
-  private val driver: SqlDriver,
+  driver: SqlDriver,
   private val playerAdapter: Player.Adapter,
 ) : TransacterImpl(driver) {
   public fun <T : Any> insertAndReturn(

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TeamQueries.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TeamQueries.kt
@@ -13,7 +13,7 @@ import kotlin.String
 import kotlin.Unit
 
 public class TeamQueries(
-  private val driver: SqlDriver,
+  driver: SqlDriver,
   private val teamAdapter: Team.Adapter,
 ) : TransacterImpl(driver) {
   public fun <T : Any> teamForCoach(coach: String, mapper: (name: Team.Name, captain: Long) -> T):

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/DatabaseGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/DatabaseGenerator.kt
@@ -22,6 +22,8 @@ import app.cash.sqldelight.core.lang.DATABASE_SCHEMA_TYPE
 import app.cash.sqldelight.core.lang.DRIVER_NAME
 import app.cash.sqldelight.core.lang.DRIVER_TYPE
 import app.cash.sqldelight.core.lang.QUERY_RESULT_TYPE
+import app.cash.sqldelight.core.lang.SUSPENDING_TRANSACTER_IMPL_TYPE
+import app.cash.sqldelight.core.lang.SUSPENDING_TRANSACTER_TYPE
 import app.cash.sqldelight.core.lang.SqlDelightFile
 import app.cash.sqldelight.core.lang.TRANSACTER_IMPL_TYPE
 import app.cash.sqldelight.core.lang.TRANSACTER_TYPE
@@ -61,7 +63,7 @@ internal class DatabaseGenerator(
 
   fun interfaceType(): TypeSpec {
     val typeSpec = TypeSpec.interfaceBuilder(fileIndex.className)
-      .addSuperinterface(TRANSACTER_TYPE)
+      .addSuperinterface(if (generateAsync) SUSPENDING_TRANSACTER_TYPE else TRANSACTER_TYPE)
 
     fileIndex.dependencies.forEach {
       typeSpec.addSuperinterface(ClassName(it.packageName, it.className))
@@ -133,7 +135,7 @@ internal class DatabaseGenerator(
 
   fun type(): TypeSpec {
     val typeSpec = TypeSpec.classBuilder("${fileIndex.className}Impl")
-      .superclass(TRANSACTER_IMPL_TYPE)
+      .superclass(if (generateAsync) SUSPENDING_TRANSACTER_IMPL_TYPE else TRANSACTER_IMPL_TYPE)
       .addModifiers(PRIVATE)
       .addSuperclassConstructorParameter(DRIVER_NAME)
 

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/QueriesTypeGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/QueriesTypeGenerator.kt
@@ -3,6 +3,7 @@ package app.cash.sqldelight.core.compiler
 import app.cash.sqldelight.core.compiler.model.NamedExecute
 import app.cash.sqldelight.core.compiler.model.NamedMutator
 import app.cash.sqldelight.core.lang.DRIVER_NAME
+import app.cash.sqldelight.core.lang.SUSPENDING_TRANSACTER_IMPL_TYPE
 import app.cash.sqldelight.core.lang.SqlDelightQueriesFile
 import app.cash.sqldelight.core.lang.TRANSACTER_IMPL_TYPE
 import app.cash.sqldelight.core.lang.queriesType
@@ -38,7 +39,7 @@ class QueriesTypeGenerator(
     val driverType = if (generateAsync) dialect.asyncRuntimeTypes.driverType else dialect.runtimeTypes.driverType
 
     val type = TypeSpec.classBuilder(file.queriesType.simpleName)
-      .superclass(TRANSACTER_IMPL_TYPE)
+      .superclass(if (generateAsync) SUSPENDING_TRANSACTER_IMPL_TYPE else TRANSACTER_IMPL_TYPE)
 
     val constructor = FunSpec.constructorBuilder()
 

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/QueriesTypeGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/QueriesTypeGenerator.kt
@@ -10,8 +10,6 @@ import app.cash.sqldelight.core.lang.queriesType
 import app.cash.sqldelight.dialect.api.SqlDelightDialect
 import com.intellij.openapi.module.Module
 import com.squareup.kotlinpoet.FunSpec
-import com.squareup.kotlinpoet.KModifier.PRIVATE
-import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 
 class QueriesTypeGenerator(
@@ -43,13 +41,7 @@ class QueriesTypeGenerator(
 
     val constructor = FunSpec.constructorBuilder()
 
-    // Add the driver as a constructor property and superclass parameter:
-    // private val driver: SqlDriver
-    type.addProperty(
-      PropertySpec.builder(DRIVER_NAME, driverType, PRIVATE)
-        .initializer(DRIVER_NAME)
-        .build()
-    )
+    // Add the driver as a constructor parameter:
     constructor.addParameter(DRIVER_NAME, driverType)
     type.addSuperclassConstructorParameter(DRIVER_NAME)
 

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/QueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/QueryGenerator.kt
@@ -58,11 +58,9 @@ abstract class QueryGenerator(
 
     if (query.statement is SqlDelightStmtClojureStmtList) {
       if (query is NamedQuery) {
-        val transaction = if (generateAsync) "suspendingTransactionWithResult" else "transactionWithResult"
-        result.add("return $transaction {\n").indent()
+        result.add("return transactionWithResult {\n").indent()
       } else {
-        val transaction = if (generateAsync) "suspendingTransaction" else "transaction"
-        result.add("$transaction {\n").indent()
+        result.add("transaction {\n").indent()
       }
       query.statement.findChildrenOfType<SqlStmt>().forEachIndexed { index, statement ->
         result.add(executeBlock(statement, query.idForIndex(index)))

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/Constants.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/Constants.kt
@@ -45,3 +45,5 @@ internal val SqlDelightFile.queriesType
 
 internal val TRANSACTER_TYPE = ClassName("app.cash.sqldelight", "Transacter")
 internal val TRANSACTER_IMPL_TYPE = ClassName("app.cash.sqldelight", "TransacterImpl")
+internal val SUSPENDING_TRANSACTER_TYPE = ClassName("app.cash.sqldelight", "SuspendingTransacter")
+internal val SUSPENDING_TRANSACTER_IMPL_TYPE = ClassName("app.cash.sqldelight", "SuspendingTransacterImpl")

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueriesTypeTest.kt
@@ -128,7 +128,7 @@ class QueriesTypeTest {
       |import kotlin.collections.setOf
       |
       |public class DataQueries(
-      |  private val driver: SqlDriver,
+      |  driver: SqlDriver,
       |  private val data_Adapter: Data_.Adapter,
       |  private val otherAdapter: Other.Adapter,
       |) : TransacterImpl(driver) {
@@ -471,7 +471,7 @@ class QueriesTypeTest {
       |import kotlin.collections.List
       |
       |public class DataQueries(
-      |  private val driver: SqlDriver,
+      |  driver: SqlDriver,
       |  private val data_Adapter: Data_.Adapter,
       |) : TransacterImpl(driver) {
       |  public fun <T : Any> selectForId(id: Long, mapper: (id: Long, value_: List?) -> T): Query<T> =
@@ -622,7 +622,7 @@ class QueriesTypeTest {
       |import kotlin.Unit
       |
       |public class SearchQueries(
-      |  private val driver: SqlDriver,
+      |  driver: SqlDriver,
       |) : TransacterImpl(driver) {
       |  public fun <T : Any> selectOffsets(search: String, mapper: (id: Long, offsets: String?) -> T):
       |      Query<T> = SelectOffsetsQuery(search) { cursor ->

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueriesTypeTest.kt
@@ -294,7 +294,7 @@ class QueriesTypeTest {
       |import kotlin.Unit
       |
       |public class DataQueries(
-      |  private val driver: SqlDriver,
+      |  driver: SqlDriver,
       |  private val data_Adapter: Data_.Adapter,
       |) : TransacterImpl(driver) {
       |  public fun insertData(data_: Data_): Unit {

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/async/AsyncQueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/async/AsyncQueriesTypeTest.kt
@@ -1,0 +1,215 @@
+package app.cash.sqldelight.core.async
+
+import app.cash.sqldelight.test.util.FixtureCompiler
+import com.google.common.truth.Truth
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class AsyncQueriesTypeTest {
+  @get:Rule val temporaryFolder = TemporaryFolder()
+
+  @Test
+  fun `queries file is generated with suspending transacter`() {
+    val result = FixtureCompiler.compileSql(
+      """
+      |CREATE TABLE data (
+      |  id INTEGER PRIMARY KEY,
+      |  value TEXT AS kotlin.collections.List
+      |);
+      |
+      |CREATE TABLE other (
+      |  id INTEGER PRIMARY KEY,
+      |  value TEXT AS kotlin.collections.List
+      |);
+      |
+      |insertData:
+      |INSERT INTO data
+      |VALUES (?, ?);
+      |
+      |selectForId:
+      |SELECT *
+      |FROM data
+      |WHERE id = ?;
+      |
+      |selectAllValues:
+      |SELECT id, value FROM data
+      |UNION
+      |SELECT id, value FROM other;
+    """.trimMargin(),
+      temporaryFolder,
+      fileName = "Data.sq",
+      generateAsync = true,
+    )
+
+    val select = result.compiledFile.namedQueries.first()
+    val insert = result.compiledFile.namedMutators.first()
+    Truth.assertThat(result.errors).isEmpty()
+
+    val database = File(result.outputDirectory, "com/example/testmodule/TestDatabaseImpl.kt")
+    Truth.assertThat(result.compilerOutput).containsKey(database)
+    Truth.assertThat(result.compilerOutput[database].toString()).isEqualTo(
+      """
+      |package com.example.testmodule
+      |
+      |import app.cash.sqldelight.SuspendingTransacterImpl
+      |import app.cash.sqldelight.db.QueryResult
+      |import app.cash.sqldelight.db.SqlDriver
+      |import app.cash.sqldelight.db.SqlSchema
+      |import com.example.DataQueries
+      |import com.example.Data_
+      |import com.example.Other
+      |import com.example.TestDatabase
+      |import kotlin.Int
+      |import kotlin.Unit
+      |import kotlin.reflect.KClass
+      |
+      |internal val KClass<TestDatabase>.schema: SqlSchema
+      |  get() = TestDatabaseImpl.Schema
+      |
+      |internal fun KClass<TestDatabase>.newInstance(
+      |  driver: SqlDriver,
+      |  data_Adapter: Data_.Adapter,
+      |  otherAdapter: Other.Adapter,
+      |): TestDatabase = TestDatabaseImpl(driver, data_Adapter, otherAdapter)
+      |
+      |private class TestDatabaseImpl(
+      |  driver: SqlDriver,
+      |  data_Adapter: Data_.Adapter,
+      |  otherAdapter: Other.Adapter,
+      |) : SuspendingTransacterImpl(driver), TestDatabase {
+      |  public override val dataQueries: DataQueries = DataQueries(driver, data_Adapter, otherAdapter)
+      |
+      |  public object Schema : SqlSchema {
+      |    public override val version: Int
+      |      get() = 1
+      |
+      |    public override fun create(driver: SqlDriver): QueryResult<Unit> = QueryResult.AsyncValue {
+      |      driver.execute(null, ""${'"'}
+      |          |CREATE TABLE data (
+      |          |  id INTEGER PRIMARY KEY,
+      |          |  value TEXT
+      |          |)
+      |          ""${'"'}.trimMargin(), 0).await()
+      |      driver.execute(null, ""${'"'}
+      |          |CREATE TABLE other (
+      |          |  id INTEGER PRIMARY KEY,
+      |          |  value TEXT
+      |          |)
+      |          ""${'"'}.trimMargin(), 0).await()
+      |    }
+      |
+      |    public override fun migrate(
+      |      driver: SqlDriver,
+      |      oldVersion: Int,
+      |      newVersion: Int,
+      |    ): QueryResult<Unit> = QueryResult.AsyncValue {
+      |    }
+      |  }
+      |}
+      |""".trimMargin()
+    )
+
+    val dataQueries = File(result.outputDirectory, "com/example/DataQueries.kt")
+    Truth.assertThat(result.compilerOutput).containsKey(dataQueries)
+    Truth.assertThat(result.compilerOutput[dataQueries].toString()).isEqualTo(
+      """
+      |package com.example
+      |
+      |import app.cash.sqldelight.Query
+      |import app.cash.sqldelight.SuspendingTransacterImpl
+      |import app.cash.sqldelight.db.QueryResult
+      |import app.cash.sqldelight.db.SqlCursor
+      |import app.cash.sqldelight.db.SqlDriver
+      |import kotlin.Any
+      |import kotlin.Long
+      |import kotlin.String
+      |import kotlin.Unit
+      |import kotlin.check
+      |import kotlin.collections.List
+      |import kotlin.collections.setOf
+      |
+      |public class DataQueries(
+      |  private val driver: SqlDriver,
+      |  private val data_Adapter: Data_.Adapter,
+      |  private val otherAdapter: Other.Adapter,
+      |) : SuspendingTransacterImpl(driver) {
+      |  public fun <T : Any> selectForId(id: Long, mapper: (id: Long, value_: List?) -> T): Query<T> =
+      |      SelectForIdQuery(id) { cursor ->
+      |    mapper(
+      |      cursor.getLong(0)!!,
+      |      cursor.getString(1)?.let { data_Adapter.value_Adapter.decode(it) }
+      |    )
+      |  }
+      |
+      |  public fun selectForId(id: Long): Query<Data_> = selectForId(id) { id_, value_ ->
+      |    Data_(
+      |      id_,
+      |      value_
+      |    )
+      |  }
+      |
+      |  public fun <T : Any> selectAllValues(mapper: (id: Long, value_: List?) -> T): Query<T> {
+      |    check(setOf(dataAdapter.value_Adapter, otherAdapter.value_Adapter).size == 1) {
+      |        "Adapter types are expected to be identical." }
+      |    return Query(424911250, arrayOf("data", "other"), driver, "Data.sq", "selectAllValues", ""${'"'}
+      |    |SELECT id, value FROM data
+      |    |UNION
+      |    |SELECT id, value FROM other
+      |    ""${'"'}.trimMargin()) { cursor ->
+      |      mapper(
+      |        cursor.getLong(0)!!,
+      |        cursor.getString(1)?.let { data_Adapter.value_Adapter.decode(it) }
+      |      )
+      |    }
+      |  }
+      |
+      |  public fun selectAllValues(): Query<SelectAllValues> = selectAllValues { id, value_ ->
+      |    SelectAllValues(
+      |      id,
+      |      value_
+      |    )
+      |  }
+      |
+      |  public suspend fun insertData(id: Long?, value_: List?): Unit {
+      |    driver.execute(${insert.id}, ""${'"'}
+      |        |INSERT INTO data
+      |        |VALUES (?, ?)
+      |        ""${'"'}.trimMargin(), 2) {
+      |          bindLong(0, id)
+      |          bindString(1, value_?.let { data_Adapter.value_Adapter.encode(it) })
+      |        }.await()
+      |    notifyQueries(${insert.id}) { emit ->
+      |      emit("data")
+      |    }
+      |  }
+      |
+      |  private inner class SelectForIdQuery<out T : Any>(
+      |    public val id: Long,
+      |    mapper: (SqlCursor) -> T,
+      |  ) : Query<T>(mapper) {
+      |    public override fun addListener(listener: Query.Listener): Unit {
+      |      driver.addListener(listener, arrayOf("data"))
+      |    }
+      |
+      |    public override fun removeListener(listener: Query.Listener): Unit {
+      |      driver.removeListener(listener, arrayOf("data"))
+      |    }
+      |
+      |    public override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> =
+      |        driver.executeQuery(${select.id}, ""${'"'}
+      |    |SELECT *
+      |    |FROM data
+      |    |WHERE id = ?
+      |    ""${'"'}.trimMargin(), mapper, 1) {
+      |      bindLong(0, id)
+      |    }
+      |
+      |    public override fun toString(): String = "Data.sq:selectForId"
+      |  }
+      |}
+      |""".trimMargin()
+    )
+  }
+}

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/async/AsyncQueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/async/AsyncQueriesTypeTest.kt
@@ -131,7 +131,7 @@ class AsyncQueriesTypeTest {
       |import kotlin.collections.setOf
       |
       |public class DataQueries(
-      |  private val driver: SqlDriver,
+      |  driver: SqlDriver,
       |  private val data_Adapter: Data_.Adapter,
       |  private val otherAdapter: Other.Adapter,
       |) : SuspendingTransacterImpl(driver) {

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
@@ -768,7 +768,7 @@ class InterfaceGeneration {
       |import kotlin.Unit
       |
       |public class SongQueries(
-      |  private val driver: SqlDriver,
+      |  driver: SqlDriver,
       |) : TransacterImpl(driver) {
       |  public fun <T : Any> selectSongsByAlbumId(album_id: Long?, mapper: (
       |    title: String?,
@@ -866,7 +866,7 @@ class InterfaceGeneration {
       |import kotlin.Unit
       |
       |public class SubscriptionQueries(
-      |  private val driver: JdbcDriver,
+      |  driver: JdbcDriver,
       |) : TransacterImpl(driver) {
       |  public fun insertUser(slack_user_id: String): Query<Int> = InsertUserQuery(slack_user_id) {
       |      cursor ->
@@ -979,7 +979,7 @@ class InterfaceGeneration {
       |import kotlin.Unit
       |
       |public class RecursiveQueries(
-      |  private val driver: SqlDriver,
+      |  driver: SqlDriver,
       |) : TransacterImpl(driver) {
       |  public fun <T : Any> recursiveQuery(id: Long, mapper: (id: Long, parent_id: Long?) -> T): Query<T>
       |      = RecursiveQueryQuery(id) { cursor ->

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/async/AsyncSelectQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/async/AsyncSelectQueryTypeTest.kt
@@ -176,7 +176,7 @@ class AsyncSelectQueryTypeTest {
     assertThat(generator.function().toString()).isEqualTo(
       """
       |public suspend fun insertTwice(`value`: kotlin.Long): kotlin.Unit {
-      |  suspendingTransaction {
+      |  transaction {
       |    driver.execute(${query.idForIndex(0)}, ""${'"'}
       |        |INSERT INTO data (value)
       |        |  VALUES (?)
@@ -229,7 +229,7 @@ class AsyncSelectQueryTypeTest {
       |  public val value_: kotlin.Long,
       |  mapper: (app.cash.sqldelight.db.SqlCursor) -> T,
       |) : app.cash.sqldelight.ExecutableQuery<T>(mapper) {
-      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = suspendingTransactionWithResult {
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = transactionWithResult {
       |    driver.execute(${query.idForIndex(0)}, ""${'"'}
       |        |INSERT INTO data (value)
       |        |  VALUES (?)

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/async/AsyncSelectQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/async/AsyncSelectQueryTypeTest.kt
@@ -1,6 +1,7 @@
 package app.cash.sqldelight.core.queries.async
 
 import app.cash.sqldelight.core.TestDialect
+import app.cash.sqldelight.core.compiler.ExecuteQueryGenerator
 import app.cash.sqldelight.core.compiler.SelectQueryGenerator
 import app.cash.sqldelight.core.dialects.intType
 import app.cash.sqldelight.core.dialects.textType
@@ -142,6 +143,107 @@ class AsyncSelectQueryTypeTest {
       |  }
       |
       |  public override fun toString(): kotlin.String = "Test.sq:selectForId"
+      |}
+      |""".trimMargin()
+    )
+  }
+
+  @Test
+  fun `grouped statements same parameter`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE data (
+      |  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+      |  value INTEGER NOT NULL
+      |);
+      |
+      |insertTwice {
+      |  INSERT INTO data (value)
+      |  VALUES (:value)
+      |  ;
+      |  INSERT INTO data (value)
+      |  VALUES (:value)
+      |  ;
+      |}
+      |""".trimMargin(),
+      tempFolder,
+      generateAsync = true
+    )
+
+    val query = file.namedExecutes.first()
+    val generator = ExecuteQueryGenerator(query)
+
+    assertThat(generator.function().toString()).isEqualTo(
+      """
+      |public suspend fun insertTwice(`value`: kotlin.Long): kotlin.Unit {
+      |  suspendingTransaction {
+      |    driver.execute(${query.idForIndex(0)}, ""${'"'}
+      |        |INSERT INTO data (value)
+      |        |  VALUES (?)
+      |        ""${'"'}.trimMargin(), 1) {
+      |          bindLong(0, value)
+      |        }.await()
+      |    driver.execute(${query.idForIndex(1)}, ""${'"'}
+      |        |INSERT INTO data (value)
+      |        |  VALUES (?)
+      |        ""${'"'}.trimMargin(), 1) {
+      |          bindLong(0, value)
+      |        }.await()
+      |  }
+      |  notifyQueries(-609468782) { emit ->
+      |    emit("data")
+      |  }
+      |}
+      |""".trimMargin()
+    )
+  }
+
+  @Test
+  fun `grouped statement with result`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE data (
+      |  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+      |  value INTEGER NOT NULL
+      |);
+      |
+      |insertAndReturn {
+      |  INSERT INTO data (value)
+      |  VALUES (?1);
+      |
+      |  SELECT value
+      |  FROM data
+      |  WHERE id = last_insert_rowid();
+      |}
+      |""".trimMargin(),
+      tempFolder,
+      generateAsync = true
+    )
+
+    val query = file.namedQueries.first()
+    val generator = SelectQueryGenerator(query)
+
+    assertThat(generator.querySubtype().toString()).isEqualTo(
+      """
+      |private inner class InsertAndReturnQuery<out T : kotlin.Any>(
+      |  public val value_: kotlin.Long,
+      |  mapper: (app.cash.sqldelight.db.SqlCursor) -> T,
+      |) : app.cash.sqldelight.ExecutableQuery<T>(mapper) {
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = suspendingTransactionWithResult {
+      |    driver.execute(${query.idForIndex(0)}, ""${'"'}
+      |        |INSERT INTO data (value)
+      |        |  VALUES (?)
+      |        ""${'"'}.trimMargin(), 1) {
+      |          bindLong(0, value_)
+      |        }.await()
+      |    driver.executeQuery(${query.idForIndex(1)}, ""${'"'}
+      |        |SELECT value
+      |        |  FROM data
+      |        |  WHERE id = last_insert_rowid()
+      |        ""${'"'}.trimMargin(), mapper, 0)
+      |  }
+      |
+      |  public override fun toString(): kotlin.String = "Test.sq:insertAndReturn"
       |}
       |""".trimMargin()
     )

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-rename-column/output/com/example/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-rename-column/output/com/example/DataQueries.kt
@@ -6,7 +6,7 @@ import app.cash.sqldelight.driver.jdbc.JdbcPreparedStatement
 import kotlin.Unit
 
 public class DataQueries(
-  private val driver: JdbcDriver,
+  driver: JdbcDriver,
   private val testAdapter: Test.Adapter,
 ) : TransacterImpl(driver) {
   public fun insertWhole(test: Test): Unit {

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/output/com/example/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/output/com/example/DataQueries.kt
@@ -9,7 +9,7 @@ import kotlin.String
 import kotlin.collections.List
 
 public class DataQueries(
-  private val driver: SqlDriver,
+  driver: SqlDriver,
   private val testAdapter: Test.Adapter,
 ) : TransacterImpl(driver) {
   public fun <T : Any> migrationSelect(mapper: (first: String, second: List<Int>?) -> T): Query<T> =


### PR DESCRIPTION
This piggybacks on the new `QueryResult` mechanism to enable transactions to be started and ended asynchronously.
The `Transaction` class and most of the logic is shared between blocking and async transactions, but since the transaction function and block must both be suspending a new set of functions and interfaces needed to be added to enable them.

```kotlin
// blocking
database.transaction { // this: TransactionWithoutReturn
  transaction {
    // Nested transaction
  }
}

// async
database.suspendingTransaction { // this: SuspendingTransactionWithoutReturn
  transaction {
    // Nested transaction
  }
}
```

This also adjusts the codgen to allow grouped statements to use `suspendingTransaction` when generating async code.