### PR TITLE
Fix compiler error: missing listener with SELECT without tables

### DIFF
--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
@@ -128,28 +128,28 @@ public class PlayerQueries(
     )
   }
 
-  public fun <T : Any> selectNull(mapper: (expr: Void?) -> T): Query<T> = Query(106890351,
-      emptyArray(), driver, "Player.sq", "selectNull", "SELECT NULL") { cursor ->
+  public fun <T : Any> selectNull(mapper: (expr: Void?) -> T): ExecutableQuery<T> = Query(106890351,
+      driver, "Player.sq", "selectNull", "SELECT NULL") { cursor ->
     mapper(
       null
     )
   }
 
-  public fun selectNull(): Query<SelectNull> = selectNull { expr ->
+  public fun selectNull(): ExecutableQuery<SelectNull> = selectNull { expr ->
     SelectNull(
       expr
     )
   }
 
-  public fun <T : Any> selectStuff(mapper: (expr: Long, expr_: Long) -> T): Query<T> =
-      Query(-976770036, emptyArray(), driver, "Player.sq", "selectStuff", "SELECT 1, 2") { cursor ->
+  public fun <T : Any> selectStuff(mapper: (expr: Long, expr_: Long) -> T): ExecutableQuery<T> =
+      Query(-976770036, driver, "Player.sq", "selectStuff", "SELECT 1, 2") { cursor ->
     mapper(
       cursor.getLong(0)!!,
       cursor.getLong(1)!!
     )
   }
 
-  public fun selectStuff(): Query<SelectStuff> = selectStuff { expr, expr_ ->
+  public fun selectStuff(): ExecutableQuery<SelectStuff> = selectStuff { expr, expr_ ->
     SelectStuff(
       expr,
       expr_

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TeamQueries.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TeamQueries.kt
@@ -1,5 +1,6 @@
 package com.example
 
+import app.cash.sqldelight.ExecutableQuery
 import app.cash.sqldelight.Query
 import app.cash.sqldelight.TransacterImpl
 import app.cash.sqldelight.core.integration.Shoots
@@ -56,15 +57,15 @@ public class TeamQueries(
     )
   }
 
-  public fun <T : Any> selectStuff(mapper: (expr: Long, expr_: Long) -> T): Query<T> =
-      Query(397134288, emptyArray(), driver, "Team.sq", "selectStuff", "SELECT 1, 2") { cursor ->
+  public fun <T : Any> selectStuff(mapper: (expr: Long, expr_: Long) -> T): ExecutableQuery<T> =
+      Query(397134288, driver, "Team.sq", "selectStuff", "SELECT 1, 2") { cursor ->
     mapper(
       cursor.getLong(0)!!,
       cursor.getLong(1)!!
     )
   }
 
-  public fun selectStuff(): Query<SelectStuff> = selectStuff { expr, expr_ ->
+  public fun selectStuff(): ExecutableQuery<SelectStuff> = selectStuff { expr, expr_ ->
     SelectStuff(
       expr,
       expr_

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SelectQueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SelectQueryGenerator.kt
@@ -229,11 +229,11 @@ class SelectQueryGenerator(
     if (query.arguments.isEmpty()) {
       // No need for a custom query type, return an instance of Query:
       // return Query(statement, selectForId) { resultSet -> ... }
-      if (query.tablesObserved != null) {
+      val tablesObserved = query.tablesObserved
+      if (tablesObserved.isNullOrEmpty()) {
         function.addCode(
-          "return %T(${query.id}, %L, $DRIVER_NAME, %S, %S, %S)%L",
+          "return %T(${query.id}, $DRIVER_NAME, %S, %S, %S)%L",
           QUERY_TYPE,
-          queryKeys(query.tablesObserved!!),
           query.statement.containingFile.name,
           query.name,
           query.statement.rawSqlText(),
@@ -241,8 +241,9 @@ class SelectQueryGenerator(
         )
       } else {
         function.addCode(
-          "return %T(${query.id}, $DRIVER_NAME, %S, %S, %S)%L",
+          "return %T(${query.id}, %L, $DRIVER_NAME, %S, %S, %S)%L",
           QUERY_TYPE,
+          queryKeys(tablesObserved),
           query.statement.containingFile.name,
           query.name,
           query.statement.rawSqlText(),
@@ -265,16 +266,15 @@ class SelectQueryGenerator(
   }
 
   /**
-   * Either emptyArray() or arrayOf("table1", "table2")
+   * Add the table listener array: arrayOf("table1", "table2")
    */
   private fun queryKeys(tablesObserved: List<TableNameElement>): CodeBlock {
-    return if (tablesObserved.isEmpty()) CodeBlock.of("emptyArray()")
-    else tablesObserved.map { CodeBlock.of("\"${it.name}\"") }
+    return tablesObserved.map { CodeBlock.of("\"${it.name}\"") }
       .joinToCode(", ", prefix = "arrayOf(", suffix = ")")
   }
 
   private fun NamedQuery.supertype() =
-    if (tablesObserved == null) EXECUTABLE_QUERY_TYPE
+    if (tablesObserved.isNullOrEmpty()) EXECUTABLE_QUERY_TYPE
     else QUERY_TYPE
 
   /**

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/model/NamedQuery.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/model/NamedQuery.kt
@@ -126,7 +126,7 @@ data class NamedQuery(
 
   internal val tablesObserved: List<TableNameElement>? by lazy {
     if (queryable is SelectQueryable && queryable.select == queryable.statement) {
-      queryable.select.tablesObserved().takeUnless { it.isEmpty() }
+      queryable.select.tablesObserved()
     } else {
       null
     }

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/model/NamedQuery.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/model/NamedQuery.kt
@@ -126,7 +126,7 @@ data class NamedQuery(
 
   internal val tablesObserved: List<TableNameElement>? by lazy {
     if (queryable is SelectQueryable && queryable.select == queryable.statement) {
-      queryable.select.tablesObserved()
+      queryable.select.tablesObserved().takeUnless { it.isEmpty() }
     } else {
       null
     }

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/SelectQueryFunctionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/SelectQueryFunctionTest.kt
@@ -201,7 +201,7 @@ class SelectQueryFunctionTest {
     val generator = SelectQueryGenerator(file.namedQueries.first())
     assertThat(generator.customResultTypeFunction().toString()).contains(
       """
-      |public fun selectValues(): app.cash.sqldelight.Query<kotlin.String>
+      |public fun selectValues(): app.cash.sqldelight.ExecutableQuery<kotlin.String>
       """.trimMargin(),
     )
   }
@@ -482,7 +482,7 @@ class SelectQueryFunctionTest {
 
     assertThat(generator.customResultTypeFunction().toString()).isEqualTo(
       """
-      |public fun <T : kotlin.Any> selectData(mapper: (expr: java.lang.Void?) -> T): app.cash.sqldelight.Query<T> = app.cash.sqldelight.Query(${query.id}, emptyArray(), driver, "Test.sq", "selectData", "SELECT NULL") { cursor ->
+      |public fun <T : kotlin.Any> selectData(mapper: (expr: java.lang.Void?) -> T): app.cash.sqldelight.ExecutableQuery<T> = app.cash.sqldelight.Query(${query.id}, driver, "Test.sq", "selectData", "SELECT NULL") { cursor ->
       |  mapper(
       |    null
       |  )
@@ -1573,7 +1573,7 @@ class SelectQueryFunctionTest {
 
     assertThat(generator.customResultTypeFunction().toString()).isEqualTo(
       """
-      |public fun selectIf(): app.cash.sqldelight.Query<kotlin.String> = app.cash.sqldelight.Query(${query.id}, emptyArray(), driver, "Test.sq", "selectIf", "SELECT IF(1 = 1, 'yes', 'no')") { cursor ->
+      |public fun selectIf(): app.cash.sqldelight.ExecutableQuery<kotlin.String> = app.cash.sqldelight.Query(${query.id}, driver, "Test.sq", "selectIf", "SELECT IF(1 = 1, 'yes', 'no')") { cursor ->
       |  check(cursor is app.cash.sqldelight.driver.jdbc.JdbcCursor)
       |  cursor.getString(0)!!
       |}
@@ -1790,7 +1790,7 @@ class SelectQueryFunctionTest {
 
     assertThat(generator.customResultTypeFunction().toString()).isEqualTo(
       """
-        |public fun query(expr: kotlin.String): app.cash.sqldelight.Query<kotlin.String> = QueryQuery(expr) { cursor ->
+        |public fun query(expr: kotlin.String): app.cash.sqldelight.ExecutableQuery<kotlin.String> = QueryQuery(expr) { cursor ->
         |  cursor.getString(0)!!
         |}
         |

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/SelectQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/SelectQueryTypeTest.kt
@@ -159,6 +159,33 @@ class SelectQueryTypeTest {
     )
   }
 
+  @Test fun `query type generates properly without from`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |selectWithoutFrom:
+      |SELECT 42;
+      |
+      """.trimMargin(),
+      tempFolder,
+    )
+
+    val query = file.namedQueries.first()
+    val generator = SelectQueryGenerator(query)
+
+    assertThat(generator.querySubtype().toString()).isEqualTo(
+      """
+      |private inner class SelectWithoutFromQuery<out T : kotlin.Any>(
+      |  mapper: (app.cash.sqldelight.db.SqlCursor) -> T,
+      |) : app.cash.sqldelight.ExecutableQuery<T>(mapper) {
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${query.id}, ""${'"'}SELECT 42""${'"'}, mapper, 0)
+      |
+      |  public override fun toString(): kotlin.String = "Test.sq:selectWithoutFrom"
+      |}
+      |
+      """.trimMargin(),
+    )
+  }
+
   @Test fun `bind arguments are ordered in generated type`() {
     val file = FixtureCompiler.parseSql(
       """

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/integrations/IntegrationTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/integrations/IntegrationTest.kt
@@ -273,4 +273,13 @@ class IntegrationTest {
     val result = runner.build()
     assertThat(result.output).contains("BUILD SUCCESSFUL")
   }
+
+  @Test fun selectWithoutFromTest() {
+    val runner = GradleRunner.create()
+      .withCommonConfiguration(File("src/test/selectWithoutFrom"))
+      .withArguments("clean", "assemble", "--stacktrace")
+
+    val result = runner.build()
+    assertThat(result.output).contains("BUILD SUCCESSFUL")
+  }
 }

--- a/sqldelight-gradle-plugin/src/test/selectWithoutFrom/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/selectWithoutFrom/build.gradle
@@ -1,0 +1,24 @@
+buildscript {
+  apply from: "${projectDir.absolutePath}/../buildscript.gradle"
+}
+
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'app.cash.sqldelight'
+
+sqldelight {
+  MyDatabase {
+    packageName = "com.sample"
+    dialect("app.cash.sqldelight:postgresql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
+  }
+}
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+  }
+  mavenCentral()
+}
+
+dependencies {
+  implementation "app.cash.sqldelight:jdbc-driver:${app.cash.sqldelight.VersionKt.VERSION}"
+}

--- a/sqldelight-gradle-plugin/src/test/selectWithoutFrom/settings.gradle
+++ b/sqldelight-gradle-plugin/src/test/selectWithoutFrom/settings.gradle
@@ -1,0 +1,2 @@
+apply from: "../settings.gradle"
+

--- a/sqldelight-gradle-plugin/src/test/selectWithoutFrom/src/main/sqldelight/com/sample/MainTable.sq
+++ b/sqldelight-gradle-plugin/src/test/selectWithoutFrom/src/main/sqldelight/com/sample/MainTable.sq
@@ -1,0 +1,2 @@
+select:
+SELECT AVG(42, ?);


### PR DESCRIPTION
Fixes #3468 

This also affects other code generation:
Before:
```kotlin
public fun <T : Any> selectNull(mapper: (expr: Void?) -> T): Query<T> = Query(106890351, emptyArray(), driver, "Player.sq", "selectNull", "SELECT NULL") { cursor ->
  mapper(
    null
  )
}
```
Now:
```kotlin
public fun <T : Any> selectNull(mapper: (expr: Void?) -> T): ExecutableQuery<T> = Query(106890351, driver, "Player.sq", "selectNull", "SELECT NULL") { cursor ->
  mapper(
    null
  )
}
```
I don't see a reason to use `Query` with `emptyArray()` as listener, because the listener is an empty array. Now the super class `ExecutableQuery` is used without listener support at all.