### PR TITLE
Apply package prefix if not already present in directory structure

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/SqlDelightEnvironment.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/SqlDelightEnvironment.kt
@@ -324,11 +324,9 @@ class SqlDelightEnvironment(
 
       for (sourceFolder in sourceFolders(file)) {
         val path = file.parent!!.relativePathUnder(sourceFolder)
-        if (path != null) return path.joinToString(separator = ".") {
-          SqlDelightFileIndex.sanitizeDirectoryName(
-            it,
-          )
-        }
+        if (path != null) return SqlDelightFileIndex.applyPackagePrefix(packageName, path.joinToString(separator = ".") {
+          SqlDelightFileIndex.sanitizeDirectoryName(it)
+        })
       }
 
       throw IllegalStateException(

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/SqlDelightFileIndex.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/SqlDelightFileIndex.kt
@@ -82,5 +82,10 @@ interface SqlDelightFileIndex {
     fun sanitizeDirectoryName(name: String): String {
       return name.filter { it.isLetterOrDigit() }
     }
+
+    fun applyPackagePrefix(packagePrefix: String, packageName: String): String {
+      val prefix = packagePrefix.removeSuffix(".") + "."
+      return prefix + packageName.removePrefix(prefix)
+    }
   }
 }

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/FileIndex.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/FileIndex.kt
@@ -50,7 +50,7 @@ class FileIndex(
     val filePath = original.virtualFile!!.path
     val startIndex = folderPath.length + 1
     try {
-      return filePath.substring(startIndex, filePath.indexOf(original.name, startIndex) - 1).replace('/', '.')
+      return SqlDelightFileIndex.applyPackagePrefix(packageName, filePath.substring(startIndex, filePath.indexOf(original.name, startIndex) - 1).replace('/', '.'))
     } catch (e: StringIndexOutOfBoundsException) {
       throw IllegalStateException("Error finding package name of $filePath in $folderPath", e)
     }


### PR DESCRIPTION
This PR will try to apply prefix defined in Gradle configuration as `packageName` if not contained in directory structure of the `sqldelight` sources.

It is done to be able to omit the common package prefix in directory structure for better code navigation and to comply with kotlin standard code style mindset.

See #3587 and [Kotlin's coding convention about directory structure](https://kotlinlang.org/docs/coding-conventions.html#directory-structure)

I wasn't able to run this project locally, so it is only draft. 