### PR TITLE
Remove default params to flow extensions

### DIFF
--- a/extensions/coroutines-extensions/src/commonMain/kotlin/app/cash/sqldelight/coroutines/FlowExtensions.kt
+++ b/extensions/coroutines-extensions/src/commonMain/kotlin/app/cash/sqldelight/coroutines/FlowExtensions.kt
@@ -22,7 +22,6 @@ import app.cash.sqldelight.Query
 import app.cash.sqldelight.async.coroutines.awaitAsList
 import app.cash.sqldelight.async.coroutines.awaitAsOne
 import app.cash.sqldelight.async.coroutines.awaitAsOneOrNull
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
 import kotlinx.coroutines.flow.Flow

--- a/extensions/coroutines-extensions/src/commonMain/kotlin/app/cash/sqldelight/coroutines/FlowExtensions.kt
+++ b/extensions/coroutines-extensions/src/commonMain/kotlin/app/cash/sqldelight/coroutines/FlowExtensions.kt
@@ -58,7 +58,7 @@ fun <T : Any> Query<T>.asFlow(): Flow<Query<T>> = flow {
 
 @JvmOverloads
 fun <T : Any> Flow<Query<T>>.mapToOne(
-  context: CoroutineContext = Dispatchers.Default,
+  context: CoroutineContext,
 ): Flow<T> = map {
   withContext(context) {
     it.awaitAsOne()
@@ -68,7 +68,7 @@ fun <T : Any> Flow<Query<T>>.mapToOne(
 @JvmOverloads
 fun <T : Any> Flow<Query<T>>.mapToOneOrDefault(
   defaultValue: T,
-  context: CoroutineContext = Dispatchers.Default,
+  context: CoroutineContext,
 ): Flow<T> = map {
   withContext(context) {
     it.awaitAsOneOrNull() ?: defaultValue
@@ -77,7 +77,7 @@ fun <T : Any> Flow<Query<T>>.mapToOneOrDefault(
 
 @JvmOverloads
 fun <T : Any> Flow<Query<T>>.mapToOneOrNull(
-  context: CoroutineContext = Dispatchers.Default,
+  context: CoroutineContext,
 ): Flow<T?> = map {
   withContext(context) {
     it.awaitAsOneOrNull()
@@ -86,7 +86,7 @@ fun <T : Any> Flow<Query<T>>.mapToOneOrNull(
 
 @JvmOverloads
 fun <T : Any> Flow<Query<T>>.mapToOneNotNull(
-  context: CoroutineContext = Dispatchers.Default,
+  context: CoroutineContext,
 ): Flow<T> = mapNotNull {
   withContext(context) {
     it.awaitAsOneOrNull()
@@ -95,7 +95,7 @@ fun <T : Any> Flow<Query<T>>.mapToOneNotNull(
 
 @JvmOverloads
 fun <T : Any> Flow<Query<T>>.mapToList(
-  context: CoroutineContext = Dispatchers.Default,
+  context: CoroutineContext,
 ): Flow<List<T>> = map {
   withContext(context) {
     it.awaitAsList()

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/app/cash/sqldelight/coroutines/QueryAsFlowTest.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/app/cash/sqldelight/coroutines/QueryAsFlowTest.kt
@@ -6,6 +6,7 @@ import app.cash.sqldelight.coroutines.Employee.Companion.USERNAME
 import app.cash.sqldelight.coroutines.TestDb.Companion.TABLE_EMPLOYEE
 import app.cash.turbine.test
 import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.yield
 import kotlin.test.Test
@@ -103,7 +104,7 @@ class QueryAsFlowTest : DbTest {
   @Test fun queryCanBeCollectedMoreThanOnce() = runTest { db ->
     val flow = db.createQuery(TABLE_EMPLOYEE, "$SELECT_EMPLOYEES WHERE $USERNAME = 'john'", MAPPER)
       .asFlow()
-      .mapToOneNotNull()
+      .mapToOneNotNull(Dispatchers.Default)
 
     val employee = Employee("john", "John Johnson")
 


### PR DESCRIPTION
Would rather be verbose and safe than introduce the default dispatcher unknowingly in situations where it would cause issues