### PR TITLE
Add "typesafe" dependency accessors

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDependencies.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDependencies.kt
@@ -1,0 +1,51 @@
+package app.cash.sqldelight.gradle
+
+import app.cash.sqldelight.VERSION
+
+fun sqldelightDependency(artifact: String) = "$artifact:$VERSION"
+
+object SqlDelightDependencies {
+  val runtime get() = sqldelightDependency("app.cash.sqldelight:runtime")
+  val asyncRuntime get() = sqldelightDependency("app.cash.sqldelight:runtime-async")
+  val drivers = DriverDependencies
+  val extensions = ExtensionDependencies
+  val dialects = DialectDependencies
+}
+
+object DriverDependencies {
+  val jdbc get() = sqldelightDependency("app.cash.sqldelight:jdbc-driver")
+  val sqlite = object {
+    val jvm get() = sqldelightDependency("app.cash.sqldelight:sqlite-driver")
+    val android get() = sqldelightDependency("app.cash.sqldelight:android-driver")
+    val native get() = sqldelightDependency("app.cash.sqldelight:native-driver")
+    val js get() = sqldelightDependency("app.cash.sqldelight:sqljs-driver")
+  }
+  val r2dbc get() = sqldelightDependency("app.cash.sqldelight:r2dbc-driver")
+}
+
+object ExtensionDependencies {
+  val androidPaging3 get() = sqldelightDependency("app.cash.sqldelight:android-paging3-extensions")
+  val async get() = sqldelightDependency("app.cash.sqldelight:async-extensions")
+  val coroutines get() = sqldelightDependency("app.cash.sqldelight:coroutines-extensions")
+  val rxjava2 get() = sqldelightDependency("app.cash.sqldelight:rxjava2-extensions")
+  val rxjava3 get() = sqldelightDependency("app.cash.sqldelight:rxjava3-extensions")
+}
+
+object DialectDependencies {
+  val hsql get() = sqldelightDependency("app.cash.sqldelight:hsql-dialect")
+  val mysql get() = sqldelightDependency("app.cash.sqldelight:mysql-dialect")
+  val postgresql get() = sqldelightDependency("app.cash.sqldelight:postgresql-dialect")
+  val sqlite = object {
+    val jsonModule get() = sqldelightDependency("app.cash.sqldelight:sqlite-json-module")
+  }
+  val sqlite_3_18 get() = sqldelightDependency("app.cash.sqldelight:sqlite-3-18-dialect")
+  val sqlite_3_24 get() = sqldelightDependency("app.cash.sqldelight:sqlite-3-24-dialect")
+  val sqlite_3_25 get() = sqldelightDependency("app.cash.sqldelight:sqlite-3-25-dialect")
+  val sqlite_3_30 get() = sqldelightDependency("app.cash.sqldelight:sqlite-3-30-dialect")
+  val sqlite_3_35 get() = sqldelightDependency("app.cash.sqldelight:sqlite-3-35-dialect")
+  val sqlite_3_38 get() = sqldelightDependency("app.cash.sqldelight:sqlite-3-38-dialect")
+}
+
+object AdapterDependencies {
+  val primitives = sqldelightDependency("app.cash.sqldelight:primitive-adapters")
+}

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
@@ -50,6 +50,8 @@ abstract class SqlDelightPlugin : Plugin<Project> {
     extension = project.extensions.create("sqldelight", SqlDelightExtension::class.java)
     extension.project = project
 
+    project.dependencies.extensions.add("sqldelight", SqlDelightDependencies)
+
     val androidPluginHandler = { _: Plugin<*> ->
       android.set(true)
       project.afterEvaluate {

--- a/sqldelight-gradle-plugin/src/test/dependency-accessors/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/dependency-accessors/build.gradle
@@ -1,0 +1,25 @@
+buildscript {
+  apply from: "${projectDir.absolutePath}/../buildscript.gradle"
+}
+
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'app.cash.sqldelight'
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../build/localMaven"
+  }
+  mavenCentral()
+}
+
+sqldelight {
+  QueryWrapper {
+    packageName = "app.cash.sqldelight.integration"
+  }
+}
+
+dependencies {
+  implementation libs.sqliteJdbc
+  implementation sqldelight.drivers.sqlite.jvm
+  implementation libs.truth
+}

--- a/sqldelight-gradle-plugin/src/test/dependency-accessors/settings.gradle
+++ b/sqldelight-gradle-plugin/src/test/dependency-accessors/settings.gradle
@@ -1,0 +1,9 @@
+apply from: "../settings.gradle"
+
+rootProject.name = 'integration'
+
+buildCache {
+  local {
+    directory = new File(rootDir, 'build-cache')
+  }
+}

--- a/sqldelight-gradle-plugin/src/test/dependency-accessors/src/main/sqldelight/app/cash/sqldelight/integration/BigTable.sq
+++ b/sqldelight-gradle-plugin/src/test/dependency-accessors/src/main/sqldelight/app/cash/sqldelight/integration/BigTable.sq
@@ -1,0 +1,40 @@
+CREATE TABLE bigTable (
+  val1 INTEGER,
+  val2 INTEGER,
+  val3 INTEGER,
+  val4 INTEGER,
+  val5 INTEGER,
+  val6 INTEGER,
+  val7 INTEGER,
+  val8 INTEGER,
+  val9 INTEGER,
+  val10 INTEGER,
+  val11 INTEGER,
+  val12 INTEGER,
+  val13 INTEGER,
+  val14 INTEGER,
+  val15 INTEGER,
+  val16 INTEGER,
+  val17 INTEGER,
+  val18 INTEGER,
+  val19 INTEGER,
+  val20 INTEGER,
+  val21 INTEGER,
+  val22 INTEGER,
+  val23 INTEGER,
+  val24 INTEGER,
+  val25 INTEGER,
+  val26 INTEGER,
+  val27 INTEGER,
+  val28 INTEGER,
+  val29 INTEGER,
+  val30 INTEGER
+);
+
+insert:
+INSERT INTO bigTable
+VALUES ?;
+
+select:
+SELECT *
+FROM bigTable;

--- a/sqldelight-gradle-plugin/src/test/dependency-accessors/src/main/sqldelight/app/cash/sqldelight/integration/GroupedStatement.sq
+++ b/sqldelight-gradle-plugin/src/test/dependency-accessors/src/main/sqldelight/app/cash/sqldelight/integration/GroupedStatement.sq
@@ -1,0 +1,25 @@
+CREATE TABLE Bug (
+    col0 TEXT NOT NULL,
+    col1 TEXT NOT NULL,
+    col2 INTEGER NOT NULL DEFAULT 0,
+    col3 INTEGER NOT NULL
+);
+
+CREATE UNIQUE INDEX Bug__col0_col1 ON Bug(col0, col1);
+
+upsert {
+  UPDATE Bug
+  SET col2 = :col2,
+      col3 = :col3
+  WHERE col0 = :col0
+    AND col1 = :col1
+  ;
+
+  INSERT OR IGNORE INTO Bug(col0, col1, col2, col3)
+  VALUES (:col0, :col1, :col2, :col3)
+  ;
+}
+
+selectAll:
+SELECT *
+FROM Bug;

--- a/sqldelight-gradle-plugin/src/test/dependency-accessors/src/main/sqldelight/app/cash/sqldelight/integration/NullableTypes.sq
+++ b/sqldelight-gradle-plugin/src/test/dependency-accessors/src/main/sqldelight/app/cash/sqldelight/integration/NullableTypes.sq
@@ -1,0 +1,12 @@
+CREATE TABLE nullableTypes (
+  val1 TEXT AS kotlin.collections.List<kotlin.String>,
+  val2 TEXT
+);
+
+insertNullableType:
+INSERT INTO nullableTypes
+VALUES ?;
+
+selectAll:
+SELECT *
+FROM nullableTypes;

--- a/sqldelight-gradle-plugin/src/test/dependency-accessors/src/main/sqldelight/app/cash/sqldelight/integration/Person.sq
+++ b/sqldelight-gradle-plugin/src/test/dependency-accessors/src/main/sqldelight/app/cash/sqldelight/integration/Person.sq
@@ -1,0 +1,59 @@
+CREATE TABLE person (
+  _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  first_name TEXT NOT NULL,
+  last_name TEXT NOT NULL
+);
+
+INSERT INTO person (first_name, last_name)
+VALUES ('Alec', 'Strong'),
+       ('Matt', 'Precious'),
+       ('Jake', 'Wharton'),
+       ('Bob', 'Bob');
+
+deleteAll:
+DELETE FROM person;
+
+equivalentNames:
+SELECT *
+FROM person
+WHERE first_name = ?1 AND last_name = ?1;
+
+equivalentNames2:
+SELECT *
+FROM person
+WHERE first_name = ?2 AND last_name = ?2;
+
+equivalentNamesNamed:
+SELECT *
+FROM person
+WHERE first_name = :name AND last_name = :name;
+
+indexedArgLast:
+SELECT *
+FROM person
+WHERE first_name = ? AND last_name = ?1;
+
+indexedArgLast2:
+SELECT *
+FROM person
+WHERE first_name = ? AND last_name = ?2;
+
+nameIn:
+SELECT *
+FROM person
+WHERE first_name IN ?;
+
+multipleNameIn:
+SELECT *
+FROM person
+WHERE first_name IN ?
+OR last_name IN ?;
+
+insertAndReturn {
+  INSERT INTO person (first_name, last_name)
+  VALUES (?, ?);
+
+  SELECT first_name, last_name
+  FROM person
+  WHERE _id = last_insert_rowid();
+}

--- a/sqldelight-gradle-plugin/src/test/dependency-accessors/src/main/sqldelight/app/cash/sqldelight/integration/SqliteKeywords.sq
+++ b/sqldelight-gradle-plugin/src/test/dependency-accessors/src/main/sqldelight/app/cash/sqldelight/integration/SqliteKeywords.sq
@@ -1,0 +1,19 @@
+CREATE TABLE `group` (
+  _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  'where' INTEGER NOT NULL,
+  [having] INTEGER NOT NULL
+);
+
+INSERT INTO `group`('where', [having])
+VALUES (10, 20);
+
+insertStmt:
+INSERT INTO `group`('where', [having])
+VALUES (?, ?);
+
+selectAll:
+SELECT *
+FROM `group`;
+
+deleteAll:
+DELETE FROM `group`;

--- a/sqldelight-gradle-plugin/src/test/dependency-accessors/src/main/sqldelight/app/cash/sqldelight/integration/Varargs.sq
+++ b/sqldelight-gradle-plugin/src/test/dependency-accessors/src/main/sqldelight/app/cash/sqldelight/integration/Varargs.sq
@@ -1,0 +1,13 @@
+CREATE TABLE myTable (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    field1 INTEGER NOT NULL,
+    field2 INTEGER NOT NULL
+);
+
+insert:
+INSERT OR REPLACE INTO myTable VALUES ?;
+
+select:
+SELECT *
+FROM myTable
+WHERE field1 IN ? AND field2 = ?;

--- a/sqldelight-gradle-plugin/src/test/dependency-accessors/src/test/java/app/cash/sqldelight/integration/IntegrationTests.kt
+++ b/sqldelight-gradle-plugin/src/test/dependency-accessors/src/test/java/app/cash/sqldelight/integration/IntegrationTests.kt
@@ -1,0 +1,186 @@
+package app.cash.sqldelight.integration
+
+import app.cash.sqldelight.ColumnAdapter
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver.Companion.IN_MEMORY
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import java.util.Arrays
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit.SECONDS
+
+class IntegrationTests {
+  private lateinit var queryWrapper: QueryWrapper
+  private lateinit var personQueries: PersonQueries
+  private lateinit var keywordsQueries: SqliteKeywordsQueries
+  private lateinit var nullableTypesQueries: NullableTypesQueries
+  private lateinit var bigTableQueries: BigTableQueries
+  private lateinit var varargsQueries: VarargsQueries
+  private lateinit var groupedStatementQueries: GroupedStatementQueries
+
+  private object listAdapter : ColumnAdapter<List<String>, String> {
+    override fun decode(databaseValue: String): List<String> = databaseValue.split(",")
+    override fun encode(value: List<String>): String = value.joinToString(",")
+  }
+
+  @Before fun before() {
+    val database = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+    QueryWrapper.Schema.create(database)
+
+    queryWrapper = QueryWrapper(database, NullableTypes.Adapter(listAdapter))
+    personQueries = queryWrapper.personQueries
+    keywordsQueries = queryWrapper.sqliteKeywordsQueries
+    nullableTypesQueries = queryWrapper.nullableTypesQueries
+    bigTableQueries = queryWrapper.bigTableQueries
+    varargsQueries = queryWrapper.varargsQueries
+    groupedStatementQueries = queryWrapper.groupedStatementQueries
+  }
+
+  @After fun after() {
+    File("test.db").delete()
+  }
+
+  @Test fun indexedArgs() {
+    // ?1 is the only arg
+    val person = personQueries.equivalentNames("Bob").executeAsOne()
+    assertThat(person).isEqualTo(Person(4, "Bob", "Bob"))
+  }
+
+  @Test fun startIndexAtTwo() {
+    // ?2 is the only arg
+    val person = personQueries.equivalentNames2("Bob").executeAsOne()
+    assertThat(person).isEqualTo(Person(4, "Bob", "Bob"))
+  }
+
+  @Test fun namedIndexArgs() {
+    // :name is the only arg
+    val person = personQueries.equivalentNamesNamed("Bob").executeAsOne()
+    assertThat(person).isEqualTo(Person(4, "Bob", "Bob"))
+  }
+
+  @Test fun indexedArgLast() {
+    // First arg declared is ?, second arg declared is ?1.
+    val person = personQueries.indexedArgLast("Bob").executeAsOne()
+    assertThat(person).isEqualTo(Person(4, "Bob", "Bob"))
+  }
+
+  @Test fun indexedArgLastTwo() {
+    // First arg declared is ?, second arg declared is ?2.
+    val person = personQueries.indexedArgLast2("Alec", "Strong").executeAsOne()
+    assertThat(person).isEqualTo(Person(1, "Alec", "Strong"))
+  }
+
+  @Test fun nameIn() {
+    val people = personQueries.nameIn(Arrays.asList("Alec", "Matt", "Jake")).executeAsList()
+    assertThat(people).hasSize(3)
+  }
+
+  @Test fun sqliteKeywordQuery() {
+    val keywords = keywordsQueries.selectAll().executeAsOne()
+    assertThat(keywords).isEqualTo(Group(1, 10, 20))
+  }
+
+  @Test fun compiledStatement() {
+    keywordsQueries.insertStmt(11, 21)
+    keywordsQueries.insertStmt(12, 22)
+
+    var current: Long = 10
+    for (group in keywordsQueries.selectAll().executeAsList()) {
+      assertThat(group.where_).isEqualTo(current++)
+    }
+    assertThat(current).isEqualTo(13)
+  }
+
+  @Test
+  @Throws(InterruptedException::class)
+  fun compiledStatementAcrossThread() {
+    keywordsQueries.insertStmt(11, 21)
+
+    val latch = CountDownLatch(1)
+    Thread(
+      object : Runnable {
+        override fun run() {
+          try {
+            keywordsQueries.insertStmt(12, 22)
+          } finally {
+            latch.countDown()
+          }
+        }
+      },
+    ).start()
+
+    assertTrue(latch.await(10, SECONDS))
+
+    var current: Long = 10
+    for (group in keywordsQueries.selectAll().executeAsList()) {
+      assertThat(group.where_).isEqualTo(current++)
+    }
+    assertThat(current).isEqualTo(13)
+  }
+
+  @Test
+  fun nullableColumnsUseAdapterProperly() {
+    val cool = NullableTypes(listOf("Alec", "Matt", "Jake"), "Cool")
+    val notCool = NullableTypes(null, "Not Cool")
+    val nulled = NullableTypes(null, null)
+    nullableTypesQueries.insertNullableType(cool)
+    nullableTypesQueries.insertNullableType(notCool)
+    nullableTypesQueries.insertNullableType(nulled)
+
+    assertThat(nullableTypesQueries.selectAll().executeAsList())
+      .containsExactly(cool, notCool, nulled)
+  }
+
+  @Test fun multipleNameIn() {
+    val people = personQueries.multipleNameIn(listOf("Alec", "Jesse"), listOf("Wharton", "Precious")).executeAsList()
+    assertThat(people).hasSize(3)
+  }
+
+  @Test fun bigTable() {
+    val bigTable = BigTable(
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+      20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+    )
+
+    bigTableQueries.insert(bigTable)
+
+    assertThat(bigTableQueries.select().executeAsOne()).isEqualTo(bigTable)
+  }
+
+  @Test fun varargs() {
+    varargsQueries.insert(MyTable(1, 1, 10))
+    varargsQueries.insert(MyTable(2, 2, 10))
+    varargsQueries.insert(MyTable(3, 3, 10))
+
+    assertThat(varargsQueries.select(setOf(1, 2), 10).executeAsList()).containsExactly(
+      MyTable(1, 1, 10),
+      MyTable(2, 2, 10),
+    )
+  }
+
+  @Test fun groupedStatement() {
+    groupedStatementQueries.upsert(col0 = "1", col1 = "1", col2 = 1, col3 = 10)
+    groupedStatementQueries.upsert(col0 = "2", col1 = "2", col2 = 1, col3 = 20)
+    groupedStatementQueries.upsert(col0 = "1", col1 = "1", col2 = 0, col3 = 11)
+
+    assertThat(groupedStatementQueries.selectAll().executeAsList()).containsExactly(
+      Bug("2", "2", 1, 20),
+      Bug("1", "1", 0, 11),
+    )
+  }
+
+  @Test fun groupedStatementWithReturn() {
+    assertThat(
+      personQueries.insertAndReturn(first_name = "Bob", last_name = "Ross").executeAsOne(),
+    ).isEqualTo(
+      InsertAndReturn(
+        first_name = "Bob",
+        last_name = "Ross",
+      ),
+    )
+  }
+}

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/PluginTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/PluginTest.kt
@@ -207,4 +207,14 @@ class PluginTest {
     assertThat(result.output)
       .contains("SQLDelight Gradle plugin was applied but there are no databases set up.")
   }
+
+  @Test
+  fun `the dependency accessor extensions work`() {
+    val result = GradleRunner.create()
+      .withCommonConfiguration(File("src/test/dependency-accessors"))
+      .withArguments("build", "--stacktrace")
+      .build()
+
+    assertThat(result.output).contains("BUILD SUCCESSFUL")
+  }
 }


### PR DESCRIPTION
For extra convenience

Some extensions to make it easier to quickly add sqldelight dependencies without having to look up the artifact strings, and to keep everything consistent with the gradle plugin version.

```kotlin
// before
dependencies {
  implementation("app.cash.sqldelight:sqlite-driver:2.0.0")
}

// after
dependencies {
  implementation(sqldelight.drivers.sqlite.jvm)
}