### PR TITLE
Hsql: Support using DEFAULT for generated columns in Insert

### DIFF
--- a/dialects/hsql/src/main/kotlin/app/cash/sqldelight/dialects/hsql/grammar/hsql.bnf
+++ b/dialects/hsql/src/main/kotlin/app/cash/sqldelight/dialects/hsql/grammar/hsql.bnf
@@ -6,7 +6,7 @@
   implements="com.alecstrong.sql.psi.core.psi.SqlCompositeElement"
   extends="com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl"
   psiClassPrefix = "Hsql"
-  
+
   parserImports=[
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.CONSTRAINT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.PRIMARY"
@@ -61,7 +61,7 @@ column_constraint ::= [ CONSTRAINT {identifier} ] (
   implements = "com.alecstrong.sql.psi.core.psi.SqlColumnConstraint"
   override = true
 }
-bind_parameter ::= ( '?' | ':' {identifier} ) {
+bind_parameter ::= ( 'DEFAULT' | '?' | ':' {identifier} ) {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlBindParameterImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlBindParameter"
   override = true

--- a/dialects/hsql/src/test/fixtures_hsql/insert/insert.s
+++ b/dialects/hsql/src/test/fixtures_hsql/insert/insert.s
@@ -3,6 +3,6 @@ CREATE TABLE InsertTbl (
   name VARCHAR(255) NOT NULL
 );
 
-INSERT INTO InsertTbl VALUES (1, 'john');
+INSERT INTO InsertTbl VALUES (DEFAULT, 'john');
 
 INSERT INTO InsertTbl(name) VALUES ('john');


### PR DESCRIPTION
```
When you add a new row to such a table using an INSERT INTO <tablename> ... statement, you can use the DEFAULT keyword for the IDENTITY column, which results in an auto-generated value for the column.
```
https://www.hsqldb.org/doc/2.0/guide/databaseobjects-chapt.html

Workaround for #3370 to provide a value for generated column. Not needed with a new release of sql-psi :P