### PR TITLE
Infer the Kotlin type of bind parameter, if possible, or fail with a …

### DIFF
--- a/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/TypeResolver.kt
+++ b/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/TypeResolver.kt
@@ -57,7 +57,11 @@ fun TypeResolver.encapsulatingType(
   val types = exprList.map { resolvedType(it) }
   val sqlTypes = types.map { it.dialectType }
 
-  val type = typeOrder.last { it in sqlTypes }
+  val type = typeOrder.lastOrNull { it in sqlTypes }
+    ?: if (PrimitiveType.ARGUMENT in sqlTypes && typeOrder.size == 1) {
+      return IntermediateType(typeOrder.single())
+    } else error("The Kotlin type of the argument cannot be inferred, use CAST instead.")
+
   if (!nullableIfAny && types.all { it.javaType.isNullable } ||
     nullableIfAny && types.any { it.javaType.isNullable }
   ) {

--- a/sqldelight-gradle-plugin/src/test/custom-dialect/src/main/sqldelight/schema/Foo.sq
+++ b/sqldelight-gradle-plugin/src/test/custom-dialect/src/main/sqldelight/schema/Foo.sq
@@ -4,3 +4,6 @@ id INTEGER
 
 selectFooWithId:
 SELECT foo(id) FROM foo;
+
+inferredType:
+SELECT 1 FROM foo WHERE foo(:inferred) NOT NULL;

--- a/sqldelight-gradle-plugin/src/test/custom-dialect/src/test/kotlin/Testing.kt
+++ b/sqldelight-gradle-plugin/src/test/custom-dialect/src/test/kotlin/Testing.kt
@@ -1,0 +1,31 @@
+import app.cash.sqldelight.Query
+import app.cash.sqldelight.driver.jdbc.JdbcDriver
+import org.junit.Test
+import schema.FooQueries
+import java.sql.Connection
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+class Testing {
+  @Test fun inferredCompiles() {
+    val fakeDriver = object : JdbcDriver() {
+      override fun getConnection() = TODO()
+      override fun closeConnection(connection: Connection) = Unit
+      override fun addListener(listener: Query.Listener, queryKeys: Array<String>) = Unit
+      override fun removeListener(listener: Query.Listener, queryKeys: Array<String>) = Unit
+      override fun notifyListeners(queryKeys: Array<String>) = Unit
+    }
+    FooQueries(fakeDriver).inferredType(1.seconds)
+  }
+
+  @Test fun customFunctionReturnsDuration() {
+    val fakeDriver = object : JdbcDriver() {
+      override fun getConnection() = TODO()
+      override fun closeConnection(connection: Connection) = Unit
+      override fun addListener(listener: Query.Listener, queryKeys: Array<String>) = Unit
+      override fun removeListener(listener: Query.Listener, queryKeys: Array<String>) = Unit
+      override fun notifyListeners(queryKeys: Array<String>) = Unit
+    }
+    val unused: Duration = FooQueries(fakeDriver).selectFooWithId().executeAsOne()
+  }
+}

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/dialect/DialectIntegrationTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/dialect/DialectIntegrationTests.kt
@@ -53,7 +53,7 @@ class DialectIntegrationTests {
   @Test fun customFunctionDialect() {
     val runner = GradleRunner.create()
       .withCommonConfiguration(File("src/test/custom-dialect"))
-      .withArguments("clean", "assemble", "--stacktrace")
+      .withArguments("clean", "compileTestKotlin", "--stacktrace")
 
     val result = runner.build()
     Truth.assertThat(result.output).contains("BUILD SUCCESSFUL")


### PR DESCRIPTION
…better error message

Fixes https://github.com/cashapp/sqldelight/issues/3407 with a better error message

The compiler can now infer the Kotlin type of a bind parameter, if `encapsulatingType` has exactly 1 sql type. This is used for `CONCAT`: eg https://github.com/cashapp/sqldelight/blob/02edf13f390229d3eb8986b5c408fd795a085e0f/dialects/mysql/src/main/kotlin/app/cash/sqldelight/dialects/mysql/MySqlTypeResolver.kt#L55