### PR TITLE
Make OffsetQueryPagingSource only work with Int

### DIFF
--- a/docs/android_sqlite/android_paging.md
+++ b/docs/android_sqlite/android_paging.md
@@ -54,7 +54,7 @@ ORDER BY id ASC;
 
 Queries used in keyset paging must have a unique ordering like shown above. 
 
-Both `beginInclusive` and `endExclusive` are _pre-calculated_ keys that act as page boundaries. Page sizes are established when pre-calculating page boundaries. The `pageBoundariesProvider` callback takes an `anchor: Key?` parameter as well as a `limit: Long?` parameter. An example query that pre-calculates page boundaries is shown below. 
+Both `beginInclusive` and `endExclusive` are _pre-calculated_ keys that act as page boundaries. Page sizes are established when pre-calculating page boundaries. The `pageBoundariesProvider` callback takes an `anchor: Key?` parameter as well as a `limit: Int?` parameter. An example query that pre-calculates page boundaries is shown below. 
 
 ```sql
 pageBoundaries:

--- a/extensions/android-paging3/src/main/java/app/cash/sqldelight/paging3/QueryPagingSource.kt
+++ b/extensions/android-paging3/src/main/java/app/cash/sqldelight/paging3/QueryPagingSource.kt
@@ -59,11 +59,11 @@ internal abstract class QueryPagingSource<Key : Any, RowType : Any> :
  */
 @Suppress("FunctionName")
 fun <RowType : Any> QueryPagingSource(
-  countQuery: Query<Long>,
+  countQuery: Query<Int>,
   transacter: Transacter,
   context: CoroutineContext = Dispatchers.IO,
-  queryProvider: (limit: Long, offset: Long) -> Query<RowType>,
-): PagingSource<Long, RowType> = OffsetQueryPagingSource(
+  queryProvider: (limit: Int, offset: Int) -> Query<RowType>,
+): PagingSource<Int, RowType> = OffsetQueryPagingSource(
   queryProvider,
   countQuery,
   transacter,

--- a/extensions/android-paging3/src/test/java/app/cash/sqldelight/paging3/OffsetQueryPagingSourceTest.kt
+++ b/extensions/android-paging3/src/test/java/app/cash/sqldelight/paging3/OffsetQueryPagingSourceTest.kt
@@ -72,7 +72,7 @@ class OffsetQueryPagingSourceTest {
     val results = runBlocking { source.load(Refresh(null, 2, false)) }
 
     assertNull((results as LoadResult.Page).prevKey)
-    assertEquals(2L, results.nextKey)
+    assertEquals(2, results.nextKey)
   }
 
   @Test fun `aligned last page gives correct prevKey and nextKey`() {
@@ -85,7 +85,7 @@ class OffsetQueryPagingSourceTest {
 
     val results = runBlocking { source.load(Refresh(8, 2, false)) }
 
-    assertEquals(6L, (results as LoadResult.Page).prevKey)
+    assertEquals(6, (results as LoadResult.Page).prevKey)
     assertNull(results.nextKey)
   }
 
@@ -98,12 +98,13 @@ class OffsetQueryPagingSourceTest {
     )
 
     runBlocking {
-      val expected = (0L until 10L).chunked(2).iterator()
-      var nextKey: Long? = null
+      val expected = (0 until 10).chunked(2).iterator()
+      var nextKey: Int? = null
       do {
         val results = source.load(Refresh(nextKey, 2, false))
         assertEquals(expected.next(), (results as LoadResult.Page).data)
         nextKey = results.nextKey
+        1L.toInt()
       } while (nextKey != null)
     }
   }
@@ -118,7 +119,7 @@ class OffsetQueryPagingSourceTest {
 
     val results = runBlocking { source.load(Refresh(9, 2, false)) }
 
-    assertEquals(7L, (results as LoadResult.Page).prevKey)
+    assertEquals(7, (results as LoadResult.Page).prevKey)
     assertNull(results.nextKey)
   }
 
@@ -130,10 +131,10 @@ class OffsetQueryPagingSourceTest {
       EmptyCoroutineContext,
     )
 
-    val results = runBlocking { source.load(Refresh(1L, 2, false)) }
+    val results = runBlocking { source.load(Refresh(1, 2, false)) }
 
-    assertEquals(-1L, (results as LoadResult.Page).prevKey)
-    assertEquals(3L, results.nextKey)
+    assertEquals(-1, (results as LoadResult.Page).prevKey)
+    assertEquals(3, results.nextKey)
   }
 
   @Test fun `initial page has correct itemsBefore and itemsAfter`() {
@@ -215,8 +216,8 @@ class OffsetQueryPagingSourceTest {
     )
 
     runBlocking {
-      val expected = listOf(listOf(1L, 2L), listOf(0L)).iterator()
-      var prevKey: Long? = 1L
+      val expected = listOf(listOf(1, 2), listOf(0)).iterator()
+      var prevKey: Int? = 1
       do {
         val results = source.load(Refresh(prevKey, 2, false))
         assertEquals(expected.next(), (results as LoadResult.Page).data)
@@ -256,12 +257,12 @@ class OffsetQueryPagingSourceTest {
     assertTrue(source.invalid)
   }
 
-  private fun query(limit: Long, offset: Long) = object : Query<Long>(
-    { cursor -> cursor.getLong(0)!! },
+  private fun query(limit: Int, offset: Int) = object : Query<Int>(
+    { cursor -> cursor.getLong(0)!!.toInt() },
   ) {
     override fun <R> execute(mapper: (SqlCursor) -> R) = driver.executeQuery(1, "SELECT value FROM testTable LIMIT ? OFFSET ?", mapper, 2) {
-      bindLong(0, limit)
-      bindLong(1, offset)
+      bindLong(0, limit.toLong())
+      bindLong(1, offset.toLong())
     }
 
     override fun addListener(listener: Listener) = driver.addListener(listener, arrayOf("testTable"))
@@ -275,7 +276,7 @@ class OffsetQueryPagingSourceTest {
     "Test.sq",
     "count",
     "SELECT count(*) FROM testTable",
-    { it.getLong(0)!! },
+    { it.getLong(0)!!.toInt() },
   )
 
   private fun insert(value: Long, db: SqlDriver = driver) {


### PR DESCRIPTION
Breaking API change! Maybe it's okay as we're releasing SQLDelight 2 soon…

Previously, we're just upcasting `state.anchorPosition` to a `Long`, which screws things up when we have between `Int.MAX_VALUE` and `Long.MAX_VALUE` items in our pager. This is because, when we refresh the paging source, `getRefreshKey(state: PagingState)` is called, and we'll end up with a very wrong `state.anchorPosition`, as it's no longer the "most recently accessed index in the list", but some truncated form of it. The result of `getRefresKey(…)` will end up being passed to `load(params: LoadParams)` in the form of `params.key`, and bad things will happen as it's not the value we're expecting.

The "fix" is just to force a maximum of `Int.MAX_VALUE` items instead of `Long.MAX_VALUE`. Room does the same thing in their [implementation of this class](https://github.com/androidx/androidx/blob/79029d109a40bdfc05c1e385b54b73fd07f7d5d6/room/room-paging/src/main/java/androidx/room/paging/LimitOffsetPagingSource.kt#L50).