### PR TITLE
mkdocs: add light/dark mode toggle

### DIFF
--- a/docs/css/app.css
+++ b/docs/css/app.css
@@ -27,7 +27,7 @@ body, input {
   font-family: cash-market, "Helvetica Neue", helvetica, sans-serif;
   line-height: normal;
   font-weight: bold;
-  color: #353535;
+  color: var(--md-default-fg-color)
 }
 
 button.dl {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -219,8 +219,23 @@ theme:
   favicon: images/icon-cashapp.png
   logo: images/icon-cashapp.png
   palette:
-    primary: 'deep purple'
-    accent: 'pink'
+    # Palette toggle for light mode
+    - scheme: default
+      media: "(prefers-color-scheme: light)"
+      primary: 'deep purple'
+      accent: 'pink'
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - scheme: slate
+      media: "(prefers-color-scheme: dark)"
+      primary: 'deep purple'
+      accent: 'pink'
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
   features:
     - navigation.tabs
     - content.tabs.link


### PR DESCRIPTION
Adds a light/dark mode toggle to the docs

Live example: https://asemy.github.io/sqldelight/

Documentation here: https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#color-palette-toggle

Example config here: https://github.com/squidfunk/mkdocs-material/blob/2569d4f0884b9fe3be934215ce0cfddf8efc94b8/mkdocs.yml#L60-L72