### PR TITLE
Support inferring kotlin type from other parameters

### DIFF
--- a/sqldelight-gradle-plugin/src/test/custom-dialect/src/main/sqldelight/schema/Foo.sq
+++ b/sqldelight-gradle-plugin/src/test/custom-dialect/src/main/sqldelight/schema/Foo.sq
@@ -7,3 +7,6 @@ SELECT foo(id) FROM foo;
 
 inferredType:
 SELECT 1 FROM foo WHERE foo(:inferred) NOT NULL;
+
+inferredTypeFromMax:
+SELECT 1 FROM foo WHERE max(1, :inferred);

--- a/sqldelight-gradle-plugin/src/test/custom-dialect/src/test/kotlin/Testing.kt
+++ b/sqldelight-gradle-plugin/src/test/custom-dialect/src/test/kotlin/Testing.kt
@@ -7,25 +7,23 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 class Testing {
-  @Test fun inferredCompiles() {
-    val fakeDriver = object : JdbcDriver() {
-      override fun getConnection() = TODO()
-      override fun closeConnection(connection: Connection) = Unit
-      override fun addListener(listener: Query.Listener, queryKeys: Array<String>) = Unit
-      override fun removeListener(listener: Query.Listener, queryKeys: Array<String>) = Unit
-      override fun notifyListeners(queryKeys: Array<String>) = Unit
-    }
-    FooQueries(fakeDriver).inferredType(1.seconds)
+  val fakeDriver = object : JdbcDriver() {
+    override fun getConnection() = TODO()
+    override fun closeConnection(connection: Connection) = Unit
+    override fun addListener(listener: Query.Listener, queryKeys: Array<String>) = Unit
+    override fun removeListener(listener: Query.Listener, queryKeys: Array<String>) = Unit
+    override fun notifyListeners(queryKeys: Array<String>) = Unit
   }
 
   @Test fun customFunctionReturnsDuration() {
-    val fakeDriver = object : JdbcDriver() {
-      override fun getConnection() = TODO()
-      override fun closeConnection(connection: Connection) = Unit
-      override fun addListener(listener: Query.Listener, queryKeys: Array<String>) = Unit
-      override fun removeListener(listener: Query.Listener, queryKeys: Array<String>) = Unit
-      override fun notifyListeners(queryKeys: Array<String>) = Unit
-    }
     val unused: Duration = FooQueries(fakeDriver).selectFooWithId().executeAsOne()
+  }
+
+  @Test fun inferredCompiles() {
+    FooQueries(fakeDriver).inferredType(1.seconds)
+  }
+
+  @Test fun inferredTypeFromMaxIsLong() {
+    FooQueries(fakeDriver).inferredTypeFromMax(1L).executeAsOne()
   }
 }


### PR DESCRIPTION
Fixes #3416

It only infers the Kotlin type, if all other parameters of the function have the same type:
`MAX(Int, Int, ARG) = > Arg = Int`.
So `MAX(Int, Text, ARG)` would result into an error, because the type is ambiguous.