### PR TITLE
Publish versioned docs using mike

### DIFF
--- a/.github/workflows/Publish-Website.yml
+++ b/.github/workflows/Publish-Website.yml
@@ -1,6 +1,8 @@
 name: Publish the mkdocs to GitHub Pages
 
 on:
+  push:
+    branches: [master]
   release:
     types: [published]
   workflow_dispatch:
@@ -39,14 +41,17 @@ jobs:
           pip3 install -r .github/workflows/requirements.txt
           mkdocs build
 
-      - uses: actions/upload-pages-artifact@v1
-        if: success()
-        with:
-          path: site
-      - name: Deploy to GitHub Pages
-        if: success()
-        id: deployment
-        uses: actions/deploy-pages@main
+      - name: Get Docs Version
+        run: cat gradle.properties | grep --color=never VERSION_NAME >> $GITHUB_OUTPUT
+        id: version
+
+      - name: Deploy SNAPSHOT Docs with mike 🗿
+        if: ${{ success() && contains(steps.version.output.VERSION_NAME, 'SNAPSHOT') }}
+        run: mike deploy --push ${{ steps.version.output.VERSION_NAME }} snapshot
+
+      - name: Deploy Docs with mike 🚀
+        if: ${{ success() && !contains(steps.version.output.VERSION_NAME , 'SNAPSHOT') }}
+        run: mike deploy --push ${{ steps.version.output.VERSION_NAME }} latest
 
 env:
   GRADLE_OPTS: -Dorg.gradle.configureondemand=true -Dorg.gradle.parallel=true -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"

--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -5,6 +5,7 @@ livereload==2.6.3
 lunr==0.6.2
 Markdown==3.3.7
 MarkupSafe==2.1.1
+mike==1.1.2
 mkdocs==1.4.2
 mkdocs-macros-plugin==0.7.0
 mkdocs-material==8.5.11

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -255,7 +255,10 @@ markdown_extensions:
 plugins:
   - search
   - macros
+  - mike
 
 extra:
   versions:
     sqldelight: '2.0.0-alpha04'
+  version:
+    provider: mike


### PR DESCRIPTION
Uses [mike](https://github.com/jimporter/mike) to publish versioned docs. As far as I know, mike currently doesn't support the new environment-based pages publishing so we have to revert back to using our `gh-pages` branch for the time being (which I think is fine).

This PR needs #3733 to be merged first, and I also need to get around to fixing #3570.