### PR TITLE
Fix Gradle deprecation warning

### DIFF
--- a/adapters/primitive-adapters/build.gradle
+++ b/adapters/primitive-adapters/build.gradle
@@ -1,8 +1,8 @@
 import org.jetbrains.kotlin.konan.target.HostManager
 
 plugins {
-  alias(deps.plugins.publish)
-  alias(deps.plugins.dokka)
+  alias(libs.plugins.publish)
+  alias(libs.plugins.dokka)
   id("app.cash.sqldelight.multiplatform")
 }
 
@@ -20,18 +20,18 @@ kotlin {
     }
     commonTest {
       dependencies {
-        implementation deps.kotlin.test.common
-        implementation deps.kotlin.test.commonAnnotations
+        implementation libs.kotlin.test.common
+        implementation libs.kotlin.test.commonAnnotations
       }
     }
     jvmTest {
       dependencies {
-        implementation deps.kotlin.test.junit
+        implementation libs.kotlin.test.junit
       }
     }
     jsTest {
       dependencies {
-        implementation deps.kotlin.test.js
+        implementation libs.kotlin.test.js
       }
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -9,24 +9,24 @@ buildscript {
 }
 
 plugins {
-  alias(deps.plugins.grammarKitComposer) apply false
-  alias(deps.plugins.kotlin.multiplatform) apply false
-  alias(deps.plugins.kotlin.jvm) apply false
-  alias(deps.plugins.kotlin.android) apply false
-  alias(deps.plugins.kotlin.js) apply false
-  alias(deps.plugins.ksp) apply false
-  alias(deps.plugins.android.application) apply false
-  alias(deps.plugins.android.library) apply false
-  alias(deps.plugins.publish) apply false
-  alias(deps.plugins.dokka)
-  alias(deps.plugins.spotless)
+  alias(libs.plugins.grammarKitComposer) apply false
+  alias(libs.plugins.kotlin.multiplatform) apply false
+  alias(libs.plugins.kotlin.jvm) apply false
+  alias(libs.plugins.kotlin.android) apply false
+  alias(libs.plugins.kotlin.js) apply false
+  alias(libs.plugins.ksp) apply false
+  alias(libs.plugins.android.application) apply false
+  alias(libs.plugins.android.library) apply false
+  alias(libs.plugins.publish) apply false
+  alias(libs.plugins.dokka)
+  alias(libs.plugins.spotless)
 }
 
 spotless {
   kotlin {
     target "**/*.kt"
     targetExclude "**/gen/**/*.*", "**/generated/**/*.*", "sqldelight-compiler/integration-tests/src/test/kotlin/com/example/**/*.*", "sqldelight-compiler/src/test/migration-interface-fixtures/**/*.*"
-    ktlint(deps.versions.ktlint.get()).editorConfigOverride([
+    ktlint(libs.versions.ktlint.get()).editorConfigOverride([
       "indent_size": "2",
        "disabled_rules": "package-name",
        "ij_kotlin_allow_trailing_comma": "true",

--- a/buildLogic/multiplatform-convention/build.gradle
+++ b/buildLogic/multiplatform-convention/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  alias(deps.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.jvm)
   id("java-gradle-plugin")
 }
 
@@ -13,5 +13,5 @@ gradlePlugin {
 }
 
 dependencies {
-  compileOnly deps.kotlin.plugin
+  compileOnly libs.kotlin.plugin
 }

--- a/buildLogic/settings.gradle
+++ b/buildLogic/settings.gradle
@@ -13,7 +13,7 @@ dependencyResolutionManagement {
   }
 
   versionCatalogs {
-    deps {
+    libs {
       from(files("../gradle/libs.versions.toml"))
     }
   }

--- a/dialects/hsql/build.gradle
+++ b/dialects/hsql/build.gradle
@@ -1,25 +1,25 @@
 plugins {
-  alias(deps.plugins.kotlin.jvm)
-  alias(deps.plugins.grammarKitComposer)
-  alias(deps.plugins.publish)
-  alias(deps.plugins.dokka)
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.grammarKitComposer)
+  alias(libs.plugins.publish)
+  alias(libs.plugins.dokka)
 }
 
 grammarKit {
-  intellijRelease.set(deps.versions.idea)
+  intellijRelease.set(libs.versions.idea)
 }
 
 dependencies {
   compileOnly project(':sqldelight-compiler:dialect')
-  compileOnly deps.intellij.core
-  compileOnly deps.intellij.lang
+  compileOnly libs.intellij.core
+  compileOnly libs.intellij.lang
 
-  testImplementation deps.intellij.core
-  testImplementation deps.intellij.lang
-  testImplementation deps.junit
-  testImplementation deps.truth
+  testImplementation libs.intellij.core
+  testImplementation libs.intellij.lang
+  testImplementation libs.junit
+  testImplementation libs.truth
   testImplementation project(':sqldelight-compiler:dialect')
-  testImplementation deps.sqlPsiTestFixtures
+  testImplementation libs.sqlPsiTestFixtures
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/dialects/mysql/build.gradle
+++ b/dialects/mysql/build.gradle
@@ -1,33 +1,33 @@
 plugins {
-  alias(deps.plugins.shadow)
-  alias(deps.plugins.kotlin.jvm)
-  alias(deps.plugins.ksp)
-  alias(deps.plugins.grammarKitComposer)
-  alias(deps.plugins.publish)
-  alias(deps.plugins.dokka)
+  alias(libs.plugins.shadow)
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.ksp)
+  alias(libs.plugins.grammarKitComposer)
+  alias(libs.plugins.publish)
+  alias(libs.plugins.dokka)
 }
 
 grammarKit {
-  intellijRelease.set(deps.versions.idea)
+  intellijRelease.set(libs.versions.idea)
 }
 
 dependencies {
-  ksp deps.moshiCodegen
+  ksp libs.moshiCodegen
 
-  api deps.mysqlJdbc
+  api libs.mysqlJdbc
 
   compileOnly project(':sqldelight-compiler:dialect')
-  compileOnly deps.intellij.core
-  compileOnly deps.intellij.lang
-  compileOnly deps.intellij.core.ui
-  compileOnly deps.moshi
+  compileOnly libs.intellij.core
+  compileOnly libs.intellij.lang
+  compileOnly libs.intellij.core.ui
+  compileOnly libs.moshi
 
-  testImplementation deps.intellij.core
-  testImplementation deps.intellij.lang
-  testImplementation deps.junit
-  testImplementation deps.truth
+  testImplementation libs.intellij.core
+  testImplementation libs.intellij.lang
+  testImplementation libs.junit
+  testImplementation libs.truth
   testImplementation project(':sqldelight-compiler:dialect')
-  testImplementation deps.sqlPsiTestFixtures
+  testImplementation libs.sqlPsiTestFixtures
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/dialects/postgresql/build.gradle
+++ b/dialects/postgresql/build.gradle
@@ -1,33 +1,33 @@
 plugins {
-  alias(deps.plugins.shadow)
-  alias(deps.plugins.kotlin.jvm)
-  alias(deps.plugins.ksp)
-  alias(deps.plugins.grammarKitComposer)
-  alias(deps.plugins.publish)
-  alias(deps.plugins.dokka)
+  alias(libs.plugins.shadow)
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.ksp)
+  alias(libs.plugins.grammarKitComposer)
+  alias(libs.plugins.publish)
+  alias(libs.plugins.dokka)
 }
 
 grammarKit {
-  intellijRelease.set(deps.versions.idea)
+  intellijRelease.set(libs.versions.idea)
 }
 
 dependencies {
-  ksp deps.moshiCodegen
+  ksp libs.moshiCodegen
 
-  api deps.postgresJdbc
+  api libs.postgresJdbc
 
   compileOnly project(':sqldelight-compiler:dialect')
-  compileOnly deps.intellij.core
-  compileOnly deps.intellij.lang
-  compileOnly deps.intellij.core.ui
-  compileOnly deps.moshi
+  compileOnly libs.intellij.core
+  compileOnly libs.intellij.lang
+  compileOnly libs.intellij.core.ui
+  compileOnly libs.moshi
 
-  testImplementation deps.intellij.core
-  testImplementation deps.intellij.lang
-  testImplementation deps.junit
-  testImplementation deps.truth
+  testImplementation libs.intellij.core
+  testImplementation libs.intellij.lang
+  testImplementation libs.junit
+  testImplementation libs.truth
   testImplementation project(':sqldelight-compiler:dialect')
-  testImplementation deps.sqlPsiTestFixtures
+  testImplementation libs.sqlPsiTestFixtures
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/dialects/sqlite-3-18/build.gradle
+++ b/dialects/sqlite-3-18/build.gradle
@@ -1,24 +1,24 @@
 plugins {
-  alias(deps.plugins.kotlin.jvm)
-  alias(deps.plugins.grammarKitComposer)
-  alias(deps.plugins.publish)
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.grammarKitComposer)
+  alias(libs.plugins.publish)
 }
 
 grammarKit {
-  intellijRelease.set(deps.versions.idea)
+  intellijRelease.set(libs.versions.idea)
 }
 
 dependencies {
   compileOnly project(':sqldelight-compiler:dialect')
-  compileOnly deps.intellij.lang
-  compileOnly deps.intellij.core.ui
+  compileOnly libs.intellij.lang
+  compileOnly libs.intellij.core.ui
 
-  testImplementation deps.intellij.core
-  testImplementation deps.intellij.lang
-  testImplementation deps.junit
-  testImplementation deps.truth
+  testImplementation libs.intellij.core
+  testImplementation libs.intellij.lang
+  testImplementation libs.junit
+  testImplementation libs.truth
   testImplementation project(':sqldelight-compiler:dialect')
-  testImplementation deps.sqlPsiTestFixtures
+  testImplementation libs.sqlPsiTestFixtures
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/dialects/sqlite-3-24/build.gradle
+++ b/dialects/sqlite-3-24/build.gradle
@@ -1,27 +1,27 @@
 plugins {
-  alias(deps.plugins.shadow)
-  alias(deps.plugins.kotlin.jvm)
-  alias(deps.plugins.grammarKitComposer)
-  alias(deps.plugins.publish)
+  alias(libs.plugins.shadow)
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.grammarKitComposer)
+  alias(libs.plugins.publish)
 }
 
 grammarKit {
-  intellijRelease.set(deps.versions.idea)
+  intellijRelease.set(libs.versions.idea)
 }
 
 dependencies {
   api project(':dialects:sqlite-3-18')
 
   compileOnly project(':sqldelight-compiler:dialect')
-  compileOnly deps.intellij.core
-  compileOnly deps.intellij.lang
+  compileOnly libs.intellij.core
+  compileOnly libs.intellij.lang
 
-  testImplementation deps.intellij.core
-  testImplementation deps.intellij.lang
-  testImplementation deps.junit
-  testImplementation deps.truth
+  testImplementation libs.intellij.core
+  testImplementation libs.intellij.lang
+  testImplementation libs.junit
+  testImplementation libs.truth
   testImplementation project(':sqldelight-compiler:dialect')
-  testImplementation deps.sqlPsiTestFixtures
+  testImplementation libs.sqlPsiTestFixtures
 }
 
 tasks.getByName("shadowJar").configure {

--- a/dialects/sqlite-3-25/build.gradle
+++ b/dialects/sqlite-3-25/build.gradle
@@ -1,27 +1,27 @@
 plugins {
-  alias(deps.plugins.shadow)
-  alias(deps.plugins.kotlin.jvm)
-  alias(deps.plugins.grammarKitComposer)
-  alias(deps.plugins.publish)
+  alias(libs.plugins.shadow)
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.grammarKitComposer)
+  alias(libs.plugins.publish)
 }
 
 grammarKit {
-  intellijRelease.set(deps.versions.idea)
+  intellijRelease.set(libs.versions.idea)
 }
 
 dependencies {
   api project(':dialects:sqlite-3-24')
 
   compileOnly project(':sqldelight-compiler:dialect')
-  compileOnly deps.intellij.core
-  compileOnly deps.intellij.lang
+  compileOnly libs.intellij.core
+  compileOnly libs.intellij.lang
 
-  testImplementation deps.intellij.core
-  testImplementation deps.intellij.lang
-  testImplementation deps.junit
-  testImplementation deps.truth
+  testImplementation libs.intellij.core
+  testImplementation libs.intellij.lang
+  testImplementation libs.junit
+  testImplementation libs.truth
   testImplementation project(':sqldelight-compiler:dialect')
-  testImplementation deps.sqlPsiTestFixtures
+  testImplementation libs.sqlPsiTestFixtures
 }
 
 tasks.getByName("shadowJar").configure {

--- a/dialects/sqlite-3-30/build.gradle
+++ b/dialects/sqlite-3-30/build.gradle
@@ -1,27 +1,27 @@
 plugins {
-  alias(deps.plugins.shadow)
-  alias(deps.plugins.kotlin.jvm)
-  alias(deps.plugins.grammarKitComposer)
-  alias(deps.plugins.publish)
+  alias(libs.plugins.shadow)
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.grammarKitComposer)
+  alias(libs.plugins.publish)
 }
 
 grammarKit {
-  intellijRelease.set(deps.versions.idea)
+  intellijRelease.set(libs.versions.idea)
 }
 
 dependencies {
   api project(':dialects:sqlite-3-25')
 
   compileOnly project(':sqldelight-compiler:dialect')
-  compileOnly deps.intellij.core
-  compileOnly deps.intellij.lang
+  compileOnly libs.intellij.core
+  compileOnly libs.intellij.lang
 
-  testImplementation deps.intellij.core
-  testImplementation deps.intellij.lang
-  testImplementation deps.junit
-  testImplementation deps.truth
+  testImplementation libs.intellij.core
+  testImplementation libs.intellij.lang
+  testImplementation libs.junit
+  testImplementation libs.truth
   testImplementation project(':sqldelight-compiler:dialect')
-  testImplementation deps.sqlPsiTestFixtures
+  testImplementation libs.sqlPsiTestFixtures
 }
 
 tasks.getByName("shadowJar").configure {

--- a/dialects/sqlite-3-35/build.gradle
+++ b/dialects/sqlite-3-35/build.gradle
@@ -1,27 +1,27 @@
 plugins {
-  alias(deps.plugins.shadow)
-  alias(deps.plugins.kotlin.jvm)
-  alias(deps.plugins.grammarKitComposer)
-  alias(deps.plugins.publish)
+  alias(libs.plugins.shadow)
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.grammarKitComposer)
+  alias(libs.plugins.publish)
 }
 
 grammarKit {
-  intellijRelease.set(deps.versions.idea)
+  intellijRelease.set(libs.versions.idea)
 }
 
 dependencies {
   api project(':dialects:sqlite-3-30')
 
   compileOnly project(':sqldelight-compiler:dialect')
-  compileOnly deps.intellij.core
-  compileOnly deps.intellij.lang
+  compileOnly libs.intellij.core
+  compileOnly libs.intellij.lang
 
-  testImplementation deps.intellij.core
-  testImplementation deps.intellij.lang
-  testImplementation deps.junit
-  testImplementation deps.truth
+  testImplementation libs.intellij.core
+  testImplementation libs.intellij.lang
+  testImplementation libs.junit
+  testImplementation libs.truth
   testImplementation project(':sqldelight-compiler:dialect')
-  testImplementation deps.sqlPsiTestFixtures
+  testImplementation libs.sqlPsiTestFixtures
 }
 
 tasks.getByName("shadowJar").configure {

--- a/dialects/sqlite-3-38/build.gradle
+++ b/dialects/sqlite-3-38/build.gradle
@@ -1,27 +1,27 @@
 plugins {
-  alias(deps.plugins.shadow)
-  alias(deps.plugins.kotlin.jvm)
-  alias(deps.plugins.grammarKitComposer)
-  alias(deps.plugins.publish)
+  alias(libs.plugins.shadow)
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.grammarKitComposer)
+  alias(libs.plugins.publish)
 }
 
 grammarKit {
-  intellijRelease.set(deps.versions.idea)
+  intellijRelease.set(libs.versions.idea)
 }
 
 dependencies {
   api project(':dialects:sqlite-3-35')
 
   compileOnly project(':sqldelight-compiler:dialect')
-  compileOnly deps.intellij.core
-  compileOnly deps.intellij.lang
+  compileOnly libs.intellij.core
+  compileOnly libs.intellij.lang
 
-  testImplementation deps.intellij.core
-  testImplementation deps.intellij.lang
-  testImplementation deps.junit
-  testImplementation deps.truth
+  testImplementation libs.intellij.core
+  testImplementation libs.intellij.lang
+  testImplementation libs.junit
+  testImplementation libs.truth
   testImplementation project(':sqldelight-compiler:dialect')
-  testImplementation deps.sqlPsiTestFixtures
+  testImplementation libs.sqlPsiTestFixtures
 }
 
 tasks.getByName("shadowJar").configure {

--- a/dialects/sqlite/json-module/build.gradle
+++ b/dialects/sqlite/json-module/build.gradle
@@ -1,25 +1,25 @@
 plugins {
-  alias(deps.plugins.kotlin.jvm)
-  alias(deps.plugins.grammarKitComposer)
-  alias(deps.plugins.publish)
-  alias(deps.plugins.dokka)
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.grammarKitComposer)
+  alias(libs.plugins.publish)
+  alias(libs.plugins.dokka)
 }
 
 grammarKit {
-  intellijRelease.set(deps.versions.idea)
+  intellijRelease.set(libs.versions.idea)
 }
 
 dependencies {
   compileOnly project(':sqldelight-compiler:dialect')
-  compileOnly deps.intellij.lang
+  compileOnly libs.intellij.lang
 
   testImplementation project(':dialects:sqlite-3-18')
-  testImplementation deps.intellij.core
-  testImplementation deps.intellij.lang
-  testImplementation deps.junit
-  testImplementation deps.truth
+  testImplementation libs.intellij.core
+  testImplementation libs.intellij.lang
+  testImplementation libs.junit
+  testImplementation libs.truth
   testImplementation project(':sqldelight-compiler:dialect')
-  testImplementation deps.sqlPsiTestFixtures
+  testImplementation libs.sqlPsiTestFixtures
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/drivers/android-driver/build.gradle
+++ b/drivers/android-driver/build.gradle
@@ -1,13 +1,13 @@
 plugins {
-  alias(deps.plugins.android.library)
-  alias(deps.plugins.kotlin.android)
-  alias(deps.plugins.publish)
-  alias(deps.plugins.dokka)
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.kotlin.android)
+  alias(libs.plugins.publish)
+  alias(libs.plugins.dokka)
 }
 archivesBaseName = 'sqldelight-android-driver'
 
 android {
-  compileSdk deps.versions.compileSdk.get() as int
+  compileSdk libs.versions.compileSdk.get() as int
 
   lint {
     textReport true
@@ -15,7 +15,7 @@ android {
   }
 
   defaultConfig {
-    minSdk deps.versions.minSdk.get() as int
+    minSdk libs.versions.minSdk.get() as int
   }
 
   buildFeatures {
@@ -32,14 +32,14 @@ android {
 dependencies {
   // workaround for https://youtrack.jetbrains.com/issue/KT-27059
   api "${project.property("GROUP")}:runtime-jvm:${project.property("VERSION_NAME")}"
-  api deps.androidx.sqlite
+  api libs.androidx.sqlite
 
-  implementation deps.androidx.sqliteFramework
+  implementation libs.androidx.sqliteFramework
 
   testImplementation project(':drivers:driver-test')
-  testImplementation deps.junit
-  testImplementation deps.androidx.test.core
-  testImplementation deps.robolectric
+  testImplementation libs.junit
+  testImplementation libs.androidx.test.core
+  testImplementation libs.robolectric
 }
 
 // workaround for https://youtrack.jetbrains.com/issue/KT-27059

--- a/drivers/driver-test/build.gradle
+++ b/drivers/driver-test/build.gradle
@@ -15,14 +15,14 @@ kotlin {
       dependencies {
         api project(':runtime')
 
-        implementation deps.kotlin.test.common
-        implementation deps.kotlin.test.commonAnnotations
+        implementation libs.kotlin.test.common
+        implementation libs.kotlin.test.commonAnnotations
       }
     }
 
     jvmMain {
       dependencies {
-        implementation deps.kotlin.test.junit
+        implementation libs.kotlin.test.junit
       }
     }
   }

--- a/drivers/jdbc-driver/build.gradle
+++ b/drivers/jdbc-driver/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-  alias(deps.plugins.kotlin.jvm)
-  alias(deps.plugins.publish)
-  alias(deps.plugins.dokka)
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.publish)
+  alias(libs.plugins.dokka)
 }
 
 archivesBaseName = 'sqldelight-jdbc-driver'

--- a/drivers/native-driver/build.gradle
+++ b/drivers/native-driver/build.gradle
@@ -1,9 +1,9 @@
 import org.jetbrains.kotlin.konan.target.HostManager
 
 plugins {
-  alias(deps.plugins.kotlin.multiplatform)
-  alias(deps.plugins.publish)
-  alias(deps.plugins.dokka)
+  alias(libs.plugins.kotlin.multiplatform)
+  alias(libs.plugins.publish)
+  alias(libs.plugins.dokka)
 }
 
 def ideaActive = System.getProperty("idea.active") == "true"
@@ -35,14 +35,14 @@ kotlin {
     }
     commonTest {
       dependencies {
-        implementation deps.kotlin.test.common
-        implementation deps.testhelp
+        implementation libs.kotlin.test.common
+        implementation libs.testhelp
       }
     }
     nativeMain {
       dependsOn(commonMain)
       dependencies {
-        api deps.sqliter
+        api libs.sqliter
       }
     }
     nativeTest {

--- a/drivers/r2dbc-driver/build.gradle
+++ b/drivers/r2dbc-driver/build.gradle
@@ -1,16 +1,16 @@
 plugins {
-  alias(deps.plugins.kotlin.jvm)
-  alias(deps.plugins.publish)
-  alias(deps.plugins.dokka)
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.publish)
+  alias(libs.plugins.dokka)
 }
 
 archivesBaseName = 'sqldelight-r2dbc-driver'
 
 dependencies {
   api project(':runtime')
-  implementation deps.r2dbc
-  implementation deps.kotlin.coroutines.core
-  implementation deps.kotlin.coroutines.reactive
+  implementation libs.r2dbc
+  implementation libs.kotlin.coroutines.core
+  implementation libs.kotlin.coroutines.reactive
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/drivers/sqlite-driver/build.gradle
+++ b/drivers/sqlite-driver/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-  alias(deps.plugins.kotlin.jvm)
-  alias(deps.plugins.publish)
-  alias(deps.plugins.dokka)
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.publish)
+  alias(libs.plugins.dokka)
 }
 
 archivesBaseName = 'sqldelight-sqlite-driver'
@@ -9,7 +9,7 @@ archivesBaseName = 'sqldelight-sqlite-driver'
 dependencies {
   api project(':drivers:jdbc-driver')
 
-  implementation deps.sqliteJdbc
+  implementation libs.sqliteJdbc
 
   testImplementation project(':drivers:driver-test')
 }

--- a/drivers/sqljs-driver/build.gradle
+++ b/drivers/sqljs-driver/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-  alias(deps.plugins.kotlin.js)
-  alias(deps.plugins.publish)
-  alias(deps.plugins.dokka)
+  alias(libs.plugins.kotlin.js)
+  alias(libs.plugins.publish)
+  alias(libs.plugins.dokka)
 }
 
 kotlin {
@@ -26,13 +26,13 @@ kotlin {
 
   sourceSets["main"].dependencies {
     api project(':runtime')
-    implementation deps.kotlin.coroutines.core
+    implementation libs.kotlin.coroutines.core
   }
   sourceSets["test"].dependencies {
-    implementation deps.kotlin.test.js
-    implementation npm('sql.js', deps.versions.sqljs.get())
+    implementation libs.kotlin.test.js
+    implementation npm('sql.js', libs.versions.sqljs.get())
     implementation devNpm("copy-webpack-plugin", "9.1.0")
-    implementation deps.kotlin.coroutines.test
+    implementation libs.kotlin.coroutines.test
     implementation project(':extensions:async-extensions')
   }
 }

--- a/extensions/android-paging3/android-test/build.gradle
+++ b/extensions/android-paging3/android-test/build.gradle
@@ -1,22 +1,22 @@
 plugins {
-  alias(deps.plugins.android.library)
-  alias(deps.plugins.kotlin.android)
-  alias(deps.plugins.dokka)
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.kotlin.android)
+  alias(libs.plugins.dokka)
 }
 
 android {
   namespace 'app.cash.sqldelight.paging3'
-  compileSdk deps.versions.compileSdk.get() as int
+  compileSdk libs.versions.compileSdk.get() as int
 }
 
 dependencies {
   testImplementation project(':drivers:sqlite-driver')
   testImplementation project(':extensions:android-paging3')
-  testImplementation deps.androidx.paging3.runtime
-  testImplementation deps.androidx.recyclerView
-  testImplementation deps.truth
-  testImplementation deps.kotlin.test.junit
-  testImplementation deps.kotlin.coroutines.test
+  testImplementation libs.androidx.paging3.runtime
+  testImplementation libs.androidx.recyclerView
+  testImplementation libs.truth
+  testImplementation libs.kotlin.test.junit
+  testImplementation libs.kotlin.coroutines.test
 }
 
 // workaround for https://youtrack.jetbrains.com/issue/KT-27059

--- a/extensions/android-paging3/build.gradle
+++ b/extensions/android-paging3/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-  alias(deps.plugins.kotlin.jvm)
-  alias(deps.plugins.publish)
-  alias(deps.plugins.dokka)
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.publish)
+  alias(libs.plugins.dokka)
 }
 
 archivesBaseName = 'sqldelight-androidx-paging3'
@@ -9,12 +9,12 @@ archivesBaseName = 'sqldelight-androidx-paging3'
 dependencies {
   // workaround for https://youtrack.jetbrains.com/issue/KT-27059
   api "${project.property("GROUP")}:runtime-jvm:${project.property("VERSION_NAME")}"
-  api deps.androidx.paging3.common
+  api libs.androidx.paging3.common
 
   testImplementation project(':drivers:sqlite-driver')
-  testImplementation deps.truth
-  testImplementation deps.kotlin.test.junit
-  testImplementation deps.kotlin.coroutines.test
+  testImplementation libs.truth
+  testImplementation libs.kotlin.test.junit
+  testImplementation libs.kotlin.coroutines.test
 }
 
 // workaround for https://youtrack.jetbrains.com/issue/KT-27059

--- a/extensions/async-extensions/build.gradle
+++ b/extensions/async-extensions/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-  alias(deps.plugins.publish)
-  alias(deps.plugins.dokka)
+  alias(libs.plugins.publish)
+  alias(libs.plugins.dokka)
   id("app.cash.sqldelight.multiplatform")
 }
 
@@ -13,13 +13,13 @@ kotlin {
     commonMain {
       dependencies {
         implementation project(':runtime')
-        api deps.kotlin.coroutines.core
+        api libs.kotlin.coroutines.core
       }
     }
     jvmTest {
       dependencies {
-        implementation deps.kotlin.test.junit
-        implementation deps.kotlin.coroutines.test
+        implementation libs.kotlin.test.junit
+        implementation libs.kotlin.coroutines.test
         implementation project(':drivers:sqlite-driver')
       }
     }

--- a/extensions/coroutines-extensions/build.gradle
+++ b/extensions/coroutines-extensions/build.gradle
@@ -1,8 +1,8 @@
 import org.jetbrains.kotlin.konan.target.HostManager
 
 plugins {
-  alias(deps.plugins.publish)
-  alias(deps.plugins.dokka)
+  alias(libs.plugins.publish)
+  alias(libs.plugins.dokka)
   id("app.cash.sqldelight.multiplatform")
 }
 
@@ -15,27 +15,27 @@ kotlin {
     commonMain {
       dependencies {
         api project(':runtime')
-        api deps.kotlin.coroutines.core
+        api libs.kotlin.coroutines.core
         implementation project(":extensions:async-extensions")
       }
     }
     commonTest {
       dependencies {
-        implementation deps.kotlin.test.common
-        implementation deps.kotlin.test.commonAnnotations
-        implementation deps.turbine
+        implementation libs.kotlin.test.common
+        implementation libs.kotlin.test.commonAnnotations
+        implementation libs.turbine
       }
     }
     jvmTest {
       dependencies {
-        implementation deps.kotlin.test.junit
-        implementation deps.kotlin.coroutines.test
+        implementation libs.kotlin.test.junit
+        implementation libs.kotlin.coroutines.test
         implementation project(':drivers:sqlite-driver')
       }
     }
     jsTest {
       dependencies {
-        implementation deps.kotlin.test.js
+        implementation libs.kotlin.test.js
         implementation project(':drivers:sqljs-driver')
       }
     }

--- a/extensions/rxjava2-extensions/build.gradle
+++ b/extensions/rxjava2-extensions/build.gradle
@@ -1,18 +1,18 @@
 plugins {
-  alias(deps.plugins.kotlin.jvm)
-  alias(deps.plugins.publish)
-  alias(deps.plugins.dokka)
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.publish)
+  alias(libs.plugins.dokka)
 }
 
 archivesBaseName = 'sqldelight-rxjava2-extensions'
 
 dependencies {
   implementation project(':runtime')
-  implementation deps.rxJava2
+  implementation libs.rxJava2
 
   testImplementation project(':drivers:sqlite-driver')
-  testImplementation deps.junit
-  testImplementation deps.truth
+  testImplementation libs.junit
+  testImplementation libs.truth
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/extensions/rxjava3-extensions/build.gradle
+++ b/extensions/rxjava3-extensions/build.gradle
@@ -1,18 +1,18 @@
 plugins {
-  alias(deps.plugins.kotlin.jvm)
-  alias(deps.plugins.publish)
-  alias(deps.plugins.dokka)
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.publish)
+  alias(libs.plugins.dokka)
 }
 
 archivesBaseName = 'sqldelight-rxjava3-extensions'
 
 dependencies {
   implementation project(':runtime')
-  implementation deps.rxJava3
+  implementation libs.rxJava3
 
   testImplementation project(':drivers:sqlite-driver')
-  testImplementation deps.junit
-  testImplementation deps.truth
+  testImplementation libs.junit
+  testImplementation libs.truth
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-  alias(deps.plugins.publish)
-  alias(deps.plugins.dokka)
+  alias(libs.plugins.publish)
+  alias(libs.plugins.dokka)
   id("app.cash.sqldelight.multiplatform")
 }
 
@@ -18,29 +18,29 @@ kotlin {
     }
     commonTest {
       dependencies {
-        implementation deps.kotlin.test.common
-        implementation deps.kotlin.test.commonAnnotations
+        implementation libs.kotlin.test.common
+        implementation libs.kotlin.test.commonAnnotations
       }
     }
     jvmTest {
       dependencies {
-        implementation deps.kotlin.test.junit
-        implementation deps.stately.collections
+        implementation libs.kotlin.test.junit
+        implementation libs.stately.collections
       }
     }
     jsTest {
       dependencies {
-        implementation deps.kotlin.test.js
+        implementation libs.kotlin.test.js
       }
     }
     nativeMain {
       dependencies {
-        implementation deps.stately.concurrency
+        implementation libs.stately.concurrency
       }
     }
     nativeTest{
       dependencies {
-        implementation deps.stately.collections
+        implementation libs.stately.collections
       }
     }
   }

--- a/sample/android/build.gradle
+++ b/sample/android/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-  alias(deps.plugins.android.application)
-  alias(deps.plugins.kotlin.android)
+  alias(libs.plugins.android.application)
+  alias(libs.plugins.kotlin.android)
 }
 
 android {
-  compileSdk deps.versions.compileSdk.get() as int
+  compileSdk libs.versions.compileSdk.get() as int
 
   lint {
     textOutput file("$reportsDir/lint-results.txt")
@@ -12,7 +12,7 @@ android {
 
   defaultConfig {
     minSdk 21
-    targetSdk deps.versions.compileSdk.get() as int
+    targetSdk libs.versions.compileSdk.get() as int
 
     applicationId 'com.example.sqldelight.hockey'
 
@@ -40,7 +40,7 @@ android {
 dependencies {
   implementation project(':common')
 
-  implementation deps.androidx.recyclerView
+  implementation libs.androidx.recyclerView
 
   implementation "app.cash.sqldelight:android-driver"
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,8 +1,8 @@
 plugins {
-  alias(deps.plugins.android.application) apply false
-  alias(deps.plugins.android.library) apply false
-  alias(deps.plugins.kotlin.multiplatform) apply false
-  alias(deps.plugins.kotlin.android) apply false
-  alias(deps.plugins.kotlin.js) apply false
-  alias(deps.plugins.kotlin.native.cocoapods) apply false
+  alias(libs.plugins.android.application) apply false
+  alias(libs.plugins.android.library) apply false
+  alias(libs.plugins.kotlin.multiplatform) apply false
+  alias(libs.plugins.kotlin.android) apply false
+  alias(libs.plugins.kotlin.js) apply false
+  alias(libs.plugins.kotlin.native.cocoapods) apply false
 }

--- a/sample/common/build.gradle
+++ b/sample/common/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-  alias(deps.plugins.kotlin.multiplatform)
-  alias(deps.plugins.kotlin.native.cocoapods)
+  alias(libs.plugins.kotlin.multiplatform)
+  alias(libs.plugins.kotlin.native.cocoapods)
   id("app.cash.sqldelight")
 }
 
@@ -50,7 +50,7 @@ kotlin {
   }
   sourceSets.jsTest.dependencies {
     implementation "org.jetbrains.kotlin:kotlin-test-js"
-    implementation deps.kotlin.coroutines.core
+    implementation libs.kotlin.coroutines.core
     implementation "app.cash.sqldelight:sqljs-driver"
   }
 

--- a/sample/settings.gradle
+++ b/sample/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 dependencyResolutionManagement {
   versionCatalogs {
-    deps {
+    libs {
       from(files("../gradle/libs.versions.toml"))
     }
   }

--- a/sample/web/build.gradle
+++ b/sample/web/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  alias(deps.plugins.kotlin.js)
+  alias(libs.plugins.kotlin.js)
 }
 
 kotlin {

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,10 +8,6 @@ pluginManagement {
     includeBuild("buildLogic")
 }
 
-dependencyResolutionManagement {
-    defaultLibrariesExtensionName.set('deps')
-}
-
 rootProject.name = 'sqldelight'
 
 include ':adapters:primitive-adapters'

--- a/sqldelight-compiler/build.gradle
+++ b/sqldelight-compiler/build.gradle
@@ -1,8 +1,8 @@
 plugins {
-  alias(deps.plugins.kotlin.jvm)
-  alias(deps.plugins.grammarKitComposer)
-  alias(deps.plugins.publish)
-  alias(deps.plugins.dokka)
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.grammarKitComposer)
+  alias(libs.plugins.publish)
+  alias(libs.plugins.dokka)
 }
 
 test {
@@ -20,32 +20,32 @@ sourceSets {
 }
 
 grammarKit {
-  intellijRelease.set(deps.versions.idea)
+  intellijRelease.set(libs.versions.idea)
 }
 
 dependencies {
-  api deps.sqlPsi
+  api libs.sqlPsi
   api(project(':sqldelight-compiler:dialect')) {
     exclude group: "com.jetbrains.intellij.platform", module: "core-impl"
   }
 
-  implementation deps.kotlinPoet
-  implementation deps.jgrapht
+  implementation libs.kotlinPoet
+  implementation libs.jgrapht
 
-  compileOnly deps.sqliteJdbc
-  compileOnly deps.intellij.core
-  compileOnly deps.intellij.lang
-  compileOnly deps.intellij.java
-  compileOnly deps.intellij.testFramework
+  compileOnly libs.sqliteJdbc
+  compileOnly libs.intellij.core
+  compileOnly libs.intellij.lang
+  compileOnly libs.intellij.java
+  compileOnly libs.intellij.testFramework
 
-  testImplementation deps.burst
-  testImplementation deps.sqliteJdbc
-  testImplementation deps.intellij.core
-  testImplementation deps.intellij.lang
-  testImplementation deps.intellij.java
-  testImplementation deps.intellij.testFramework
-  testImplementation deps.kotlin.test.junit
-  testImplementation deps.truth
+  testImplementation libs.burst
+  testImplementation libs.sqliteJdbc
+  testImplementation libs.intellij.core
+  testImplementation libs.intellij.lang
+  testImplementation libs.intellij.java
+  testImplementation libs.intellij.testFramework
+  testImplementation libs.kotlin.test.junit
+  testImplementation libs.truth
   testImplementation project(':test-util')
   testImplementation project(':dialects:hsql')
   testImplementation project(path: ':dialects:mysql', configuration: 'shadowRuntimeElements')

--- a/sqldelight-compiler/dialect/build.gradle
+++ b/sqldelight-compiler/dialect/build.gradle
@@ -1,13 +1,13 @@
 plugins {
-  alias(deps.plugins.kotlin.jvm)
-  alias(deps.plugins.publish)
-  alias(deps.plugins.dokka)
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.publish)
+  alias(libs.plugins.dokka)
 }
 
 dependencies {
-  api deps.sqlPsi
-  api deps.kotlinPoet
-  api deps.intellij.core
+  api libs.sqlPsi
+  api libs.kotlinPoet
+  api libs.intellij.core
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/sqldelight-compiler/integration-tests/build.gradle
+++ b/sqldelight-compiler/integration-tests/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  alias(deps.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.jvm)
 }
 
 dependencies {
@@ -7,7 +7,7 @@ dependencies {
   testImplementation project(':drivers:sqlite-driver')
   testImplementation project(':test-util')
 
-  testImplementation deps.sqlPsi
-  testImplementation deps.truth
-  testImplementation deps.junit
+  testImplementation libs.sqlPsi
+  testImplementation libs.truth
+  testImplementation libs.junit
 }

--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -1,10 +1,10 @@
 import org.jetbrains.kotlin.konan.target.HostManager
 
 plugins {
-  alias(deps.plugins.kotlin.jvm)
-  alias(deps.plugins.shadow) apply false
-  alias(deps.plugins.publish)
-  alias(deps.plugins.dokka)
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.shadow) apply false
+  alias(libs.plugins.publish)
+  alias(libs.plugins.dokka)
   id("java-gradle-plugin")
   id("jvm-test-suite")
 }
@@ -36,33 +36,33 @@ configurations {
 }
 
 dependencies {
-  api(deps.sqlPsi) {
+  api(libs.sqlPsi) {
     exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jdk8'
   }
 
-  implementation deps.sqliteJdbc
-  implementation deps.objectDiff
-  implementation deps.schemaCrawler.tools
-  implementation deps.schemaCrawler.sqlite
+  implementation libs.sqliteJdbc
+  implementation libs.objectDiff
+  implementation libs.schemaCrawler.tools
+  implementation libs.schemaCrawler.sqlite
 
   shade project(':sqlite-migrations')
   shade project(':sqldelight-compiler')
-  shade deps.intellij.analysis
-  shade deps.intellij.core
-  shade deps.intellij.java
-  shade deps.intellij.lang
-  shade deps.intellij.testFramework
+  shade libs.intellij.analysis
+  shade libs.intellij.core
+  shade libs.intellij.java
+  shade libs.intellij.lang
+  shade libs.intellij.testFramework
 
   compileOnly gradleApi()
-  implementation deps.kotlin.plugin
-  compileOnly deps.android.plugin
+  implementation libs.kotlin.plugin
+  compileOnly libs.android.plugin
 
-  testImplementation deps.sqlPsi
+  testImplementation libs.sqlPsi
   testImplementation project(':sqlite-migrations')
   testImplementation project(':sqldelight-compiler')
-  testImplementation deps.junit
-  testImplementation deps.truth
-  testImplementation deps.testParameterInjector
+  testImplementation libs.junit
+  testImplementation libs.truth
+  testImplementation libs.testParameterInjector
 }
 
 test {

--- a/sqldelight-gradle-plugin/src/test/adapter-questionmark/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/adapter-questionmark/build.gradle
@@ -19,7 +19,7 @@ sqldelight {
 }
 
 dependencies {
-  implementation deps.sqliteJdbc
+  implementation libs.sqliteJdbc
   implementation "app.cash.sqldelight:sqlite-driver:${app.cash.sqldelight.VersionKt.VERSION}"
-  implementation deps.truth
+  implementation libs.truth
 }

--- a/sqldelight-gradle-plugin/src/test/buildscript.gradle
+++ b/sqldelight-gradle-plugin/src/test/buildscript.gradle
@@ -10,6 +10,6 @@
 
   project.buildscript.dependencies {
     classpath 'app.cash.sqldelight:gradle-plugin:+'
-    classpath deps.kotlin.plugin
-    classpath deps.android.plugin
+    classpath libs.kotlin.plugin
+    classpath libs.android.plugin
   }

--- a/sqldelight-gradle-plugin/src/test/custom-dialect/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/custom-dialect/build.gradle
@@ -20,7 +20,7 @@ sqldelight {
 }
 
 dependencies {
-  implementation deps.sqliteJdbc
+  implementation libs.sqliteJdbc
   implementation "app.cash.sqldelight:sqlite-driver:${app.cash.sqldelight.VersionKt.VERSION}"
-  implementation deps.truth
+  implementation libs.truth
 }

--- a/sqldelight-gradle-plugin/src/test/fulfilled-table-variant/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/fulfilled-table-variant/build.gradle
@@ -15,7 +15,7 @@ repositories {
 android {
   namespace "com.example.sqldelight"
 
-  compileSdk deps.versions.compileSdk.get() as int
+  compileSdk libs.versions.compileSdk.get() as int
 
   lint {
     textReport true

--- a/sqldelight-gradle-plugin/src/test/integration-android-library/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-android-library/build.gradle
@@ -15,13 +15,13 @@ repositories {
 }
 
 dependencies {
-  implementation deps.androidx.sqlite
-  implementation deps.androidx.sqliteFramework
+  implementation libs.androidx.sqlite
+  implementation libs.androidx.sqliteFramework
 
   implementation "app.cash.sqldelight:android-driver:${app.cash.sqldelight.VersionKt.VERSION}"
 
-  androidTestImplementation deps.androidx.test.runner
-  androidTestImplementation deps.truth
+  androidTestImplementation libs.androidx.test.runner
+  androidTestImplementation libs.truth
 }
 
 sqldelight {
@@ -33,10 +33,10 @@ sqldelight {
 android {
   namespace "app.cash.sqldelight.integration"
 
-  compileSdk deps.versions.compileSdk.get() as int
+  compileSdk libs.versions.compileSdk.get() as int
 
   defaultConfig {
-    minSdk deps.versions.minSdk.get() as int
+    minSdk libs.versions.minSdk.get() as int
 
     testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
   }

--- a/sqldelight-gradle-plugin/src/test/integration-android-variants/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-android-variants/build.gradle
@@ -15,9 +15,9 @@ repositories {
 }
 
 dependencies {
-  implementation deps.sqliteJdbc
+  implementation libs.sqliteJdbc
   implementation "app.cash.sqldelight:sqlite-driver:${app.cash.sqldelight.VersionKt.VERSION}"
-  implementation deps.truth
+  implementation libs.truth
 }
 
 sqldelight {
@@ -29,10 +29,10 @@ sqldelight {
 android {
   namespace "app.cash.sqldelight.integration"
 
-  compileSdk deps.versions.compileSdk.get() as int
+  compileSdk libs.versions.compileSdk.get() as int
 
   defaultConfig {
-    minSdk deps.versions.minSdk.get() as int
+    minSdk libs.versions.minSdk.get() as int
   }
 
   lint {

--- a/sqldelight-gradle-plugin/src/test/integration-android/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-android/build.gradle
@@ -15,13 +15,13 @@ repositories {
 }
 
 dependencies {
-  implementation deps.androidx.sqlite
-  implementation deps.androidx.sqliteFramework
+  implementation libs.androidx.sqlite
+  implementation libs.androidx.sqliteFramework
 
   implementation "app.cash.sqldelight:android-driver:${app.cash.sqldelight.VersionKt.VERSION}"
 
-  androidTestImplementation deps.androidx.test.runner
-  androidTestImplementation deps.truth
+  androidTestImplementation libs.androidx.test.runner
+  androidTestImplementation libs.truth
 }
 
 sqldelight {
@@ -33,10 +33,10 @@ sqldelight {
 android {
   namespace "app.cash.sqldelight.integration"
 
-  compileSdk deps.versions.compileSdk.get() as int
+  compileSdk libs.versions.compileSdk.get() as int
 
   defaultConfig {
-    minSdk deps.versions.minSdk.get() as int
+    minSdk libs.versions.minSdk.get() as int
 
     testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
   }

--- a/sqldelight-gradle-plugin/src/test/integration-catalog/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-catalog/build.gradle
@@ -20,8 +20,8 @@ repositories {
 }
 
 dependencies {
-  implementation deps.mysqlJdbc
+  implementation libs.mysqlJdbc
   implementation "org.testcontainers:mysql:1.16.2"
   implementation "app.cash.sqldelight:jdbc-driver:${app.cash.sqldelight.VersionKt.VERSION}"
-  implementation deps.truth
+  implementation libs.truth
 }

--- a/sqldelight-gradle-plugin/src/test/integration-hsql/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-hsql/build.gradle
@@ -22,5 +22,5 @@ repositories {
 dependencies {
     implementation "org.hsqldb:hsqldb:2.5.0"
     implementation "app.cash.sqldelight:jdbc-driver:${app.cash.sqldelight.VersionKt.VERSION}"
-    implementation deps.truth
+    implementation libs.truth
 }

--- a/sqldelight-gradle-plugin/src/test/integration-migration-callbacks/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-migration-callbacks/build.gradle
@@ -20,7 +20,7 @@ sqldelight {
 }
 
 dependencies {
-  implementation deps.sqliteJdbc
+  implementation libs.sqliteJdbc
   implementation "app.cash.sqldelight:sqlite-driver:${app.cash.sqldelight.VersionKt.VERSION}"
-  implementation deps.truth
+  implementation libs.truth
 }

--- a/sqldelight-gradle-plugin/src/test/integration-module/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-module/build.gradle
@@ -21,6 +21,6 @@ sqldelight {
 }
 
 dependencies {
-  implementation deps.sqliteJdbc
+  implementation libs.sqliteJdbc
   implementation "app.cash.sqldelight:sqlite-driver:${app.cash.sqldelight.VersionKt.VERSION}"
 }

--- a/sqldelight-gradle-plugin/src/test/integration-multiplatform/android-build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-multiplatform/android-build.gradle
@@ -17,10 +17,10 @@ repositories {
 android {
   namespace "app.cash.sqldelight.integration"
 
-  compileSdk deps.versions.compileSdk.get() as int
+  compileSdk libs.versions.compileSdk.get() as int
 
   defaultConfig {
-    minSdk deps.versions.minSdk.get() as int
+    minSdk libs.versions.minSdk.get() as int
     testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
   }
 
@@ -44,10 +44,10 @@ kotlin {
   sourceSets {
     commonTest {
       dependencies {
-        implementation deps.kotlin.test.common
-        implementation deps.kotlin.test.commonAnnotations
-        implementation deps.stately.core
-        implementation deps.stately.concurrency
+        implementation libs.kotlin.test.common
+        implementation libs.kotlin.test.commonAnnotations
+        implementation libs.stately.core
+        implementation libs.stately.concurrency
         implementation "app.cash.sqldelight:runtime:${app.cash.sqldelight.VersionKt.VERSION}"
       }
     }
@@ -58,7 +58,7 @@ kotlin {
     }
     androidTest {
       dependencies {
-        implementation deps.kotlin.test.junit
+        implementation libs.kotlin.test.junit
         implementation "app.cash.sqldelight:sqlite-driver:${app.cash.sqldelight.VersionKt.VERSION}"
       }
     }

--- a/sqldelight-gradle-plugin/src/test/integration-multiplatform/ios-build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-multiplatform/ios-build.gradle
@@ -30,10 +30,10 @@ kotlin {
   sourceSets {
     commonTest {
       dependencies {
-        implementation deps.kotlin.test.common
-        implementation deps.kotlin.test.commonAnnotations
-        implementation deps.stately.core
-        implementation deps.stately.concurrency
+        implementation libs.kotlin.test.common
+        implementation libs.kotlin.test.commonAnnotations
+        implementation libs.stately.core
+        implementation libs.stately.concurrency
         implementation "app.cash.sqldelight:runtime:${app.cash.sqldelight.VersionKt.VERSION}"
       }
     }

--- a/sqldelight-gradle-plugin/src/test/integration-mysql-async/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-mysql-async/build.gradle
@@ -21,14 +21,14 @@ repositories {
 }
 
 dependencies {
-  implementation deps.mysqlJdbc
+  implementation libs.mysqlJdbc
   implementation "org.testcontainers:mysql:1.16.2"
   implementation "org.testcontainers:r2dbc:1.16.2"
   implementation "dev.miku:r2dbc-mysql:0.8.2.RELEASE"
   implementation "app.cash.sqldelight:r2dbc-driver:${app.cash.sqldelight.VersionKt.VERSION}"
   implementation "app.cash.sqldelight:coroutines-extensions:${app.cash.sqldelight.VersionKt.VERSION}"
-  implementation deps.truth
-  implementation deps.kotlin.coroutines.core
-  implementation deps.kotlin.coroutines.test
-  implementation deps.kotlin.coroutines.reactive
+  implementation libs.truth
+  implementation libs.kotlin.coroutines.core
+  implementation libs.kotlin.coroutines.test
+  implementation libs.kotlin.coroutines.reactive
 }

--- a/sqldelight-gradle-plugin/src/test/integration-mysql-schema/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-mysql-schema/build.gradle
@@ -21,8 +21,8 @@ repositories {
 }
 
 dependencies {
-  implementation deps.mysqlJdbc
+  implementation libs.mysqlJdbc
   implementation 'org.testcontainers:mysql:1.16.2'
   implementation "app.cash.sqldelight:jdbc-driver:${app.cash.sqldelight.VersionKt.VERSION}"
-  implementation deps.truth
+  implementation libs.truth
 }

--- a/sqldelight-gradle-plugin/src/test/integration-mysql/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-mysql/build.gradle
@@ -20,8 +20,8 @@ repositories {
 }
 
 dependencies {
-  implementation deps.mysqlJdbc
+  implementation libs.mysqlJdbc
   implementation "org.testcontainers:mysql:1.16.2"
   implementation "app.cash.sqldelight:jdbc-driver:${app.cash.sqldelight.VersionKt.VERSION}"
-  implementation deps.truth
+  implementation libs.truth
 }

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql-migrations/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql-migrations/build.gradle
@@ -21,8 +21,8 @@ repositories {
 }
 
 dependencies {
-  implementation deps.postgresJdbc
+  implementation libs.postgresJdbc
   implementation "org.testcontainers:postgresql:1.16.2"
   implementation "app.cash.sqldelight:jdbc-driver:${app.cash.sqldelight.VersionKt.VERSION}"
-  implementation deps.truth
+  implementation libs.truth
 }

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/build.gradle
@@ -20,8 +20,8 @@ repositories {
 }
 
 dependencies {
-  implementation deps.postgresJdbc
+  implementation libs.postgresJdbc
   implementation "org.testcontainers:postgresql:1.16.2"
   implementation "app.cash.sqldelight:jdbc-driver:${app.cash.sqldelight.VersionKt.VERSION}"
-  implementation deps.truth
+  implementation libs.truth
 }

--- a/sqldelight-gradle-plugin/src/test/integration-sqlite-3-24/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-sqlite-3-24/build.gradle
@@ -20,8 +20,8 @@ sqldelight {
 }
 
 dependencies {
-  implementation deps.sqliteJdbc
+  implementation libs.sqliteJdbc
   implementation "app.cash.sqldelight:sqlite-driver:${app.cash.sqldelight.VersionKt.VERSION}"
   implementation "org.xerial:sqlite-jdbc:3.34.0"
-  implementation deps.truth
+  implementation libs.truth
 }

--- a/sqldelight-gradle-plugin/src/test/integration-sqlite-3-35/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-sqlite-3-35/build.gradle
@@ -20,8 +20,8 @@ sqldelight {
 }
 
 dependencies {
-  implementation deps.sqliteJdbc
+  implementation libs.sqliteJdbc
   implementation "app.cash.sqldelight:sqlite-driver:${app.cash.sqldelight.VersionKt.VERSION}"
   implementation "org.xerial:sqlite-jdbc:3.35.0"
-  implementation deps.truth
+  implementation libs.truth
 }

--- a/sqldelight-gradle-plugin/src/test/integration-sqlite-json/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-sqlite-json/build.gradle
@@ -21,8 +21,8 @@ sqldelight {
 }
 
 dependencies {
-  implementation deps.sqliteJdbc
+  implementation libs.sqliteJdbc
   implementation "app.cash.sqldelight:sqlite-driver:${app.cash.sqldelight.VersionKt.VERSION}"
-  implementation deps.truth
+  implementation libs.truth
   implementation("com.squareup.moshi:moshi:1.13.0")
 }

--- a/sqldelight-gradle-plugin/src/test/integration/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration/build.gradle
@@ -19,7 +19,7 @@ sqldelight {
 }
 
 dependencies {
-  implementation deps.sqliteJdbc
+  implementation libs.sqliteJdbc
   implementation "app.cash.sqldelight:sqlite-driver:${app.cash.sqldelight.VersionKt.VERSION}"
-  implementation deps.truth
+  implementation libs.truth
 }

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/properties/PropertiesFileTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/properties/PropertiesFileTest.kt
@@ -67,10 +67,10 @@ class PropertiesFileTest {
         |archivesBaseName = 'Test'
         |
         |android {
-        |  compileSdk deps.versions.compileSdk.get() as int
+        |  compileSdk libs.versions.compileSdk.get() as int
         |
         |  defaultConfig {
-        |    minSdk deps.versions.minSdk.get() as int
+        |    minSdk libs.versions.minSdk.get() as int
         |  }
         |}
         |

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/CompilationUnitTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/CompilationUnitTests.kt
@@ -199,7 +199,7 @@ class CompilationUnitTests {
         |}
         |
         |android {
-        |  compileSdk deps.versions.compileSdk.get() as int
+        |  compileSdk libs.versions.compileSdk.get() as int
         |
         |  buildTypes {
         |    release {}
@@ -276,7 +276,7 @@ class CompilationUnitTests {
         |}
         |
         |android {
-        |  compileSdk deps.versions.compileSdk.get() as int
+        |  compileSdk libs.versions.compileSdk.get() as int
         |
         |  buildTypes {
         |    release {}

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/GradlePluginCombinationTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/GradlePluginCombinationTests.kt
@@ -35,7 +35,7 @@ class GradlePluginCombinationTests {
         |}
         |
         |android {
-        |  compileSdk deps.versions.compileSdk.get() as int
+        |  compileSdk libs.versions.compileSdk.get() as int
         |}
         |
         |kotlin {

--- a/sqldelight-gradle-plugin/src/test/library-project/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/library-project/build.gradle
@@ -15,7 +15,7 @@ repositories {
 android {
   namespace "com.example.sqldelight"
 
-  compileSdk deps.versions.compileSdk.get() as int
+  compileSdk libs.versions.compileSdk.get() as int
 
   lint {
     textReport true

--- a/sqldelight-gradle-plugin/src/test/multi-module/AndroidProject/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/multi-module/AndroidProject/build.gradle
@@ -12,7 +12,7 @@ sqldelight {
 android {
   namespace "com.example.sqldelight"
 
-  compileSdk deps.versions.compileSdk.get() as int
+  compileSdk libs.versions.compileSdk.get() as int
 
   buildTypes {
     release {}
@@ -34,5 +34,5 @@ android {
 dependencies {
   implementation project(path: ':MultiplatformProject')
   implementation "app.cash.sqldelight:sqlite-driver:${app.cash.sqldelight.VersionKt.VERSION}"
-  implementation deps.truth
+  implementation libs.truth
 }

--- a/sqldelight-gradle-plugin/src/test/multi-module/MultiplatformProject/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/multi-module/MultiplatformProject/build.gradle
@@ -11,7 +11,7 @@ sqldelight {
 android {
   namespace "app.cash.sqldelight.multiplatform.project"
 
-  compileSdk deps.versions.compileSdk.get() as int
+  compileSdk libs.versions.compileSdk.get() as int
 
   buildTypes {
     release {}

--- a/sqldelight-gradle-plugin/src/test/multi-module/ProjectA/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/multi-module/ProjectA/build.gradle
@@ -12,5 +12,5 @@ sqldelight {
 dependencies {
   implementation project(':ProjectB')
   implementation "app.cash.sqldelight:sqlite-driver:${app.cash.sqldelight.VersionKt.VERSION}"
-  implementation deps.truth
+  implementation libs.truth
 }

--- a/sqldelight-gradle-plugin/src/test/multithreaded-sqlite/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/multithreaded-sqlite/build.gradle
@@ -15,7 +15,7 @@ repositories {
 dependencies {
   implementation "org.xerial:sqlite-jdbc:3.34.0"
   implementation "app.cash.sqldelight:sqlite-driver:${app.cash.sqldelight.VersionKt.VERSION}"
-  implementation deps.truth
+  implementation libs.truth
 }
 
 sqldelight {

--- a/sqldelight-gradle-plugin/src/test/no-kotlin-android/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/no-kotlin-android/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 android {
-  compileSdk deps.versions.compileSdk.get() as int
+  compileSdk libs.versions.compileSdk.get() as int
 
   lint {
     textReport true

--- a/sqldelight-gradle-plugin/src/test/properties-file-android/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/properties-file-android/build.gradle
@@ -15,7 +15,7 @@ repositories {
 android {
   namespace "com.example"
 
-  compileSdk deps.versions.compileSdk.get() as int
+  compileSdk libs.versions.compileSdk.get() as int
 
   defaultConfig {
     minSdk 30

--- a/sqldelight-gradle-plugin/src/test/schema-file-android/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/schema-file-android/build.gradle
@@ -15,7 +15,7 @@ repositories {
 android {
   namespace "com.example.sqldelight"
 
-  compileSdk deps.versions.compileSdk.get() as int
+  compileSdk libs.versions.compileSdk.get() as int
 
   lint {
     textReport true

--- a/sqldelight-gradle-plugin/src/test/schema-output/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/schema-output/build.gradle
@@ -22,5 +22,5 @@ repositories {
 }
 
 dependencies {
-  implementation deps.truth
+  implementation libs.truth
 }

--- a/sqldelight-gradle-plugin/src/test/settings.gradle
+++ b/sqldelight-gradle-plugin/src/test/settings.gradle
@@ -1,6 +1,6 @@
 dependencyResolutionManagement {
     versionCatalogs {
-        deps {
+        libs {
             from(files("../../../gradle/libs.versions.toml"))
         }
     }

--- a/sqldelight-gradle-plugin/src/test/variants/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/variants/build.gradle
@@ -17,10 +17,10 @@ repositories {
 android {
   namespace "com.example.sqldelight"
 
-  compileSdk deps.versions.compileSdk.get() as int
+  compileSdk libs.versions.compileSdk.get() as int
 
   defaultConfig {
-    minSdk deps.versions.minSdk.get() as int
+    minSdk libs.versions.minSdk.get() as int
   }
 
   lint {

--- a/sqldelight-gradle-plugin/src/test/working-variants/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/working-variants/build.gradle
@@ -16,7 +16,7 @@ repositories {
 android {
   namespace "com.example.sqldelight"
 
-  compileSdk deps.versions.compileSdk.get() as int
+  compileSdk libs.versions.compileSdk.get() as int
 
   defaultConfig {
     applicationId "com.sample"

--- a/sqldelight-idea-plugin/build.gradle
+++ b/sqldelight-idea-plugin/build.gradle
@@ -1,17 +1,17 @@
 import org.jetbrains.intellij.tasks.RunPluginVerifierTask.FailureLevel
 
 plugins {
-  alias(deps.plugins.intellij)
-  alias(deps.plugins.kotlin.jvm)
-  alias(deps.plugins.changelog)
-  alias(deps.plugins.ksp)
+  alias(libs.plugins.intellij)
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.changelog)
+  alias(libs.plugins.ksp)
 }
 
 intellij {
   updateSinceUntilBuild = false
 
   // Comment version and uncomment localPath to test a local IDE build.
-  version = "IC-${deps.versions.idea.get()}"
+  version = "IC-${libs.versions.idea.get()}"
 //  localPath = "/Applications/Android Studio.app"
 
   pluginName = 'SQLDelight'
@@ -91,18 +91,18 @@ repositories {
 }
 
 dependencies {
-  ksp deps.moshiCodegen
+  ksp libs.moshiCodegen
 
   implementation project(':sqldelight-compiler')
 
-  implementation deps.sqliteJdbc
-  implementation(deps.bugsnag) {
+  implementation libs.sqliteJdbc
+  implementation(libs.bugsnag) {
     exclude group: "org.slf4j"
   }
-  implementation deps.picnic
-  implementation deps.moshi
+  implementation libs.picnic
+  implementation libs.moshi
 
-  testImplementation deps.truth
+  testImplementation libs.truth
   testImplementation project(':dialects:sqlite-3-18')
   testImplementation project(':test-util')
 }

--- a/sqlite-migrations/build.gradle
+++ b/sqlite-migrations/build.gradle
@@ -1,24 +1,24 @@
 plugins {
-  alias(deps.plugins.kotlin.jvm)
-  alias(deps.plugins.publish)
-  alias(deps.plugins.dokka)
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.publish)
+  alias(libs.plugins.dokka)
 }
 
 dependencies {
   // These dependencies will not be shadowed by sqldelight-gradle-plugin
-  compileOnly deps.sqliteJdbc
-  compileOnly deps.objectDiff
-  compileOnly deps.schemaCrawler.tools
-  compileOnly deps.schemaCrawler.sqlite
+  compileOnly libs.sqliteJdbc
+  compileOnly libs.objectDiff
+  compileOnly libs.schemaCrawler.tools
+  compileOnly libs.schemaCrawler.sqlite
 
-  implementation deps.sqlPsi
+  implementation libs.sqlPsi
 
-  testImplementation deps.sqliteJdbc
-  testImplementation deps.objectDiff
-  testImplementation deps.schemaCrawler.tools
-  testImplementation deps.schemaCrawler.sqlite
-  testImplementation deps.junit
-  testImplementation deps.truth
+  testImplementation libs.sqliteJdbc
+  testImplementation libs.objectDiff
+  testImplementation libs.schemaCrawler.tools
+  testImplementation libs.schemaCrawler.sqlite
+  testImplementation libs.junit
+  testImplementation libs.truth
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/test-util/build.gradle
+++ b/test-util/build.gradle
@@ -1,15 +1,15 @@
 plugins {
-  alias(deps.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.jvm)
 }
 
 dependencies {
   api project(':sqldelight-compiler')
   api project(':dialects:sqlite-3-18')
 
-  implementation deps.sqlPsi
-  implementation deps.intellij.core
-  implementation deps.intellij.lang
-  implementation deps.intellij.java
-  implementation deps.intellij.testFramework
-  implementation deps.junit
+  implementation libs.sqlPsi
+  implementation libs.intellij.core
+  implementation libs.intellij.lang
+  implementation libs.intellij.java
+  implementation libs.intellij.testFramework
+  implementation libs.junit
 }


### PR DESCRIPTION
Deprecation warning: The name of version catalogs must end with 'Libs' to reduce chances of extension conflicts. This will fail with an error in Gradle 8.0.

Documentation: https://docs.gradle.org/7.5.1/userguide/platforms.html#sec:multiple where it says:

> Each catalog will generate an extension applied to all projects for accessing its content. As such it makes sense to reduce the chance of collisions by picking a name that reduces the potential conflicts. Gradle will emit a deprecation warning if a catalog does not have a name that ends with Libs.