### PR TITLE
Add test for user defined functions

### DIFF
--- a/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/TypeResolver.kt
+++ b/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/TypeResolver.kt
@@ -18,6 +18,9 @@ interface TypeResolver {
    */
   fun argumentType(parent: PsiElement, argument: SqlExpr): IntermediateType
 
+  /**
+   * Resolves the type of dialect specific functions
+   */
   fun functionType(functionExpr: SqlFunctionExpr): IntermediateType?
 
   /**

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/SqlDelightFile.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/SqlDelightFile.kt
@@ -45,7 +45,7 @@ abstract class SqlDelightFile(
     get() = SqlDelightProjectService.getInstance(project).generateAsync
 
   internal val typeResolver: TypeResolver by lazy {
-    var parentResolver: TypeResolver = AnsiSqlTypeResolver()
+    var parentResolver: TypeResolver = AnsiSqlTypeResolver
     ServiceLoader.load(SqlDelightModule::class.java, dialect::class.java.classLoader).forEach {
       parentResolver = it.typeResolver(parentResolver)
     }

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/ExprUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/ExprUtil.kt
@@ -67,7 +67,7 @@ internal val SqlExpr.name: String get() = when (this) {
   else -> "expr"
 }
 
-internal class AnsiSqlTypeResolver : TypeResolver {
+internal object AnsiSqlTypeResolver : TypeResolver {
   override fun resolvedType(expr: SqlExpr): IntermediateType {
     return expr.ansiType()
   }

--- a/sqldelight-gradle-plugin/src/test/custom-dialect/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/custom-dialect/build.gradle
@@ -1,0 +1,26 @@
+buildscript {
+  apply from: "${projectDir.absolutePath}/../buildscript.gradle"
+}
+
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'app.cash.sqldelight'
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+  }
+  mavenCentral()
+}
+
+sqldelight {
+  customDialect {
+    packageName = "app.cash.sqldelight.customdialect"
+    dialect(project(":dialect"))
+  }
+}
+
+dependencies {
+  implementation deps.sqliteJdbc
+  implementation "app.cash.sqldelight:sqlite-driver:${app.cash.sqldelight.VersionKt.VERSION}"
+  implementation deps.truth
+}

--- a/sqldelight-gradle-plugin/src/test/custom-dialect/dialect/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/custom-dialect/dialect/build.gradle
@@ -1,0 +1,44 @@
+plugins {
+    id("org.jetbrains.kotlin.jvm")
+    id("com.github.johnrengelman.shadow") version "7.1.2"
+}
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  maven { url "https://www.jetbrains.com/intellij-repository/releases" }
+  maven { url "https://cache-redirector.jetbrains.com/intellij-dependencies" }
+}
+
+dependencies {
+    api "app.cash.sqldelight:sqlite-3-18-dialect:${app.cash.sqldelight.VersionKt.VERSION}"
+
+    compileOnly "app.cash.sqldelight:dialect-api:${app.cash.sqldelight.VersionKt.VERSION}"
+}
+
+tasks.getByName("shadowJar").configure {
+    classifier = ''
+    include "*.jar"
+    include "app/cash/sqldelight/**"
+    include "foo/**"
+    include 'META-INF/services/*'
+}
+
+tasks.jar.configure {
+    // Prevents shadowJar (with classifier = '') and this task from writing to the same path.
+    enabled = false
+}
+
+configurations {
+    [apiElements, runtimeElements].each {
+        it.outgoing.artifacts.removeIf { it.buildDependencies.getDependencies(null).contains(jar) }
+        it.outgoing.artifact(shadowJar)
+    }
+}
+
+artifacts {
+    runtimeOnly(shadowJar)
+    archives(shadowJar)
+}

--- a/sqldelight-gradle-plugin/src/test/custom-dialect/dialect/src/main/kotlin/foo/FooDialect.kt
+++ b/sqldelight-gradle-plugin/src/test/custom-dialect/dialect/src/main/kotlin/foo/FooDialect.kt
@@ -1,0 +1,19 @@
+package foo
+
+import app.cash.sqldelight.dialect.api.*
+import app.cash.sqldelight.dialects.sqlite_3_18.SqliteDialect
+import app.cash.sqldelight.dialects.sqlite_3_18.SqliteTypeResolver
+import com.alecstrong.sql.psi.core.psi.*
+
+class FooDialect : SqlDelightDialect by SqliteDialect() {
+  override fun typeResolver(parentResolver: TypeResolver) = CustomResolver(parentResolver)
+
+  class CustomResolver(private val parentResolver: TypeResolver) : TypeResolver by SqliteTypeResolver(parentResolver) {
+    override fun functionType(functionExpr: SqlFunctionExpr): IntermediateType? {
+      return when (functionExpr.functionName.text.lowercase()) {
+        "foo" -> encapsulatingType(functionExpr.exprList, PrimitiveType.INTEGER)
+        else -> parentResolver.functionType(functionExpr)
+      }
+    }
+  }
+}

--- a/sqldelight-gradle-plugin/src/test/custom-dialect/dialect/src/main/kotlin/foo/FooDialect.kt
+++ b/sqldelight-gradle-plugin/src/test/custom-dialect/dialect/src/main/kotlin/foo/FooDialect.kt
@@ -1,9 +1,13 @@
 package foo
 
-import app.cash.sqldelight.dialect.api.*
+import app.cash.sqldelight.dialect.api.IntermediateType
+import app.cash.sqldelight.dialect.api.PrimitiveType
+import app.cash.sqldelight.dialect.api.SqlDelightDialect
+import app.cash.sqldelight.dialect.api.TypeResolver
+import app.cash.sqldelight.dialect.api.encapsulatingType
 import app.cash.sqldelight.dialects.sqlite_3_18.SqliteDialect
 import app.cash.sqldelight.dialects.sqlite_3_18.SqliteTypeResolver
-import com.alecstrong.sql.psi.core.psi.*
+import com.alecstrong.sql.psi.core.psi.SqlFunctionExpr
 
 class FooDialect : SqlDelightDialect by SqliteDialect() {
   override fun typeResolver(parentResolver: TypeResolver) = CustomResolver(parentResolver)

--- a/sqldelight-gradle-plugin/src/test/custom-dialect/dialect/src/main/resources/META-INF/services/app.cash.sqldelight.dialect.api.SqlDelightDialect
+++ b/sqldelight-gradle-plugin/src/test/custom-dialect/dialect/src/main/resources/META-INF/services/app.cash.sqldelight.dialect.api.SqlDelightDialect
@@ -1,0 +1,1 @@
+foo.FooDialect

--- a/sqldelight-gradle-plugin/src/test/custom-dialect/settings.gradle
+++ b/sqldelight-gradle-plugin/src/test/custom-dialect/settings.gradle
@@ -1,0 +1,5 @@
+apply from: "../settings.gradle"
+
+rootProject.name = 'custom-dialect'
+
+include(":dialect")

--- a/sqldelight-gradle-plugin/src/test/custom-dialect/src/main/sqldelight/schema/Foo.sq
+++ b/sqldelight-gradle-plugin/src/test/custom-dialect/src/main/sqldelight/schema/Foo.sq
@@ -1,0 +1,6 @@
+CREATE TABLE foo(
+id INTEGER
+);
+
+selectFooWithId:
+SELECT foo(id) FROM foo;

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/dialect/DialectIntegrationTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/dialect/DialectIntegrationTests.kt
@@ -49,4 +49,13 @@ class DialectIntegrationTests {
     val result = runner.build()
     Truth.assertThat(result.output).contains("BUILD SUCCESSFUL")
   }
+
+  @Test fun customFunctionDialect() {
+    val runner = GradleRunner.create()
+      .withCommonConfiguration(File("src/test/custom-dialect"))
+      .withArguments("clean", "assemble", "--stacktrace")
+
+    val result = runner.build()
+    Truth.assertThat(result.output).contains("BUILD SUCCESSFUL")
+  }
 }


### PR DESCRIPTION
Tried to find a better api for simplifying adding custom functions, but adding `customFunction(functionExpr: SqlFunctionExpr): IntermediateType?` to `TypeResolver` results only into overriding the child `customFunction`, but not the parent one, which is called.
So I only add a test but it could be linked in the docs later (in an advanced section)