### PR TITLE
Revert opening dialect and driver classes, use delegating instead

### DIFF
--- a/dialects/hsql/src/main/kotlin/app/cash/sqldelight/dialects/hsql/HsqlDialect.kt
+++ b/dialects/hsql/src/main/kotlin/app/cash/sqldelight/dialects/hsql/HsqlDialect.kt
@@ -15,7 +15,6 @@ import com.squareup.kotlinpoet.ClassName
  */
 class HsqlDialect : SqlDelightDialect {
   override val runtimeTypes: RuntimeTypes = RuntimeTypes(
-    ClassName("app.cash.sqldelight.driver.jdbc", "JdbcDriver"),
     ClassName("app.cash.sqldelight.driver.jdbc", "JdbcCursor"),
     ClassName("app.cash.sqldelight.driver.jdbc", "JdbcPreparedStatement")
   )

--- a/dialects/hsql/src/main/kotlin/app/cash/sqldelight/dialects/hsql/HsqlDialect.kt
+++ b/dialects/hsql/src/main/kotlin/app/cash/sqldelight/dialects/hsql/HsqlDialect.kt
@@ -13,7 +13,7 @@ import com.squareup.kotlinpoet.ClassName
 /**
  * Base dialect for JDBC implementations.
  */
-open class HsqlDialect : SqlDelightDialect {
+class HsqlDialect : SqlDelightDialect {
   override val runtimeTypes: RuntimeTypes = RuntimeTypes(
     ClassName("app.cash.sqldelight.driver.jdbc", "JdbcDriver"),
     ClassName("app.cash.sqldelight.driver.jdbc", "JdbcCursor"),

--- a/dialects/hsql/src/main/kotlin/app/cash/sqldelight/dialects/hsql/HsqlTypeResolver.kt
+++ b/dialects/hsql/src/main/kotlin/app/cash/sqldelight/dialects/hsql/HsqlTypeResolver.kt
@@ -15,7 +15,7 @@ import app.cash.sqldelight.dialects.hsql.grammar.psi.HsqlTypeName
 import com.alecstrong.sql.psi.core.psi.SqlFunctionExpr
 import com.alecstrong.sql.psi.core.psi.SqlTypeName
 
-open class HsqlTypeResolver(private val parentResolver: TypeResolver) : TypeResolver by parentResolver {
+class HsqlTypeResolver(private val parentResolver: TypeResolver) : TypeResolver by parentResolver {
   override fun definitionType(typeName: SqlTypeName): IntermediateType {
     check(typeName is HsqlTypeName)
     with(typeName) {

--- a/dialects/mysql/src/main/kotlin/app/cash/sqldelight/dialects/mysql/MySqlDialect.kt
+++ b/dialects/mysql/src/main/kotlin/app/cash/sqldelight/dialects/mysql/MySqlDialect.kt
@@ -17,7 +17,7 @@ import com.squareup.kotlinpoet.ClassName
 /**
  * Base dialect for JDBC implementations.
  */
-open class MySqlDialect : SqlDelightDialect {
+class MySqlDialect : SqlDelightDialect {
   override val runtimeTypes: RuntimeTypes = RuntimeTypes(
     ClassName("app.cash.sqldelight.driver.jdbc", "JdbcDriver"),
     ClassName("app.cash.sqldelight.driver.jdbc", "JdbcCursor"),

--- a/dialects/mysql/src/main/kotlin/app/cash/sqldelight/dialects/mysql/MySqlDialect.kt
+++ b/dialects/mysql/src/main/kotlin/app/cash/sqldelight/dialects/mysql/MySqlDialect.kt
@@ -19,13 +19,11 @@ import com.squareup.kotlinpoet.ClassName
  */
 class MySqlDialect : SqlDelightDialect {
   override val runtimeTypes: RuntimeTypes = RuntimeTypes(
-    ClassName("app.cash.sqldelight.driver.jdbc", "JdbcDriver"),
     ClassName("app.cash.sqldelight.driver.jdbc", "JdbcCursor"),
     ClassName("app.cash.sqldelight.driver.jdbc", "JdbcPreparedStatement")
   )
 
   override val asyncRuntimeTypes: RuntimeTypes = RuntimeTypes(
-    ClassName("app.cash.sqldelight.driver.r2dbc", "R2dbcDriver"),
     ClassName("app.cash.sqldelight.driver.r2dbc", "R2dbcCursor"),
     ClassName("app.cash.sqldelight.driver.r2dbc", "R2dbcPreparedStatement"),
   )

--- a/dialects/mysql/src/main/kotlin/app/cash/sqldelight/dialects/mysql/MySqlTypeResolver.kt
+++ b/dialects/mysql/src/main/kotlin/app/cash/sqldelight/dialects/mysql/MySqlTypeResolver.kt
@@ -20,7 +20,7 @@ import com.alecstrong.sql.psi.core.psi.SqlTypeName
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
 
-open class MySqlTypeResolver(
+class MySqlTypeResolver(
   private val parentResolver: TypeResolver
 ) : TypeResolver by parentResolver {
   override fun resolvedType(expr: SqlExpr): IntermediateType {

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlDialect.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlDialect.kt
@@ -18,13 +18,11 @@ import com.squareup.kotlinpoet.ClassName
  */
 class PostgreSqlDialect : SqlDelightDialect {
   override val runtimeTypes: RuntimeTypes = RuntimeTypes(
-    ClassName("app.cash.sqldelight.driver.jdbc", "JdbcDriver"),
     ClassName("app.cash.sqldelight.driver.jdbc", "JdbcCursor"),
     ClassName("app.cash.sqldelight.driver.jdbc", "JdbcPreparedStatement"),
   )
 
   override val asyncRuntimeTypes: RuntimeTypes = RuntimeTypes(
-    ClassName("app.cash.sqldelight.driver.r2dbc", "R2dbcDriver"),
     ClassName("app.cash.sqldelight.driver.r2dbc", "R2dbcCursor"),
     ClassName("app.cash.sqldelight.driver.r2dbc", "R2dbcPreparedStatement"),
   )

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlDialect.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlDialect.kt
@@ -16,7 +16,7 @@ import com.squareup.kotlinpoet.ClassName
 /**
  * Base dialect for JDBC implementations.
  */
-open class PostgreSqlDialect : SqlDelightDialect {
+class PostgreSqlDialect : SqlDelightDialect {
   override val runtimeTypes: RuntimeTypes = RuntimeTypes(
     ClassName("app.cash.sqldelight.driver.jdbc", "JdbcDriver"),
     ClassName("app.cash.sqldelight.driver.jdbc", "JdbcCursor"),

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -27,7 +27,7 @@ import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.asTypeName
 
-open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeResolver by parentResolver {
+class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeResolver by parentResolver {
   override fun definitionType(typeName: SqlTypeName): IntermediateType = with(typeName) {
     check(this is PostgreSqlTypeName)
     val type = IntermediateType(

--- a/dialects/sqlite-3-35/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_35/SqliteTypeResolver.kt
+++ b/dialects/sqlite-3-35/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_35/SqliteTypeResolver.kt
@@ -9,7 +9,7 @@ import com.alecstrong.sql.psi.core.psi.SqlAnnotatedElement
 import com.alecstrong.sql.psi.core.psi.SqlStmt
 import app.cash.sqldelight.dialects.sqlite_3_24.SqliteTypeResolver as Sqlite324TypeResolver
 
-open class SqliteTypeResolver(private val parentResolver: TypeResolver) : Sqlite324TypeResolver(parentResolver) {
+class SqliteTypeResolver(private val parentResolver: TypeResolver) : Sqlite324TypeResolver(parentResolver) {
   override fun queryWithResults(sqlStmt: SqlStmt): QueryWithResults? {
     sqlStmt.insertStmt?.let { insert ->
       check(insert is SqliteInsertStmt)

--- a/dialects/sqlite-3-38/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_38/SqliteDialect.kt
+++ b/dialects/sqlite-3-38/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_38/SqliteDialect.kt
@@ -3,7 +3,7 @@ package app.cash.sqldelight.dialects.sqlite_3_38
 import app.cash.sqldelight.dialects.sqlite_3_38.grammar.SqliteParserUtil
 import app.cash.sqldelight.dialects.sqlite_3_35.SqliteDialect as Sqlite335Dialect
 
-open class SqliteDialect : Sqlite335Dialect() {
+class SqliteDialect : Sqlite335Dialect() {
   override fun setup() {
     super.setup()
     SqliteParserUtil.reset()

--- a/drivers/android-driver/src/main/java/app/cash/sqldelight/driver/android/AndroidSqliteDriver.kt
+++ b/drivers/android-driver/src/main/java/app/cash/sqldelight/driver/android/AndroidSqliteDriver.kt
@@ -182,7 +182,7 @@ class AndroidSqliteDriver private constructor(
     return openHelper?.close() ?: database.close()
   }
 
-  open class Callback(
+  class Callback(
     private val schema: SqlSchema,
     vararg callbacks: AfterVersion,
   ) : SupportSQLiteOpenHelper.Callback(schema.version) {

--- a/drivers/jdbc-driver/src/main/kotlin/app/cash/sqldelight/driver/jdbc/JdbcDriver.kt
+++ b/drivers/jdbc-driver/src/main/kotlin/app/cash/sqldelight/driver/jdbc/JdbcDriver.kt
@@ -173,7 +173,7 @@ abstract class JdbcDriver : SqlDriver, ConnectionManager {
  * Binds the parameter to [preparedStatement] by calling [bindString], [bindLong] or similar.
  * After binding, [execute] executes the query without a result, while [executeQuery] returns [JdbcCursor].
  */
-open class JdbcPreparedStatement(
+class JdbcPreparedStatement(
   private val preparedStatement: PreparedStatement
 ) : SqlPreparedStatement {
   override fun bindBytes(index: Int, bytes: ByteArray?) {
@@ -287,7 +287,7 @@ open class JdbcPreparedStatement(
  * Iterate each row in [resultSet] and map the columns to Kotlin classes by calling [getString], [getLong] etc.
  * Use [next] to retrieve the next row and [close] to close the connection.
  */
-open class JdbcCursor(val resultSet: ResultSet) : SqlCursor {
+class JdbcCursor(val resultSet: ResultSet) : SqlCursor {
   override fun getString(index: Int): String? = resultSet.getString(index + 1)
   override fun getBytes(index: Int): ByteArray? = resultSet.getBytes(index + 1)
   override fun getBoolean(index: Int): Boolean? = getAtIndex(index, resultSet::getBoolean)

--- a/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
+++ b/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
@@ -98,7 +98,7 @@ class R2dbcDriver(private val connection: Connection) : SqlDriver {
   }
 }
 
-open class R2dbcPreparedStatement(private val statement: Statement) : SqlPreparedStatement {
+class R2dbcPreparedStatement(private val statement: Statement) : SqlPreparedStatement {
   override fun bindBytes(index: Int, bytes: ByteArray?) {
     if (bytes == null) {
       statement.bindNull(index, ByteArray::class.java)
@@ -151,7 +151,7 @@ open class R2dbcPreparedStatement(private val statement: Statement) : SqlPrepare
 /**
  * TODO: Write a better async cursor API
  */
-open class R2dbcCursor(val rowSet: List<Map<Int, Any?>>) : SqlCursor {
+class R2dbcCursor(val rowSet: List<Map<Int, Any?>>) : SqlCursor {
   var row = -1
     private set
 

--- a/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/RuntimeTypes.kt
+++ b/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/RuntimeTypes.kt
@@ -6,7 +6,6 @@ import com.squareup.kotlinpoet.ClassName
  * Types that can be specified by each dialect for different driver components
  */
 data class RuntimeTypes(
-  val driverType: ClassName,
   val cursorType: ClassName,
   val preparedStatementType: ClassName
 )

--- a/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/SqlDelightDialect.kt
+++ b/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/SqlDelightDialect.kt
@@ -9,7 +9,6 @@ interface SqlDelightDialect {
    */
   val runtimeTypes: RuntimeTypes
     get() = RuntimeTypes(
-      ClassName("app.cash.sqldelight.db", "SqlDriver"),
       ClassName("app.cash.sqldelight.db", "SqlCursor"),
       ClassName("app.cash.sqldelight.db", "SqlPreparedStatement"),
     )
@@ -19,7 +18,6 @@ interface SqlDelightDialect {
    */
   val asyncRuntimeTypes: RuntimeTypes
     get() = RuntimeTypes(
-      ClassName("app.cash.sqldelight.db", "SqlDriver"),
       ClassName("app.cash.sqldelight.db", "SqlCursor"),
       ClassName("app.cash.sqldelight.db", "SqlPreparedStatement"),
     )

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/DatabaseGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/DatabaseGenerator.kt
@@ -78,7 +78,7 @@ internal class DatabaseGenerator(
 
     // Database constructor parameter:
     // driver: SqlDriver
-    val dbParameter = ParameterSpec.builder(DRIVER_NAME, if (generateAsync) dialect.asyncRuntimeTypes.driverType else dialect.runtimeTypes.driverType).build()
+    val dbParameter = ParameterSpec.builder(DRIVER_NAME, DRIVER_TYPE).build()
     invoke.addParameter(dbParameter)
     invokeReturn.add("%N", dbParameter)
 
@@ -139,13 +139,11 @@ internal class DatabaseGenerator(
       .addModifiers(PRIVATE)
       .addSuperclassConstructorParameter(DRIVER_NAME)
 
-    val dialectDriverType = if (generateAsync) dialect.asyncRuntimeTypes.driverType else dialect.runtimeTypes.driverType
-
     val constructor = FunSpec.constructorBuilder()
 
     // Database constructor parameter:
     // driver: SqlDriver
-    val dbParameter = ParameterSpec.builder(DRIVER_NAME, dialectDriverType).build()
+    val dbParameter = ParameterSpec.builder(DRIVER_NAME, DRIVER_TYPE).build()
     constructor.addParameter(dbParameter)
 
     // Static on create function:

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/QueriesTypeGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/QueriesTypeGenerator.kt
@@ -2,8 +2,8 @@ package app.cash.sqldelight.core.compiler
 
 import app.cash.sqldelight.core.compiler.model.NamedExecute
 import app.cash.sqldelight.core.compiler.model.NamedMutator
-import app.cash.sqldelight.core.lang.DRIVER_TYPE
 import app.cash.sqldelight.core.lang.DRIVER_NAME
+import app.cash.sqldelight.core.lang.DRIVER_TYPE
 import app.cash.sqldelight.core.lang.SUSPENDING_TRANSACTER_IMPL_TYPE
 import app.cash.sqldelight.core.lang.SqlDelightQueriesFile
 import app.cash.sqldelight.core.lang.TRANSACTER_IMPL_TYPE

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/QueriesTypeGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/QueriesTypeGenerator.kt
@@ -2,6 +2,7 @@ package app.cash.sqldelight.core.compiler
 
 import app.cash.sqldelight.core.compiler.model.NamedExecute
 import app.cash.sqldelight.core.compiler.model.NamedMutator
+import app.cash.sqldelight.core.lang.DRIVER_TYPE
 import app.cash.sqldelight.core.lang.DRIVER_NAME
 import app.cash.sqldelight.core.lang.SUSPENDING_TRANSACTER_IMPL_TYPE
 import app.cash.sqldelight.core.lang.SqlDelightQueriesFile
@@ -34,15 +35,13 @@ class QueriesTypeGenerator(
       return null
     }
 
-    val driverType = if (generateAsync) dialect.asyncRuntimeTypes.driverType else dialect.runtimeTypes.driverType
-
     val type = TypeSpec.classBuilder(file.queriesType.simpleName)
       .superclass(if (generateAsync) SUSPENDING_TRANSACTER_IMPL_TYPE else TRANSACTER_IMPL_TYPE)
 
     val constructor = FunSpec.constructorBuilder()
 
     // Add the driver as a constructor parameter:
-    constructor.addParameter(DRIVER_NAME, driverType)
+    constructor.addParameter(DRIVER_NAME, DRIVER_TYPE)
     type.addSuperclassConstructorParameter(DRIVER_NAME)
 
     // Add any required adapters.

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueryWrapperTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueryWrapperTest.kt
@@ -201,7 +201,6 @@ class QueryWrapperTest {
         |import app.cash.sqldelight.db.QueryResult
         |import app.cash.sqldelight.db.SqlDriver
         |import app.cash.sqldelight.db.SqlSchema
-        |import app.cash.sqldelight.driver.jdbc.JdbcDriver
         |import com.example.TestDatabase
         |import kotlin.Int
         |import kotlin.Unit
@@ -210,11 +209,11 @@ class QueryWrapperTest {
         |internal val KClass<TestDatabase>.schema: SqlSchema
         |  get() = TestDatabaseImpl.Schema
         |
-        |internal fun KClass<TestDatabase>.newInstance(driver: JdbcDriver): TestDatabase =
+        |internal fun KClass<TestDatabase>.newInstance(driver: SqlDriver): TestDatabase =
         |    TestDatabaseImpl(driver)
         |
         |private class TestDatabaseImpl(
-        |  driver: JdbcDriver,
+        |  driver: SqlDriver,
         |) : TransacterImpl(driver), TestDatabase {
         |  public object Schema : SqlSchema {
         |    public override val version: Int
@@ -378,7 +377,6 @@ class QueryWrapperTest {
         |import app.cash.sqldelight.db.QueryResult
         |import app.cash.sqldelight.db.SqlDriver
         |import app.cash.sqldelight.db.SqlSchema
-        |import app.cash.sqldelight.driver.jdbc.JdbcDriver
         |import com.example.TestDatabase
         |import kotlin.Int
         |import kotlin.Unit
@@ -387,11 +385,11 @@ class QueryWrapperTest {
         |internal val KClass<TestDatabase>.schema: SqlSchema
         |  get() = TestDatabaseImpl.Schema
         |
-        |internal fun KClass<TestDatabase>.newInstance(driver: JdbcDriver): TestDatabase =
+        |internal fun KClass<TestDatabase>.newInstance(driver: SqlDriver): TestDatabase =
         |    TestDatabaseImpl(driver)
         |
         |private class TestDatabaseImpl(
-        |  driver: JdbcDriver,
+        |  driver: SqlDriver,
         |) : TransacterImpl(driver), TestDatabase {
         |  public object Schema : SqlSchema {
         |    public override val version: Int

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
@@ -857,8 +857,8 @@ class InterfaceGeneration {
       |import app.cash.sqldelight.TransacterImpl
       |import app.cash.sqldelight.db.QueryResult
       |import app.cash.sqldelight.db.SqlCursor
+      |import app.cash.sqldelight.db.SqlDriver
       |import app.cash.sqldelight.driver.jdbc.JdbcCursor
-      |import app.cash.sqldelight.driver.jdbc.JdbcDriver
       |import app.cash.sqldelight.driver.jdbc.JdbcPreparedStatement
       |import kotlin.Any
       |import kotlin.Int
@@ -866,7 +866,7 @@ class InterfaceGeneration {
       |import kotlin.Unit
       |
       |public class SubscriptionQueries(
-      |  driver: JdbcDriver,
+      |  driver: SqlDriver,
       |) : TransacterImpl(driver) {
       |  public fun insertUser(slack_user_id: String): Query<Int> = InsertUserQuery(slack_user_id) {
       |      cursor ->

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-rename-column/output/com/example/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-rename-column/output/com/example/DataQueries.kt
@@ -1,12 +1,12 @@
 package com.example
 
 import app.cash.sqldelight.TransacterImpl
-import app.cash.sqldelight.driver.jdbc.JdbcDriver
+import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.jdbc.JdbcPreparedStatement
 import kotlin.Unit
 
 public class DataQueries(
-  driver: JdbcDriver,
+  driver: SqlDriver,
   private val testAdapter: Test.Adapter,
 ) : TransacterImpl(driver) {
   public fun insertWhole(test: Test): Unit {


### PR DESCRIPTION
Make Jake happy: https://github.com/cashapp/sqldelight/pull/2672#issuecomment-1016581976
Because delegating works only with interfaces the queries need to take `SqlDriver` instead: https://github.com/cashapp/sqldelight/pull/2918#issuecomment-1153214004