### PR TITLE
R2DBC Expose dependencies

### DIFF
--- a/drivers/r2dbc-driver/build.gradle
+++ b/drivers/r2dbc-driver/build.gradle
@@ -8,9 +8,8 @@ archivesBaseName = 'sqldelight-r2dbc-driver'
 
 dependencies {
   api project(':runtime')
-  implementation libs.r2dbc
-  implementation libs.kotlin.coroutines.core
-  implementation libs.kotlin.coroutines.reactive
+  api libs.r2dbc
+  api libs.kotlin.coroutines.reactive
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"


### PR DESCRIPTION
Using a reactive driver in Kotlin without coroutines is a very rare case, so exposing this dependency makes the usage nicer.

Every r2dbc driver needs and depends on `r2dbc-spi`, so I don't see a reason to hide this dependency too.

