### PR TITLE
Bump intellij to 221.6008.13

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -28,11 +28,11 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3.9.0
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
       - name: Setup gradle
         uses: gradle/gradle-build-action@v2
         with:
@@ -69,6 +69,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
+          arch: x86_64
           script: ./gradlew connectedCheck :sqldelight-gradle-plugin:build --stacktrace -PInstrumentation
 
       - name: Run ios tests

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -23,11 +23,11 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3.9.0
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
       - name: Setup gradle
         uses: gradle/gradle-build-action@v2
 

--- a/adapters/primitive-adapters/build.gradle
+++ b/adapters/primitive-adapters/build.gradle
@@ -1,7 +1,15 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
   id("app.cash.sqldelight.multiplatform")
+}
+
+tasks.withType(KotlinCompile).configureEach {
+  kotlinOptions {
+    jvmTarget = "1.8"
+  }
 }
 
 archivesBaseName = 'sqldelight-primitive-adapters'

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 buildscript {
   dependencies {
     classpath("com.squareup.okhttp3:okhttp") {
@@ -43,6 +45,8 @@ allprojects {
     google()
     maven { url 'https://www.jetbrains.com/intellij-repository/releases' }
     maven { url "https://cache-redirector.jetbrains.com/intellij-dependencies" }
+    maven { url "https://maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-ide-plugin-dependencies/" }
+    maven { url "https://maven.pkg.jetbrains.space/public/p/ktor/eap" }
   }
 
   tasks.withType(Test).configureEach {
@@ -55,6 +59,12 @@ allprojects {
   tasks.withType(JavaCompile).configureEach {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
+  }
+
+  tasks.withType(KotlinCompile).configureEach {
+    kotlinOptions {
+      jvmTarget = "11"
+    }
   }
 
   // Workaround for yarn concurrency issue - https://youtrack.jetbrains.com/issue/KT-43320
@@ -74,10 +84,17 @@ allprojects {
     dependsOn(tasks.withType(Sign))
   }
 
-  configurations.all {
+  configurations.configureEach {
     exclude group: 'com.jetbrains.rd'
     exclude group: 'com.github.jetbrains', module: 'jetCheck'
     exclude group: 'org.roaringbitmap'
+    exclude group: "com.jetbrains.infra"
+    exclude group: "org.jetbrains.teamcity"
+    exclude group: "org.roaringbitmap"
+    exclude group: "ai.grazie.spell"
+    exclude group: "ai.grazie.model"
+    exclude group: "ai.grazie.utils"
+    exclude group: "ai.grazie.nlp"
   }
 
   group = GROUP

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,10 @@ allprojects {
     google()
     maven { url 'https://www.jetbrains.com/intellij-repository/releases' }
     maven { url "https://cache-redirector.jetbrains.com/intellij-dependencies" }
+    // Repo for the backported Android IntelliJ Plugin by Jetbrains used in Ultimate
     maven { url "https://maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-ide-plugin-dependencies/" }
+    // Repo for Ktor eap builds used by IntelliJ. Some builds use a eap version. 
+    // When a new version of Intellij switched to a stable Ktor version, this repo can be removed. 
     maven { url "https://maven.pkg.jetbrains.space/public/p/ktor/eap" }
   }
 

--- a/dialects/hsql/build.gradle
+++ b/dialects/hsql/build.gradle
@@ -14,11 +14,16 @@ dependencies {
 
   compileOnly libs.intellij.ideImpl
 
-  testImplementation libs.intellij.ideImpl
+  testImplementation(libs.intellij.ideImpl) {
+    exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-core"
+  }
+  testImplementation libs.kotlin.coroutines.core
   testImplementation libs.junit
   testImplementation libs.truth
   testImplementation project(':sqldelight-compiler:dialect')
-  testImplementation libs.sqlPsiTestFixtures
+  testImplementation(libs.sqlPsiTestFixtures) {
+    exclude group: "com.jetbrains.intellij.platform"
+  }
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/dialects/mysql/build.gradle
+++ b/dialects/mysql/build.gradle
@@ -20,11 +20,16 @@ dependencies {
   compileOnly libs.intellij.core.ui
   compileOnly libs.moshi
 
-  testImplementation libs.intellij.ideImpl
+  testImplementation(libs.intellij.ideImpl) {
+    exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-core"
+  }
+  testImplementation libs.kotlin.coroutines.core
   testImplementation libs.junit
   testImplementation libs.truth
   testImplementation project(':sqldelight-compiler:dialect')
-  testImplementation libs.sqlPsiTestFixtures
+  testImplementation(libs.sqlPsiTestFixtures) {
+    exclude group: "com.jetbrains.intellij.platform"
+  }
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/dialects/postgresql/build.gradle
+++ b/dialects/postgresql/build.gradle
@@ -20,11 +20,16 @@ dependencies {
   compileOnly libs.intellij.core.ui
   compileOnly libs.moshi
 
-  testImplementation libs.intellij.ideImpl
+  testImplementation(libs.intellij.ideImpl) {
+    exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-core"
+  }
+  testImplementation libs.kotlin.coroutines.core
   testImplementation libs.junit
   testImplementation libs.truth
   testImplementation project(':sqldelight-compiler:dialect')
-  testImplementation libs.sqlPsiTestFixtures
+  testImplementation(libs.sqlPsiTestFixtures) {
+    exclude group: "com.jetbrains.intellij.platform"
+  }
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/dialects/sqlite-3-18/build.gradle
+++ b/dialects/sqlite-3-18/build.gradle
@@ -14,11 +14,16 @@ dependencies {
   compileOnly libs.intellij.ideImpl
   compileOnly libs.intellij.core.ui
 
-  testImplementation libs.intellij.ideImpl
+  testImplementation(libs.intellij.ideImpl) {
+    exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-core"
+  }
+  testImplementation libs.kotlin.coroutines.core
   testImplementation libs.junit
   testImplementation libs.truth
   testImplementation project(':sqldelight-compiler:dialect')
-  testImplementation libs.sqlPsiTestFixtures
+  testImplementation(libs.sqlPsiTestFixtures) {
+    exclude group: "com.jetbrains.intellij.platform"
+  }
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/dialects/sqlite-3-24/build.gradle
+++ b/dialects/sqlite-3-24/build.gradle
@@ -13,11 +13,16 @@ dependencies {
 
   compileOnly libs.intellij.ideImpl
 
-  testImplementation libs.intellij.ideImpl
+  testImplementation(libs.intellij.ideImpl) {
+    exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-core"
+  }
+  testImplementation libs.kotlin.coroutines.core
   testImplementation libs.junit
   testImplementation libs.truth
   testImplementation project(':sqldelight-compiler:dialect')
-  testImplementation libs.sqlPsiTestFixtures
+  testImplementation(libs.sqlPsiTestFixtures) {
+    exclude group: "com.jetbrains.intellij.platform"
+  }
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/dialects/sqlite-3-25/build.gradle
+++ b/dialects/sqlite-3-25/build.gradle
@@ -13,11 +13,16 @@ dependencies {
 
   compileOnly libs.intellij.ideImpl
 
-  testImplementation libs.intellij.ideImpl
+  testImplementation(libs.intellij.ideImpl) {
+    exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-core"
+  }
+  testImplementation libs.kotlin.coroutines.core
   testImplementation libs.junit
   testImplementation libs.truth
   testImplementation project(':sqldelight-compiler:dialect')
-  testImplementation libs.sqlPsiTestFixtures
+  testImplementation(libs.sqlPsiTestFixtures) {
+    exclude group: "com.jetbrains.intellij.platform"
+  }
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/dialects/sqlite-3-30/build.gradle
+++ b/dialects/sqlite-3-30/build.gradle
@@ -13,11 +13,16 @@ dependencies {
 
   compileOnly libs.intellij.ideImpl
 
-  testImplementation libs.intellij.ideImpl
+  testImplementation(libs.intellij.ideImpl) {
+    exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-core"
+  }
+  testImplementation libs.kotlin.coroutines.core
   testImplementation libs.junit
   testImplementation libs.truth
   testImplementation project(':sqldelight-compiler:dialect')
-  testImplementation libs.sqlPsiTestFixtures
+  testImplementation(libs.sqlPsiTestFixtures) {
+    exclude group: "com.jetbrains.intellij.platform"
+  }
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/dialects/sqlite-3-33/build.gradle
+++ b/dialects/sqlite-3-33/build.gradle
@@ -13,11 +13,16 @@ dependencies {
 
   compileOnly libs.intellij.ideImpl
 
-  testImplementation libs.intellij.ideImpl
+  testImplementation(libs.intellij.ideImpl) {
+    exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-core"
+  }
+  testImplementation libs.kotlin.coroutines.core
   testImplementation libs.junit
   testImplementation libs.truth
   testImplementation project(':sqldelight-compiler:dialect')
-  testImplementation libs.sqlPsiTestFixtures
+  testImplementation(libs.sqlPsiTestFixtures) {
+    exclude group: "com.jetbrains.intellij.platform"
+  }
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/dialects/sqlite-3-35/build.gradle
+++ b/dialects/sqlite-3-35/build.gradle
@@ -13,11 +13,16 @@ dependencies {
 
   compileOnly libs.intellij.ideImpl
 
-  testImplementation libs.intellij.ideImpl
+  testImplementation(libs.intellij.ideImpl) {
+    exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-core"
+  }
+  testImplementation libs.kotlin.coroutines.core
   testImplementation libs.junit
   testImplementation libs.truth
   testImplementation project(':sqldelight-compiler:dialect')
-  testImplementation libs.sqlPsiTestFixtures
+  testImplementation(libs.sqlPsiTestFixtures) {
+    exclude group: "com.jetbrains.intellij.platform"
+  }
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/dialects/sqlite-3-38/build.gradle
+++ b/dialects/sqlite-3-38/build.gradle
@@ -13,11 +13,16 @@ dependencies {
 
   compileOnly libs.intellij.ideImpl
 
-  testImplementation libs.intellij.ideImpl
+  testImplementation(libs.intellij.ideImpl) {
+    exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-core"
+  }
+  testImplementation libs.kotlin.coroutines.core
   testImplementation libs.junit
   testImplementation libs.truth
   testImplementation project(':sqldelight-compiler:dialect')
-  testImplementation libs.sqlPsiTestFixtures
+  testImplementation(libs.sqlPsiTestFixtures) {
+    exclude group: "com.jetbrains.intellij.platform"
+  }
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/dialects/sqlite/json-module/build.gradle
+++ b/dialects/sqlite/json-module/build.gradle
@@ -15,11 +15,16 @@ dependencies {
   compileOnly libs.intellij.ideImpl
 
   testImplementation project(':dialects:sqlite-3-18')
-  testImplementation libs.intellij.ideImpl
+  testImplementation(libs.intellij.ideImpl) {
+    exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-core"
+  }
+  testImplementation libs.kotlin.coroutines.core
   testImplementation libs.junit
   testImplementation libs.truth
   testImplementation project(':sqldelight-compiler:dialect')
-  testImplementation libs.sqlPsiTestFixtures
+  testImplementation(libs.sqlPsiTestFixtures) {
+    exclude group: "com.jetbrains.intellij.platform"
+  }
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/drivers/android-driver/build.gradle
+++ b/drivers/android-driver/build.gradle
@@ -1,9 +1,18 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
   alias(libs.plugins.android.library)
   alias(libs.plugins.kotlin.android)
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
 }
+
+tasks.withType(KotlinCompile).configureEach {
+  kotlinOptions {
+    jvmTarget = "1.8"
+  }
+}
+
 archivesBaseName = 'sqldelight-android-driver'
 
 android {

--- a/drivers/jdbc-driver/build.gradle
+++ b/drivers/jdbc-driver/build.gradle
@@ -1,7 +1,15 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
+}
+
+tasks.withType(KotlinCompile).configureEach {
+  kotlinOptions {
+    jvmTarget = "1.8"
+  }
 }
 
 archivesBaseName = 'sqldelight-jdbc-driver'

--- a/drivers/r2dbc-driver/build.gradle
+++ b/drivers/r2dbc-driver/build.gradle
@@ -1,7 +1,15 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
+}
+
+tasks.withType(KotlinCompile).configureEach {
+  kotlinOptions {
+    jvmTarget = "1.8"
+  }
 }
 
 archivesBaseName = 'sqldelight-r2dbc-driver'

--- a/drivers/sqlite-driver/build.gradle
+++ b/drivers/sqlite-driver/build.gradle
@@ -1,7 +1,15 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
+}
+
+tasks.withType(KotlinCompile).configureEach {
+  kotlinOptions {
+    jvmTarget = "1.8"
+  }
 }
 
 archivesBaseName = 'sqldelight-sqlite-driver'

--- a/extensions/androidx-paging3/build.gradle
+++ b/extensions/androidx-paging3/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
   alias(libs.plugins.publish)
@@ -5,6 +7,12 @@ plugins {
 }
 
 archivesBaseName = 'sqldelight-androidx-paging3'
+
+tasks.withType(KotlinCompile).configureEach {
+  kotlinOptions {
+    jvmTarget = "1.8"
+  }
+}
 
 kotlin {
   ios()

--- a/extensions/async-extensions/build.gradle
+++ b/extensions/async-extensions/build.gradle
@@ -1,7 +1,15 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
   id("app.cash.sqldelight.multiplatform")
+}
+
+tasks.withType(KotlinCompile).configureEach {
+  kotlinOptions {
+    jvmTarget = "1.8"
+  }
 }
 
 archivesBaseName = 'sqldelight-async-extensions'

--- a/extensions/coroutines-extensions/build.gradle
+++ b/extensions/coroutines-extensions/build.gradle
@@ -1,7 +1,15 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
   id("app.cash.sqldelight.multiplatform")
+}
+
+tasks.withType(KotlinCompile).configureEach {
+  kotlinOptions {
+    jvmTarget = "1.8"
+  }
 }
 
 archivesBaseName = 'sqldelight-coroutines-extensions'

--- a/extensions/rxjava2-extensions/build.gradle
+++ b/extensions/rxjava2-extensions/build.gradle
@@ -1,7 +1,15 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
+}
+
+tasks.withType(KotlinCompile).configureEach {
+  kotlinOptions {
+    jvmTarget = "1.8"
+  }
 }
 
 archivesBaseName = 'sqldelight-rxjava2-extensions'

--- a/extensions/rxjava3-extensions/build.gradle
+++ b/extensions/rxjava3-extensions/build.gradle
@@ -1,7 +1,15 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
+}
+
+tasks.withType(KotlinCompile).configureEach {
+  kotlinOptions {
+    jvmTarget = "1.8"
+  }
 }
 
 archivesBaseName = 'sqldelight-rxjava3-extensions'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,6 +59,8 @@ intellij-android = { module = "com.jetbrains.intellij.android:android-adt-ui-mod
 intellij-projectModel = { module = "com.jetbrains.intellij.platform:project-model", version.ref = "idea" }
 intellij-projectModelImpl = { module = "com.jetbrains.intellij.platform:project-model-impl", version.ref = "idea" }
 
+jna = { module = "net.java.dev.jna:jna", version = "5.9.0" }
+
 sqlPsi = { module = "com.alecstrong.sql.psi:core", version.ref = "sqlPsi" }
 sqlPsiTestFixtures  = { module = "com.alecstrong.sql.psi:test-fixtures", version.ref = "sqlPsi" }
 robolectric = { module = "org.robolectric:robolectric", version = "4.9.2" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin = "1.8.0"
 dokka = "1.7.20"
 kotlinCoroutines = "1.6.4"
-idea = "211.7628.21" # Android Studio Bumblebee (see https://plugins.jetbrains.com/docs/intellij/android-studio-releases-list.html)
+idea = "221.6008.13" # Electric Eel (2022.1.1) RC 1 (see https://plugins.jetbrains.com/docs/intellij/android-studio-releases-list.html)
 androidxSqlite = "2.2.0"
 schemaCrawler = "16.19.2"
 stately = "1.2.3"
@@ -55,6 +55,7 @@ intellij-lang = { module = "com.jetbrains.intellij.platform:lang", version.ref =
 intellij-langImpl = { module = "com.jetbrains.intellij.platform:lang-impl", version.ref = "idea" }
 intellij-analysis = { module = "com.jetbrains.intellij.platform:analysis", version.ref = "idea" }
 intellij-analysisImpl = { module = "com.jetbrains.intellij.platform:analysis-impl", version.ref = "idea" }
+intellij-android = { module = "com.jetbrains.intellij.android:android-adt-ui-model", version.ref = "idea" }
 intellij-projectModel = { module = "com.jetbrains.intellij.platform:project-model", version.ref = "idea" }
 intellij-projectModelImpl = { module = "com.jetbrains.intellij.platform:project-model-impl", version.ref = "idea" }
 
@@ -91,8 +92,8 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-js = { id = "org.jetbrains.kotlin.js", version.ref = "kotlin" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
-intellij = { id = "org.jetbrains.intellij", version = "1.6.0" }
-grammarKitComposer = { id = "com.alecstrong.grammar.kit.composer", version = "0.1.10" }
+intellij = { id = "org.jetbrains.intellij", version = "1.11.0" }
+grammarKitComposer = { id = "com.alecstrong.grammar.kit.composer", version = "0.1.11" }
 publish = { id = "com.vanniktech.maven.publish", version = "0.20.0" }
 spotless = { id = "com.diffplug.spotless", version = "6.12.1" }
 changelog = { id = "org.jetbrains.changelog", version = "2.0.0" }

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
@@ -7,6 +9,12 @@ plugins {
 // https://youtrack.jetbrains.com/issue/KTIJ-14471
 sourceSets {
   main
+}
+
+tasks.withType(KotlinCompile).configureEach {
+  kotlinOptions {
+    jvmTarget = "1.8"
+  }
 }
 
 kotlin {

--- a/sqldelight-compiler/build.gradle
+++ b/sqldelight-compiler/build.gradle
@@ -35,7 +35,10 @@ dependencies {
 
   testImplementation libs.burst
   testImplementation libs.sqliteJdbc
-  testImplementation libs.intellij.testFramework
+  testImplementation (libs.intellij.testFramework) {
+    exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-core"
+  }
+  testImplementation libs.kotlin.coroutines.core
   testImplementation libs.kotlin.test.junit
   testImplementation libs.truth
   testImplementation project(':test-util')

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/SqlDelightEnvironment.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/SqlDelightEnvironment.kt
@@ -38,7 +38,6 @@ import com.alecstrong.sql.psi.core.psi.SqlStmt
 import com.intellij.core.CoreApplicationEnvironment
 import com.intellij.mock.MockModule
 import com.intellij.openapi.module.Module
-import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModuleExtension
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.FileTypeFileViewProviders
@@ -49,7 +48,6 @@ import com.intellij.psi.PsiErrorElement
 import com.intellij.psi.PsiFileSystemItem
 import com.intellij.psi.PsiManager
 import com.intellij.psi.util.PsiTreeUtil
-import org.picocontainer.MutablePicoContainer
 import java.io.File
 import java.util.StringTokenizer
 import kotlin.math.log10
@@ -73,15 +71,12 @@ class SqlDelightEnvironment(
     .map { it.folder },
 ) : SqlCoreEnvironment(sourceFolders, dependencyFolders),
   SqlDelightProjectService {
-  val project: Project = projectEnvironment.project
+  val project = projectEnvironment.project
   val module = MockModule(project, projectEnvironment.parentDisposable)
   private val moduleName = SqlDelightFileIndex.sanitizeDirectoryName(moduleName)
 
   init {
-    (project.picoContainer as MutablePicoContainer).registerComponentInstance(
-      SqlDelightProjectService::class.java.name,
-      this,
-    )
+    project.registerService(SqlDelightProjectService::class.java, this)
 
     CoreApplicationEnvironment.registerExtensionPoint(
       module.extensionArea,

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/SqlDelightProjectService.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/SqlDelightProjectService.kt
@@ -16,7 +16,6 @@
 package app.cash.sqldelight.core
 
 import app.cash.sqldelight.dialect.api.SqlDelightDialect
-import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
@@ -40,7 +39,7 @@ interface SqlDelightProjectService {
 
   companion object {
     fun getInstance(project: Project): SqlDelightProjectService {
-      return ServiceManager.getService(project, SqlDelightProjectService::class.java)!!
+      return project.getService(SqlDelightProjectService::class.java)!!
     }
   }
 }

--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -76,7 +76,7 @@ dependencies {
   implementation libs.kotlin.plugin
   compileOnly libs.android.plugin
 
-  implementation "net.java.dev.jna:jna:5.9.0"
+  implementation libs.jna
 
   testImplementation libs.junit
   testImplementation libs.truth

--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -76,9 +76,8 @@ dependencies {
   implementation libs.kotlin.plugin
   compileOnly libs.android.plugin
 
-  testImplementation libs.sqlPsi
-  testImplementation project(':sqlite-migrations')
-  testImplementation project(':sqldelight-compiler')
+  implementation "net.java.dev.jna:jna:5.9.0"
+
   testImplementation libs.junit
   testImplementation libs.truth
   testImplementation libs.testParameterInjector

--- a/sqldelight-idea-plugin/build.gradle
+++ b/sqldelight-idea-plugin/build.gradle
@@ -38,11 +38,9 @@ tasks.named('runIde') {
 
 tasks.named('runPluginVerifier') {
   ideVersions = [
-      "IC-2021.1.3",
-      "IC-2021.2.4",
-      "IC-2021.3.3",
-      "IC-2022.1.4",
-      "IC-2022.2.2",
+      "IC-2022.1.4", // AS: Electric Eel (2022.1.1) RC 1
+      "IC-2022.2.4", // IC
+      "IC-2022.3.1", // IC
   ]
 
   def customFailureLevel = FailureLevel.ALL
@@ -50,8 +48,9 @@ tasks.named('runPluginVerifier') {
   customFailureLevel.remove(FailureLevel.EXPERIMENTAL_API_USAGES)
   customFailureLevel.remove(FailureLevel.INTERNAL_API_USAGES)
   customFailureLevel.remove(FailureLevel.NOT_DYNAMIC)
+  customFailureLevel.remove(FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES)
 
-  setFailureLevel(customFailureLevel)
+  failureLevel = customFailureLevel
 }
 
 changelog {
@@ -96,6 +95,7 @@ dependencies {
   implementation libs.moshi
 
   testImplementation libs.truth
+  testImplementation libs.intellij.android
   testImplementation project(':dialects:sqlite-3-18')
 }
 

--- a/sqldelight-idea-plugin/gradle.properties
+++ b/sqldelight-idea-plugin/gradle.properties
@@ -2,3 +2,4 @@ POM_ARTIFACT_ID=idea-plugin
 POM_NAME=SQLDelight IDEA Plugin
 POM_DESCRIPTION=IDEA plugin for generating java interfaces for sqlite files
 POM_PACKAGING=jar
+kotlin.stdlib.default.dependency = false

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/FileIndex.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/FileIndex.kt
@@ -56,10 +56,10 @@ class FileIndex(
     }
   }
 
-  override fun outputDirectory(sqFile: SqlDelightFile): List<String> {
-    val file = sqFile.virtualFile ?: return emptyList()
+  override fun outputDirectory(file: SqlDelightFile): List<String> {
+    val vfile = file.virtualFile ?: return emptyList()
     val compilationUnits = properties.compilationUnits.filter { compilationUnit ->
-      compilationUnit.sourceFolders.any { it.folder.localVirtualFile()?.isAncestorOf(file) == true }
+      compilationUnit.sourceFolders.any { it.folder.localVirtualFile()?.isAncestorOf(vfile) == true }
     }
     return compilationUnits.map { it.outputDirectoryPath }.distinct()
   }

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/GradleSystemListener.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/GradleSystemListener.kt
@@ -6,7 +6,7 @@ import app.cash.sqldelight.intellij.notifications.FileIndexingNotification.Uncon
 import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskId
 import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskNotificationListenerAdapter
 import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskType.RESOLVE_PROJECT
-import org.jetbrains.kotlin.idea.framework.GRADLE_SYSTEM_ID
+import org.jetbrains.kotlin.idea.configuration.GRADLE_SYSTEM_ID
 
 class GradleSystemListener : ExternalSystemTaskNotificationListenerAdapter() {
   override fun onStart(

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/SqlDelightGotoDeclarationHandler.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/SqlDelightGotoDeclarationHandler.kt
@@ -39,6 +39,7 @@ import com.intellij.psi.PsiReference
 import com.intellij.psi.search.FileTypeIndex
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
+import com.intellij.psi.util.childrenOfType
 import org.jetbrains.kotlin.idea.references.KtSimpleNameReference
 import org.jetbrains.kotlin.idea.util.projectStructure.getModule
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
@@ -49,7 +50,6 @@ import org.jetbrains.kotlin.psi.psiUtil.getChildOfType
 import org.jetbrains.kotlin.psi.psiUtil.getNextSiblingIgnoringWhitespaceAndComments
 import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstance
-import org.jetbrains.plugins.groovy.lang.psi.util.childrenOfType
 
 class SqlDelightGotoDeclarationHandler : GotoDeclarationHandler {
   override fun getGotoDeclarationTargets(

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/notifications/FileIndexingNotification.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/notifications/FileIndexingNotification.kt
@@ -13,8 +13,8 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.ui.EditorNotificationPanel
+import com.intellij.ui.EditorNotificationProvider
 import com.intellij.ui.EditorNotifications
-import com.intellij.ui.EditorNotificationsImpl
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstance
 import java.awt.Color
 
@@ -59,7 +59,7 @@ class FileIndexingNotification(
 
   companion object {
     fun getInstance(project: Project): FileIndexingNotification {
-      return DumbService.getDumbAwareExtensions(project, EditorNotificationsImpl.EP_PROJECT).firstIsInstance()
+      return DumbService.getDumbAwareExtensions(project, EditorNotificationProvider.EP_NAME).firstIsInstance()
     }
   }
 

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/run/window/ConnectionListPanel.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/run/window/ConnectionListPanel.kt
@@ -11,7 +11,6 @@ import com.intellij.ui.AnActionButton
 import com.intellij.ui.CollectionListModel
 import com.intellij.ui.ToolbarDecorator
 import com.intellij.ui.components.JBList
-import org.jetbrains.kotlin.utils.addToStdlib.firstNotNullResult
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
 import java.awt.event.MouseAdapter
@@ -115,7 +114,7 @@ internal class ConnectionListPanel(
   }
 
   private fun JComponent.connectionPanel(): ConnectionListPanel? {
-    return components.firstNotNullResult {
+    return components.firstNotNullOfOrNull {
       when (it) {
         is ConnectionListPanel -> it
         is JComponent -> it.connectionPanel()

--- a/sqldelight-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/sqldelight-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -3,7 +3,7 @@
   <name>SQLDelight</name>
   <category>Custom Languages</category>
   <vendor url="https://github.com/square">Square, Inc.</vendor>
-  <idea-version since-build="211"/>
+  <idea-version since-build="221"/>
   <depends>com.intellij.modules.lang</depends>
   <depends>com.intellij.java</depends>
   <depends>org.jetbrains.kotlin</depends>

--- a/sqldelight-idea-plugin/src/test/kotlin/app/cash/sqldelight/intellij/ReferenceContrubutorTest.kt
+++ b/sqldelight-idea-plugin/src/test/kotlin/app/cash/sqldelight/intellij/ReferenceContrubutorTest.kt
@@ -2,9 +2,9 @@ package app.cash.sqldelight.intellij
 
 import app.cash.sqldelight.core.lang.SqlDelightFileType
 import com.google.common.truth.Truth.assertThat
+import com.intellij.psi.util.childrenOfType
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtTypeAlias
-import org.jetbrains.plugins.groovy.lang.psi.util.childrenOfType
 
 class ReferenceContrubutorTest : SqlDelightFixtureTestCase() {
 

--- a/sqldelight-idea-plugin/src/test/kotlin/app/cash/sqldelight/intellij/SqlDelightProjectTestCase.kt
+++ b/sqldelight-idea-plugin/src/test/kotlin/app/cash/sqldelight/intellij/SqlDelightProjectTestCase.kt
@@ -22,11 +22,14 @@ import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
 import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
 import java.io.File
 import java.io.PrintStream
+import kotlin.io.path.absolutePathString
 
 abstract class SqlDelightProjectTestCase : LightJavaCodeInsightFixtureTestCase() {
   protected val tempRoot: VirtualFile
     get() = module.rootManager.contentRoots.single()
   override fun setUp() {
+    val tmp = java.nio.file.Files.createTempDirectory("ideaHack")
+    System.setProperty("idea.home.path", tmp.absolutePathString())
     super.setUp()
     SqliteDialect().setup()
     SqldelightParserUtil.overrideSqlParser()

--- a/test-util/build.gradle
+++ b/test-util/build.gradle
@@ -7,6 +7,9 @@ dependencies {
   api project(':dialects:sqlite-3-18')
 
   implementation libs.sqlPsi
-  implementation libs.intellij.testFramework
+  implementation(libs.intellij.testFramework) {
+    exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-core"
+  }
+  implementation libs.kotlin.coroutines.core
   implementation libs.junit
 }


### PR DESCRIPTION
To build sqlDelight JDK 17 is needed, reason GrammarKit.
To use the sqldelight gradle plugin (including compiler and dialects), users need to use JDK 11, reason IntelliJ. 

The runtime (including adapters and extensions) uses JDK 1.8 (previously 1.6), aligned with Kotlin 1.8, now.