### PR TITLE
Ensure single instance of yarn runs at once

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ allprojects {
     targetCompatibility = JavaVersion.VERSION_11
   }
 
+  // Workaround for yarn concurrency issue - https://youtrack.jetbrains.com/issue/KT-43320
   tasks.withType(org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask).configureEach {
     args.addAll(["--mutex", "file:${file("build/.yarn-mutex")}".toString()])
   }

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,10 @@ allprojects {
     targetCompatibility = JavaVersion.VERSION_11
   }
 
+  tasks.withType(org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask).configureEach {
+    args.addAll(["--mutex", "file:${file("build/.yarn-mutex")}".toString()])
+  }
+
   tasks.withType(org.jetbrains.grammarkit.tasks.GenerateParserTask).configureEach {
     doFirst {
       // https://github.com/JetBrains/gradle-grammar-kit-plugin/pull/78.

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -6,3 +6,7 @@ plugins {
   alias(libs.plugins.kotlin.js) apply false
   alias(libs.plugins.kotlin.native.cocoapods) apply false
 }
+
+tasks.withType(org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask).configureEach {
+  args.addAll(["--mutex", "file:${file("../build/.yarn-mutex")}".toString()])
+}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -7,6 +7,7 @@ plugins {
   alias(libs.plugins.kotlin.native.cocoapods) apply false
 }
 
+// Workaround yarn concurrency issue - https://youtrack.jetbrains.com/issue/KT-43320
 tasks.withType(org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask).configureEach {
   args.addAll(["--mutex", "file:${file("../build/.yarn-mutex")}".toString()])
 }


### PR DESCRIPTION
https://classic.yarnpkg.com/lang/en/docs/cli/#toc-concurrency-and-mutex

> When running multiple instances of yarn as the same user on the same server, you can ensure only one instance runs at any given time (and avoid conflicts) by passing the global flag --mutex followed by file or network.

See https://github.com/cashapp/sqldelight/pull/3700#issuecomment-1327775716