### PR TITLE
Don't allow ABS("foo")

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/ExprUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/ExprUtil.kt
@@ -134,7 +134,7 @@ internal object AnsiSqlTypeResolver : TypeResolver {
     }
 
     "avg" -> IntermediateType(REAL).asNullable()
-    "abs" -> exprList[0].type()
+    "abs" -> encapsulatingType(exprList, INTEGER, REAL)
     "iif" -> exprList[1].type()
     "coalesce", "ifnull" -> encapsulatingType(exprList, INTEGER, REAL, TEXT, BLOB)
     "nullif" -> exprList[0].type().asNullable()


### PR DESCRIPTION
It is not valid SQL, but SqlDelight supports it.