### PR TITLE
Use numbered indices in list arguments for async postgresql queries

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/BindParameterMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/BindParameterMixin.kt
@@ -8,4 +8,6 @@ abstract class BindParameterMixin(node: ASTNode) : BindParameterMixin(node) {
     isAsync -> "$$index"
     else -> "?"
   }
+
+  override fun useNumberedIndices(isAsync: Boolean) = isAsync
 }

--- a/runtime/src/commonMain/kotlin/app/cash/sqldelight/Transacter.kt
+++ b/runtime/src/commonMain/kotlin/app/cash/sqldelight/Transacter.kt
@@ -336,6 +336,24 @@ abstract class BaseTransacterImpl(protected val driver: SqlDriver) {
       append(')')
     }
   }
+
+  /**
+   * For internal use, creates a string in the format ($1, $2, $3) where there are [count] variables beginning at
+   * [offset] +1.
+   */
+  protected fun createNumberedArguments(offset: Int, count: Int): String {
+    if (count == 0) return "()"
+
+    return buildString(3 * count + 1) {
+      append("(\$")
+      append(offset + 1)
+      repeat(count - 1) {
+        append(",\$")
+        append(offset + 1 + index)
+      }
+      append(')')
+    }
+  }
 }
 
 /**

--- a/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/grammar/mixins/BindParameterMixin.kt
+++ b/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/grammar/mixins/BindParameterMixin.kt
@@ -12,4 +12,6 @@ abstract class BindParameterMixin(node: ASTNode) : SqlCompositeElementImpl(node)
    * user provided parameter with [replaceWith] for a homogen generated code.
    */
   open fun replaceWith(isAsync: Boolean, index: Int): String = "?"
+
+  open fun useNumberedIndices(isAsync: Boolean) = false
 }


### PR DESCRIPTION
Queries with "IN" use the `createArguments` function at runtime to generate an argument list consisting of the correct number of questionmarks.

In #3559 the BindParameterMixin was introduced to replace questionsmarks with numbered indices for queries generated with the postgresql dialect when the `R2dbcDriver` is used. This change did not include the dynamic generation of argument lists at runtime.

This PR introduces a new helper function `createNumberedArguments` and changes the code generation to switch between this and the already existing `createArguments` function depending on the dialect and if async queries are to be used. 

Also, if numbered indices are used, each query in a transactions uses a seperate ${name}Indexes variable due to probably different offsets. It may be possible to optimize them away in some cases if the offsets are stored and only one variable per list argument and offset is created. I did not attempt to write this optimization since I expect the code to become significantly more complicated for an insignificant performance gain.