### PR TITLE
Upgrade API docs and add 2.x API links

### DIFF
--- a/.github/workflows/prepare_mkdocs.sh
+++ b/.github/workflows/prepare_mkdocs.sh
@@ -9,29 +9,21 @@
 set -ex
 
 # Generate the API docs
-./gradlew dokkaGfm
+./gradlew dokkaHtmlMultiModule
 
-# Dokka filenames like `-http-url/index.md` don't work well with MkDocs <title> tags.
-# Assign metadata to the file's first Markdown heading.
-# https://www.mkdocs.org/user-guide/writing-your-docs/#meta-data
-title_markdown_file() {
-  TITLE_PATTERN="s/^[#]+ *(.*)/title: \1 - SQLDelight/"
-  echo "---"                                                     > "$1.fixed"
-  cat $1 | sed -E "$TITLE_PATTERN" | grep "title: " | head -n 1 >> "$1.fixed"
-  echo "---"                                                    >> "$1.fixed"
-  echo                                                          >> "$1.fixed"
-  cat $1                                                        >> "$1.fixed"
-  mv "$1.fixed" "$1"
-}
-
+# Fix up some styling/functionality on the generated dokka HTML pages
 set +x
-for MARKDOWN_FILE in $(find docs/1.x/ -name '*.md'); do
-  echo $MARKDOWN_FILE
-  title_markdown_file $MARKDOWN_FILE
+for HTML_FILE in $(find docs/2.x/ -name '*.html'); do
+  echo $HTML_FILE
+
+  # Change header link to direct back to the main docs site
+  sed -i '' 's/<a href="\(.*\)">SQLDelight<\/a>/<a href="\/sqldelight\/">SQLDelight<\/a>/g' $HTML_FILE
+  sed -i '' 's/<a href="\(.*\)"><span>SQLDelight<\/span><\/a>/<a href="\/sqldelight\/"><span>SQLDelight<\/span><\/a>/g' $HTML_FILE
+  # Add a link to the favicon
+  sed -i '' 's/<\/head>/<link rel="icon" href="\/sqldelight\/images\/icon-cashapp.png"><\/head>/g' $HTML_FILE
 done
 set -x
 
 # Copy in special files that GitHub wants in the project root.
-cp UPGRADING.md docs/upgrading.md
 cp CHANGELOG.md docs/changelog.md
 cp CONTRIBUTING.md docs/contributing.md

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ iosApp.xcworkspace
 # Mkdocs
 site/
 docs/1.x
+docs/2.x
 docs/changelog.md
 docs/upgrading.md
 docs/contributing.md

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
   alias(deps.plugins.android.application) apply false
   alias(deps.plugins.android.library) apply false
   alias(deps.plugins.publish) apply false
-  alias(deps.plugins.dokka) apply false
+  alias(deps.plugins.dokka)
   alias(deps.plugins.spotless)
 }
 
@@ -79,4 +79,16 @@ allprojects {
 
   group = GROUP
   version = VERSION_NAME
+}
+
+tasks.named("dokkaHtmlMultiModule").configure {
+  outputDirectory = file("$rootDir/docs/2.x")
+
+  moduleName.set("SQLDelight")
+  pluginsMapConfiguration.set(["org.jetbrains.dokka.base.DokkaBase": """
+    {
+      "footerMessage": "Copyright &copy; 2022 Square, Inc.",
+      "customStyleSheets": ["${file("docs/css/logo-styles.css")}"]
+    }
+  """])
 }

--- a/docs/css/logo-styles.css
+++ b/docs/css/logo-styles.css
@@ -1,0 +1,25 @@
+@import url("/sqldelight/css/app.css");
+
+:root {
+  --color-dark: #7e56c2;
+}
+
+.library-name a {
+  display: flex;
+  font-size: 1.1rem;
+}
+
+.library-name a::before {
+  content: ' ';
+  background: url("/sqldelight/images/icon-cashapp.png") center no-repeat;
+  height: 24px;
+  width: 24px;
+  background-size: cover;
+  display: inline-block;
+  margin-right: 24px;
+}
+
+h1, h2, h3, h4, .library-name a {
+  font-family: cash-market, "Helvetica Neue", helvetica, sans-serif !important;
+  font-weight: bold;
+}

--- a/extensions/android-paging3/android-test/build.gradle
+++ b/extensions/android-paging3/android-test/build.gradle
@@ -1,6 +1,7 @@
 plugins {
   alias(deps.plugins.android.library)
   alias(deps.plugins.kotlin.android)
+  alias(deps.plugins.dokka)
 }
 
 android {

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -1,9 +1,3 @@
-plugins.withId("org.jetbrains.dokka") {
-    tasks.named("dokkaGfm").configure {
-        outputDirectory = file("$rootDir/docs/1.x")
-    }
-}
-
 publishing {
     repositories {
         maven {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,13 @@ nav:
     - 'IntelliJ Plugin': android_sqlite/intellij_plugin.md
     - 'Gradle': android_sqlite/gradle.md
     - 'Upgrading Pre-1.0': android_sqlite/upgrading.md
+    - '2.x API':
+        - 'coroutines-extensions': 2.x/extensions/coroutines-extensions/index.html
+        - 'rxjava2-extensions': 2.x/extensions/rxjava2-extensions/index.html
+        - 'rxjava3-extensions': 2.x/extensions/rxjava3-extensions/index.html
+        - 'android-paging3': 2.x/extensions/android-paging3/index.html
+        - 'android-driver': 2.x/drivers/android-driver/index.html
+        - 'runtime': 2.x/runtime/index.html
     - '1.x API':
         - 'coroutines-extensions': 1.x/coroutines-extensions/index.md
         - 'rxjava2-extensions': 1.x/rxjava2-extensions/index.md
@@ -55,6 +62,9 @@ nav:
       - 'IntelliJ Plugin': multiplatform_sqlite/intellij_plugin.md
       - 'Gradle': multiplatform_sqlite/gradle.md
       - 'Resources': multiplatform_sqlite/resources.md
+      - '2.x API':
+          - 'coroutines-extensions': 2.x/extensions/coroutines-extensions/index.html
+          - 'runtime': 2.x/runtime/index.html
       - '1.x API':
           - 'coroutines-extensions': 1.x/coroutines-extensions/index.md
           - 'runtime': 1.x/runtime/index.md
@@ -70,6 +80,9 @@ nav:
       - 'Migrations': jvm_mysql/migrations.md
       - 'IntelliJ Plugin': jvm_mysql/intellij_plugin.md
       - 'Gradle': jvm_mysql/gradle.md
+      - '2.x API':
+          - 'jdbc-driver': 2.x/drivers/jdbc-driver/index.html
+          - 'runtime': 2.x/runtime/index.html
       - '1.x API':
           - 'jdbc-driver': 1.x/jdbc-driver/index.md
           - 'runtime': 1.x/runtime/index.md
@@ -85,6 +98,9 @@ nav:
       - 'Migrations': jvm_postgresql/migrations.md
       - 'IntelliJ Plugin': jvm_postgresql/intellij_plugin.md
       - 'Gradle': jvm_postgresql/gradle.md
+      - '2.x API':
+          - 'jdbc-driver': 2.x/drivers/jdbc-driver/index.html
+          - 'runtime': 2.x/runtime/index.html
       - '1.x API':
           - 'jdbc-driver': 1.x/jdbc-driver/index.md
           - 'runtime': 1.x/runtime/index.md
@@ -100,6 +116,9 @@ nav:
       - 'Migrations': jvm_h2/migrations.md
       - 'IntelliJ Plugin': jvm_h2/intellij_plugin.md
       - 'Gradle': jvm_h2/gradle.md
+      - '2.x API':
+          - 'jdbc-driver': 2.x/drivers/jdbc-driver/index.html
+          - 'runtime': 2.x/runtime/index.html
       - '1.x API':
           - 'jdbc-driver': 1.x/jdbc-driver/index.md
           - 'runtime': 1.x/runtime/index.md
@@ -117,6 +136,10 @@ nav:
     - 'Migrations': native_sqlite/migrations.md
     - 'IntelliJ Plugin': native_sqlite/intellij_plugin.md
     - 'Gradle': native_sqlite/gradle.md
+    - '2.x API':
+        - 'coroutines-extensions': 2.x/extensions/coroutines-extensions/index.html
+        - 'native-driver': 2.x/drivers/native-driver/index.html
+        - 'runtime': 2.x/runtime/index.html
     - '1.x API':
       - 'coroutines-extensions': 1.x/coroutines-extensions/index.md
       - 'native-driver': 1.x/native-driver/index.md
@@ -136,6 +159,12 @@ nav:
     - 'Migrations': jvm_sqlite/migrations.md
     - 'IntelliJ Plugin': jvm_sqlite/intellij_plugin.md
     - 'Gradle': jvm_sqlite/gradle.md
+    - '2.x API':
+        - 'coroutines-extensions': 2.x/extensions/coroutines-extensions/index.html
+        - 'rxjava2-extensions': 2.x/extensions/rxjava2-extensions/index.html
+        - 'rxjava3-extensions': 2.x/extensions/rxjava3-extensions/index.html
+        - 'sqlite-driver': 2.x/drivers/sqlite-driver/index.html
+        - 'runtime': 2.x/runtime/index.html
     - '1.x API':
         - 'coroutines-extensions': 1.x/coroutines-extensions/index.md
         - 'rxjava2-extensions': 1.x/rxjava2-extensions/index.md
@@ -158,10 +187,16 @@ nav:
       - 'Migrations': js_sqlite/migrations.md
       - 'IntelliJ Plugin': js_sqlite/intellij_plugin.md
       - 'Gradle': js_sqlite/gradle.md
+      - '2.x API':
+          - 'coroutines-extensions': 2.x/extensions/coroutines-extensions/index.html
+          - 'sqljs-driver': 2.x/drivers/sqljs-driver/index.html
+          - 'runtime': 2.x/runtime/index.html
       - '1.x API':
           - 'coroutines-extensions': 1.x/coroutines-extensions/index.md
           - 'sqljs-driver': 1.x/sqljs-driver/index.md
           - 'runtime': 1.x/runtime/index.md
+
+  - '2.x API': 2.x/index.html
 
   - '1.x API':
       - 'android-driver': 1.x/android-driver/index.md
@@ -193,6 +228,9 @@ extra_css:
   - 'css/app.css'
 
 markdown_extensions:
+  - pymdownx.highlight:
+      use_pygments: true
+  - pymdownx.superfences
   - codehilite:
       guess_lang: false
 


### PR DESCRIPTION
This upgrades the generated API doc pages for 2.x by using Dokka's HTML format, and also adds links for 2.x throughout the other pages.

The generated pages are customized a bit to make it pretty and easier to navigate back to the main docs.
<img width="1727" alt="Screen Shot 2022-08-12 at 4 30 21 PM" src="https://user-images.githubusercontent.com/6743693/184440502-56d5ea64-d9bd-4adf-bdf7-e7676557fa67.png">

The 1.x links are still broken, but I'll leave that for a future PR.