### PR TITLE
Fix duplicate generation of ${name}Indexes variables when using transactions

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/QueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/QueryGenerator.kt
@@ -68,7 +68,7 @@ abstract class QueryGenerator(
       }
       val handledArrayArgs = mutableSetOf<BindableQuery.Argument>()
       query.statement.findChildrenOfType<SqlStmt>().forEachIndexed { index, statement ->
-        val (block,additionalArrayArgs) = executeBlock(statement, handledArrayArgs, query.idForIndex(index))
+        val (block, additionalArrayArgs) = executeBlock(statement, handledArrayArgs, query.idForIndex(index))
         handledArrayArgs.addAll(additionalArrayArgs)
         result.add(block)
       }
@@ -85,7 +85,7 @@ abstract class QueryGenerator(
     statement: PsiElement,
     handledArrayArgs: Set<BindableQuery.Argument>,
     id: Int,
-  ): Pair<CodeBlock,Set<BindableQuery.Argument>> {
+  ): Pair<CodeBlock, Set<BindableQuery.Argument>> {
     val dialectPreparedStatementType = if (generateAsync) dialect.asyncRuntimeTypes.preparedStatementType else dialect.runtimeTypes.preparedStatementType
 
     val result = CodeBlock.builder()
@@ -307,7 +307,7 @@ abstract class QueryGenerator(
       )
     }
 
-    return Pair(result.build(),seenArrayArguments)
+    return Pair(result.build(), seenArrayArguments)
   }
 
   private fun PsiElement.leftWhitspace(): String {

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/MutatorQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/MutatorQueryTypeTest.kt
@@ -897,9 +897,9 @@ class MutatorQueryTypeTest {
     )
   }
 
-    @Test fun `delete using named list parameter twice is fine`() {
-        val file = FixtureCompiler.parseSql(
-            """
+  @Test fun `delete using named list parameter twice is fine`() {
+    val file = FixtureCompiler.parseSql(
+      """
       |CREATE TABLE data (
       |  id INTEGER AS Int PRIMARY KEY,
       |  other INTEGER AS Int NOT NULL
@@ -910,15 +910,15 @@ class MutatorQueryTypeTest {
       |  DELETE FROM data WHERE other IN :ids;
       |}
       """.trimMargin(),
-            tempFolder,
-            fileName = "Data.sq",
-        )
+      tempFolder,
+      fileName = "Data.sq",
+    )
 
-        val mutator = file.namedExecutes.first()
-        val generator = ExecuteQueryGenerator(mutator)
+    val mutator = file.namedExecutes.first()
+    val generator = ExecuteQueryGenerator(mutator)
 
-        assertThat(generator.function().toString()).isEqualTo(
-            """
+    assertThat(generator.function().toString()).isEqualTo(
+      """
       |public fun delete(ids: kotlin.collections.Collection<Int>): kotlin.Unit {
       |  transaction {
       |    val idsIndexes = createArguments(count = ids.size)
@@ -939,6 +939,6 @@ class MutatorQueryTypeTest {
       |}
       |
       """.trimMargin(),
-        )
-    }
+    )
+  }
 }


### PR DESCRIPTION
If a single variable with an array type is used in multiple queries inside the same transaction the compiler generates multiple `val ${name}Indexes = createArguments(count = ${name}.size)` lines (one for each query).

This PR adds a test for the behaviour and a simple fix to prevent all but the first generation. The fix tries to reuse the code from commit cc524c70 which fixed the behaviour when using only a single query.

Running "./gradlew sqldelight-compiler:build" did not change any file under version control. I assume the change on the codegen did not affect any existing integration tests.