### PR TITLE
Make the Callback open again

### DIFF
--- a/drivers/android-driver/src/main/java/app/cash/sqldelight/driver/android/AndroidSqliteDriver.kt
+++ b/drivers/android-driver/src/main/java/app/cash/sqldelight/driver/android/AndroidSqliteDriver.kt
@@ -182,7 +182,7 @@ class AndroidSqliteDriver private constructor(
     return openHelper?.close() ?: database.close()
   }
 
-  class Callback(
+  open class Callback(
     private val schema: SqlSchema,
     vararg callbacks: AfterVersion,
   ) : SupportSQLiteOpenHelper.Callback(schema.version) {

--- a/drivers/android-driver/src/test/java/com/squareup/sqldelight/android/AndroidDriverTest.kt
+++ b/drivers/android-driver/src/test/java/com/squareup/sqldelight/android/AndroidDriverTest.kt
@@ -99,4 +99,17 @@ class AndroidDriverTest : DriverTest() {
 
     assertFalse(factory.lastConfiguration.useNoBackupDirectory)
   }
+
+  @Test
+  fun `using a custom callback works`() {
+    AndroidSqliteDriver(
+      schema = schema,
+      context = getApplicationContext(),
+      callback = object : AndroidSqliteDriver.Callback(schema) {
+        override fun onOpen(db: androidx.sqlite.db.SupportSQLiteDatabase) {
+          db.execSQL("PRAGMA foreign_keys=ON;")
+        }
+      },
+    )
+  }
 }


### PR DESCRIPTION
Fixes #3571
`androidx.sqlite.db.SupportSQLiteOpenHelper.Callback` is a class, so delegation does not work.