### PR TITLE
chore: enable GitHub SQL highlight for .sq files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,7 @@
 *.woff2         binary
 *.ico           binary
 *.a             binary
+
+# GitHub syntax highligthing 
+*.sq            linguist-language=SQL
+*.sqm           linguist-language=SQL


### PR DESCRIPTION
# What's new in this PR?

### Issues

GitHub doesn't add syntax highlighting for `.sq` and `.sqm` files.

### Solutions

Add `.gitattributes` instructions to add `SQL` syntax to these files. As seen in https://github.com/github/linguist/blob/master/docs/overrides.md.

Works for `.sq` and `.sqm` files, both when browsing code or when reviewing diffs.

### Testing

#### How to Test

Compare browsing a `.sq` or `.sqm` file on [cashapp/sqldelight](https://github.com/cashapp/sqldelight/blob/master/sample/common/src/commonMain/sqldelight/com/example/sqldelight/hockey/data/Player.sq) VS on [vitorhugods/sqldelight](https://github.com/vitorhugods/sqldelight/blob/master/sample/common/src/commonMain/sqldelight/com/example/sqldelight/hockey/data/Player.sq).

### Attachments

#### Before

![grafik](https://user-images.githubusercontent.com/9389043/198264026-326df7e4-75b5-447e-b3f2-2dcc1e3f7c0d.png)


##### After

![grafik](https://user-images.githubusercontent.com/9389043/198264059-a77fd66a-55b6-4984-85f3-d3ff750c612d.png)


----