### PR TITLE
Fix SelectQueryGenerator to support bind expression without parenthesis

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SelectQueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SelectQueryGenerator.kt
@@ -62,8 +62,7 @@ class SelectQueryGenerator(
    */
   fun defaultResultTypeFunction(): FunSpec {
     val argNameAllocator = NameAllocator()
-    val parametersAndTypes = query.arguments.sortedBy { it.index }
-      .map { (_, arg) -> argNameAllocator.newName(arg.name, arg) to arg.argumentType() }
+    val parametersAndTypes = query.parameters.map { argNameAllocator.newName(it.name, it) to it.argumentType() }
 
     val function = defaultResultTypeFunctionInterface(parametersAndTypes)
     val params = parametersAndTypes.map { (name) -> CodeBlock.of(name) }
@@ -117,13 +116,11 @@ class SelectQueryGenerator(
 
   private fun customResultTypeFunctionInterface(): FunSpec.Builder {
     val function = FunSpec.builder(query.name).also(::addJavadoc)
-    val params = mutableListOf<CodeBlock>()
 
-    query.arguments.sortedBy { it.index }.forEach { (_, argument) ->
+    query.parameters.forEach {
       // Adds each sqlite parameter to the argument list:
       // fun <T> selectForId(<<id>>, <<other_param>>, ...)
-      function.addParameter(argument.name, argument.argumentType())
-      params.add(CodeBlock.of(argument.name))
+      function.addParameter(it.name, it.argumentType())
     }
 
     if (query.needsWrapper()) {

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/PgInsertReturningTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/PgInsertReturningTest.kt
@@ -1,0 +1,60 @@
+package app.cash.sqldelight.core.queries
+
+import app.cash.sqldelight.core.compiler.SelectQueryGenerator
+import app.cash.sqldelight.dialects.postgresql.PostgreSqlDialect
+import app.cash.sqldelight.test.util.FixtureCompiler
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class PgInsertReturningTest {
+  @get:Rule
+  val tempFolder = TemporaryFolder()
+
+  @Test
+  fun `postgres INSERT RETURNING works with bind expr ?`() {
+    val file = FixtureCompiler.parseSql(
+      """
+            |CREATE TABLE data (
+            |  id INTEGER NOT NULL PRIMARY KEY,
+            |  col1 TEXT DEFAULT ''
+            |);
+            |
+            |insertReturn:
+            |INSERT INTO data
+            |VALUES ?
+            |RETURNING *;
+      """.trimMargin(),
+      tempFolder,
+      dialect = PostgreSqlDialect(),
+    )
+
+    val insert = file.namedQueries.first()
+    val generator = SelectQueryGenerator(insert)
+
+    assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo(
+      """
+        |public fun insertReturn(data_: com.example.Data_): app.cash.sqldelight.ExecutableQuery<com.example.Data_> = insertReturn(data_) { id, col1 ->
+        |  com.example.Data_(
+        |    id,
+        |    col1
+        |  )
+        |}
+        |
+      """.trimMargin(),
+    )
+    assertThat(generator.customResultTypeFunction().toString()).isEqualTo(
+      """
+        |public fun <T : kotlin.Any> insertReturn(data_: com.example.Data_, mapper: (id: kotlin.Int, col1: kotlin.String?) -> T): app.cash.sqldelight.ExecutableQuery<T> = InsertReturnQuery(data_.id, data_.col1) { cursor ->
+        |  check(cursor is app.cash.sqldelight.driver.jdbc.JdbcCursor)
+        |  mapper(
+        |    cursor.getLong(0)!!.toInt(),
+        |    cursor.getString(1)
+        |  )
+        |}
+        |
+      """.trimMargin()
+    )
+  }
+}


### PR DESCRIPTION
```
CREATE TABLE data (
  id INTEGER NOT NULL PRIMARY KEY,
  col1 TEXT DEFAULT ''
);

insertReturn:
INSERT INTO data
VALUES ?
RETURNING *;
```

Above query can not be compiled since the query's arguments with name like as `data_.id` can not be placed in parameters.
https://github.com/cashapp/sqldelight/blob/6df5dea83b04876f36981e4f9b47cf6a72606923/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SelectQueryGenerator.kt#L122-L127

So this PR addressed this problem by using query's parameters directly instead of arguments.