### PR TITLE
Adopt R2DBC changes which do not always send a value

### DIFF
--- a/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
+++ b/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
@@ -29,7 +29,7 @@ class R2dbcDriver(private val connection: Connection) : SqlDriver {
       val result = prepared.execute().awaitSingle()
 
       val rowSet = result.map { row, rowMetadata ->
-        List(rowMetadata.columnMetadatas.size) { index -> index to row.get(index) }.toMap()
+        List(rowMetadata.columnMetadatas.size) { index -> row.get(index) }
       }.asFlow().toList()
 
       return@AsyncValue mapper(R2dbcCursor(rowSet))
@@ -152,7 +152,7 @@ class R2dbcPreparedStatement(private val statement: Statement) : SqlPreparedStat
 /**
  * TODO: Write a better async cursor API
  */
-class R2dbcCursor(val rowSet: List<Map<Int, Any?>>) : SqlCursor {
+class R2dbcCursor(val rowSet: List<List<Any?>>) : SqlCursor {
   var row = -1
     private set
 

--- a/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
+++ b/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
@@ -8,7 +8,9 @@ import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlPreparedStatement
 import io.r2dbc.spi.Connection
 import io.r2dbc.spi.Statement
-import kotlinx.coroutines.reactive.awaitLast
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.reactive.asFlow
+import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.reactive.awaitSingle
 
 class R2dbcDriver(private val connection: Connection) : SqlDriver {
@@ -29,7 +31,7 @@ class R2dbcDriver(private val connection: Connection) : SqlDriver {
       val rowSet = mutableListOf<Map<Int, Any?>>()
       result.map { row, rowMetadata ->
         rowSet.add(rowMetadata.columnMetadatas.mapIndexed { index, _ -> index to row.get(index) }.toMap())
-      }.awaitLast()
+      }.asFlow().collect()
 
       return@AsyncValue mapper(R2dbcCursor(rowSet))
     }
@@ -47,7 +49,7 @@ class R2dbcDriver(private val connection: Connection) : SqlDriver {
 
     return QueryResult.AsyncValue {
       val result = prepared.execute().awaitSingle()
-      return@AsyncValue result.rowsUpdated.awaitSingle()
+      return@AsyncValue result.rowsUpdated.awaitFirstOrNull()?.toLong() ?: 0
     }
   }
 
@@ -64,7 +66,7 @@ class R2dbcDriver(private val connection: Connection) : SqlDriver {
     this.transaction = transaction
 
     if (enclosing == null) {
-      connection.beginTransaction().awaitSingle()
+      connection.beginTransaction().awaitFirstOrNull()
     }
 
     return@AsyncValue transaction
@@ -88,9 +90,9 @@ class R2dbcDriver(private val connection: Connection) : SqlDriver {
     override fun endTransaction(successful: Boolean): QueryResult<Unit> = QueryResult.AsyncValue {
       if (enclosingTransaction == null) {
         if (successful) {
-          connection.commitTransaction().awaitSingle()
+          connection.commitTransaction().awaitFirstOrNull()
         } else {
-          connection.rollbackTransaction().awaitSingle()
+          connection.rollbackTransaction().awaitFirstOrNull()
         }
       }
       transaction = enclosingTransaction

--- a/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
+++ b/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
@@ -48,7 +48,7 @@ class R2dbcDriver(private val connection: Connection) : SqlDriver {
 
     return QueryResult.AsyncValue {
       val result = prepared.execute().awaitSingle()
-      return@AsyncValue result.rowsUpdated.awaitFirstOrNull()?.toLong() ?: 0
+      return@AsyncValue result.rowsUpdated.awaitFirstOrNull() ?: 0
     }
   }
 


### PR DESCRIPTION
The new 1.0.0 release does not send a value when executing a sql statement (eg create a database). Instead, the `Publisher` is finished without a value, thus `awaitSingle` fails. Preparation for https://github.com/cashapp/sqldelight/pull/3375 which will enable the R2DBC tests.