### PR TITLE
Add a default dispatcher to the KeyedQueryPagingSource backed QueryPagingSource function

### DIFF
--- a/extensions/android-paging3/src/main/java/app/cash/sqldelight/paging3/QueryPagingSource.kt
+++ b/extensions/android-paging3/src/main/java/app/cash/sqldelight/paging3/QueryPagingSource.kt
@@ -133,7 +133,7 @@ fun <RowType : Any> QueryPagingSource(
 @Suppress("FunctionName")
 fun <Key : Any, RowType : Any> QueryPagingSource(
   transacter: Transacter,
-  context: CoroutineContext,
+  context: CoroutineContext = Dispatchers.IO,
   pageBoundariesProvider: (anchor: Key?, limit: Long) -> Query<Key>,
   queryProvider: (beginInclusive: Key, endExclusive: Key?) -> Query<RowType>,
 ): PagingSource<Key, RowType> = KeyedQueryPagingSource(


### PR DESCRIPTION
This is expected, as per the documentation:

https://github.com/cashapp/sqldelight/blob/e4b10641ca83e3f9e15f8d302f7f17db4ce7a1ab/docs/android_sqlite/android_paging.md?plain=1#L95