### PR TITLE
Simplify creation of internal releases

### DIFF
--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -11,4 +11,21 @@ publishing {
             url = "${rootProject.buildDir}/localMaven"
         }
     }
+
+    /**
+     * Want to push to an internal repository for testing?
+     * Set the following properties in ~/.gradle/gradle.properties.
+     *
+     * internalUrl=YOUR_INTERNAL_URL
+     * internalUsername=YOUR_USERNAME
+     * internalPassword=YOUR_PASSWORD
+     */
+    def internalUrl = providers.gradleProperty("internalUrl")
+    if (internalUrl.isPresent()) {
+        maven {
+            name = "internal"
+            url = uri(internalUrl)
+            credentials(PasswordCredentials)
+        }
+    }
 }


### PR DESCRIPTION
Similar to https://github.com/square/wire/blob/master/wire-library/build.gradle.kts#L150-L167.

Thanks @jrodbx for originally writing it, and @oldergod for pointing me to the implementation.