### PR TITLE
Prevent overwriting concurrent releases

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -7,6 +7,10 @@ on:
     tags:
       - '*'
 
+concurrency:
+  group: "release"
+  cancel-in-progress: false
+
 jobs:
   publish_archives:
     strategy:


### PR DESCRIPTION
If you merge two PRs very fast it is possible that the first workflow is slower than the second one. This results in non-consistent releases because the changes from the second later merged PR are not included in the first and the SNAPSHOT release misses these changes. 