### PR TITLE
Downgrade Markdown to 3.3.7

### DIFF
--- a/.github/workflows/Renovate.yml
+++ b/.github/workflows/Renovate.yml
@@ -1,0 +1,24 @@
+name: Extra Renovate Checks
+
+on:
+  pull_request:
+    paths:
+      - '.github/**'
+    branches:
+      - renovate/*
+
+jobs:
+  mkdocs_requirements:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+
+      - name: Install Requirements
+        run: pip3 install -r .github/workflows/prepare_mkdocs.sh

--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -3,7 +3,7 @@ future==0.18.2
 Jinja2==3.1.2
 livereload==2.6.3
 lunr==0.6.2
-Markdown==3.4.1
+Markdown==3.3.7
 MarkupSafe==2.1.1
 mkdocs==1.4.2
 mkdocs-macros-plugin==0.7.0


### PR DESCRIPTION
mkdocs currently requires a version of Markdown that is <3.4.

This also adds an action to check renovate upgrades on the requirements.txt