### PR TITLE
docs: fix 404 link to jdoneill.com article

### DIFF
--- a/docs/multiplatform_sqlite/resources.md
+++ b/docs/multiplatform_sqlite/resources.md
@@ -3,7 +3,7 @@
 ## Guides
 
 - [Introduction to Multiplatform Persistence with SQLDelight](https://johnoreilly.dev/posts/sqldelight-multiplatform/)
-- [Multiplatform Persistence with SQLDelight](http://gh.jdoneill.com/2020/06/28/sqldelight/)
+- [Multiplatform Persistence with SQLDelight](https://gh.jdoneill.com/2020/06/29/sqldelight/)
 
 ## Samples
 


### PR DESCRIPTION
The current link https://gh.jdoneill.com/2020/06/28/sqldelight/ 404's

The correct link is https://gh.jdoneill.com/2020/06/29/sqldelight/