### PR TITLE
Move await* to upper class ExecutableQuery

### DIFF
--- a/extensions/async-extensions/src/commonMain/kotlin/app/cash/sqldelight/async/coroutines/QueryExtensions.kt
+++ b/extensions/async-extensions/src/commonMain/kotlin/app/cash/sqldelight/async/coroutines/QueryExtensions.kt
@@ -1,19 +1,19 @@
 package app.cash.sqldelight.async.coroutines
 
-import app.cash.sqldelight.Query
+import app.cash.sqldelight.ExecutableQuery
 
-suspend fun <T : Any> Query<T>.awaitAsList(): List<T> = execute { cursor ->
+suspend fun <T : Any> ExecutableQuery<T>.awaitAsList(): List<T> = execute { cursor ->
   val result = mutableListOf<T>()
   while (cursor.next()) result.add(mapper(cursor))
   result
 }.await()
 
-suspend fun <T : Any> Query<T>.awaitAsOne(): T {
+suspend fun <T : Any> ExecutableQuery<T>.awaitAsOne(): T {
   return awaitAsOneOrNull()
     ?: throw NullPointerException("ResultSet returned null for $this")
 }
 
-suspend fun <T : Any> Query<T>.awaitAsOneOrNull(): T? = execute { cursor ->
+suspend fun <T : Any> ExecutableQuery<T>.awaitAsOneOrNull(): T? = execute { cursor ->
   if (!cursor.next()) return@execute null
   val value = mapper(cursor)
   check(!cursor.next()) { "ResultSet returned more than 1 row for $this" }


### PR DESCRIPTION
`Query` is the subclass of `ExecutableQuery`, so you can't use these extensions with `ExecutableQuery`.