### PR TITLE
Remove afterEvaluate with Kotlin only projects

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/GenerateMigrationOutputTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/GenerateMigrationOutputTask.kt
@@ -32,15 +32,19 @@ abstract class GenerateMigrationOutputTask : SqlDelightWorkerTask() {
   val pluginVersion = VERSION
 
   @get:OutputDirectory
-  var outputDirectory: File? = null
+  abstract val outputDirectory: DirectoryProperty
 
-  @get:Input abstract val projectName: Property<String>
+  @get:Input 
+  abstract val projectName: Property<String>
 
-  @get:Nested abstract var properties: SqlDelightDatabasePropertiesImpl
+  @get:Nested 
+  abstract val properties: Property<SqlDelightDatabasePropertiesImpl>
 
-  @get:Nested abstract var compilationUnit: SqlDelightCompilationUnitImpl
+  @get:Nested 
+  abstract val compilationUnit: Property<SqlDelightCompilationUnitImpl>
 
-  @get:Input abstract var migrationOutputExtension: String
+  @get:Input 
+  abstract val migrationOutputExtension: Property<String>
 
   @TaskAction
   fun generateSchemaFile() {

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/GenerateSchemaTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/GenerateSchemaTask.kt
@@ -36,15 +36,23 @@ abstract class GenerateSchemaTask : SqlDelightWorkerTask() {
   val pluginVersion = VERSION
 
   @get:OutputDirectory
-  var outputDirectory: File? = null
+  abstract val outputDirectory: DirectoryProperty
 
-  @get:Input abstract val projectName: Property<String>
+  @get:Input 
+  abstract val projectName: Property<String>
 
-  @get:Nested abstract var properties: SqlDelightDatabasePropertiesImpl
+  @get:Nested 
+  abstract val properties: Property<SqlDelightDatabasePropertiesImpl>
 
-  @get:Nested abstract var compilationUnit: SqlDelightCompilationUnitImpl
+  @get:Nested
+  abstract val compilationUnit: Property<SqlDelightCompilationUnitImpl>
 
-  @Input var verifyMigrations: Boolean = false
+  @get:Input
+  abstract val verifyMigrations: Property<Boolean>
+
+  init {
+    verifyMigrations.convention(false)
+  }
 
   @TaskAction
   fun generateSchemaFile() {

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightTask.kt
@@ -41,7 +41,6 @@ import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
-import java.io.File
 import java.util.ServiceLoader
 
 @CacheableTask
@@ -52,15 +51,22 @@ abstract class SqlDelightTask : SqlDelightWorkerTask() {
   val pluginVersion = VERSION
 
   @get:OutputDirectory
-  var outputDirectory: File? = null
+  abstract val outputDirectory: DirectoryProperty
 
   @get:Input abstract val projectName: Property<String>
 
-  @get:Nested abstract var properties: SqlDelightDatabasePropertiesImpl
+  @get:Nested
+  abstract val properties: Property<SqlDelightDatabasePropertiesImpl>
 
-  @get:Nested abstract var compilationUnit: SqlDelightCompilationUnitImpl
+  @get:Nested 
+  abstract val compilationUnit: Property<SqlDelightCompilationUnitImpl>
 
-  @Input var verifyMigrations: Boolean = false
+  @get:Input
+  abstract val verifyMigrations: Property<Boolean>
+  
+  init {
+    verifyMigrations.convention(false)
+  }
 
   @TaskAction
   fun generateSqlDelightFiles() {

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightWorkerTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightWorkerTask.kt
@@ -1,5 +1,6 @@
 package app.cash.sqldelight.gradle
 
+import org.gradle.api.Named
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
@@ -13,7 +14,7 @@ import javax.inject.Inject
  * in tasks
  */
 @CacheableTask
-abstract class SqlDelightWorkerTask : SourceTask() {
+abstract class SqlDelightWorkerTask : SourceTask(), Named {
 
   @get:Inject
   internal abstract val workerExecutor: WorkerExecutor

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/VerifyMigrationTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/VerifyMigrationTask.kt
@@ -38,18 +38,29 @@ abstract class VerifyMigrationTask : SqlDelightWorkerTask() {
   @Input
   val pluginVersion = VERSION
 
-  @get:Input abstract val projectName: Property<String>
+  @get:Input 
+  abstract val projectName: Property<String>
 
   /** Directory where the database files are copied for the migration scripts to run against. */
-  @get:Internal abstract var workingDirectory: File
+  @get:Internal 
+  abstract val workingDirectory: DirectoryProperty
 
-  @get:Nested abstract var properties: SqlDelightDatabasePropertiesImpl
+  @get:Nested 
+  abstract val properties: Property<SqlDelightDatabasePropertiesImpl>
 
-  @get:Nested abstract var compilationUnit: SqlDelightCompilationUnitImpl
+  @get:Nested 
+  abstract val compilationUnit: Property<SqlDelightCompilationUnitImpl>
 
-  @Input var verifyMigrations: Boolean = false
+  @get:Input 
+  abstract val verifyMigrations: Property<Boolean>
 
-  @Input var verifyDefinitions: Boolean = true
+  @get:Input 
+  abstract val verifyDefinitions: Property<Boolean>
+  
+  init {
+    verifyMigrations.convention(false)
+    verifyDefinitions.convention(true)
+  }
 
   /* Tasks without an output are never considered UP-TO-DATE by Gradle. Adding an output file that's created when the
    * task completes successfully works around the lack of an output for this task. There may be a better solution once

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/android/PackageName.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/android/PackageName.kt
@@ -4,6 +4,7 @@ import app.cash.sqldelight.VERSION
 import com.android.build.gradle.BaseExtension
 import org.gradle.api.GradleException
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Dependency
 
 internal fun Project.packageName(): String {
   val androidExtension = extensions.getByType(BaseExtension::class.java)
@@ -26,10 +27,11 @@ internal fun Project.packageName(): String {
   )
 }
 
-internal fun Project.sqliteVersion(): String? {
+internal fun Project.sqliteVersion(): Dependency? {
   val androidExtension = extensions.getByType(BaseExtension::class.java)
   val minSdk = androidExtension.defaultConfig.minSdk ?: return null
-  if (minSdk >= 31) return "app.cash.sqldelight:sqlite-3-30-dialect:$VERSION"
-  if (minSdk >= 30) return "app.cash.sqldelight:sqlite-3-25-dialect:$VERSION"
-  return "app.cash.sqldelight:sqlite-3-18-dialect:$VERSION"
+  return dependencies.create(
+    if (minSdk >= 31) "app.cash.sqldelight:sqlite-3-30-dialect:$VERSION" else if (minSdk >= 30) "app.cash.sqldelight:sqlite-3-25-dialect:$VERSION"
+    else "app.cash.sqldelight:sqlite-3-18-dialect:$VERSION",
+  )
 }

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/gradleUtil.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/gradleUtil.kt
@@ -1,0 +1,33 @@
+package app.cash.sqldelight.gradle
+
+import org.gradle.api.*
+import org.gradle.api.model.*
+import org.gradle.api.provider.*
+
+internal fun <T> NamedDomainObjectContainer<T>.maybeRegister(
+    name: String,
+    configure: Action<T>,
+): NamedDomainObjectProvider<T> = if (name in names) {
+    named(name, configure)
+} else register(name, configure)
+
+internal fun <T> NamedDomainObjectContainer<T>.elements(
+    providerFactory: ProviderFactory,
+): Provider<Set<T>> = providerFactory.provider {
+    this
+}
+
+internal inline fun <reified T> Provider<Collection<T>>.resolveRecursive(
+    providerFactory: ObjectFactory,
+    crossinline getChildren: T.() -> Provider<Collection<T>>,
+    onError: T.() -> Nothing
+): Provider<Collection<T>> {
+    val s: Provider<Collection<T>> = map { items ->
+        val provider = providerFactory.domainObjectSet(T::class.java)
+        for (item in items) { 
+            provider.addAllLater(item.getChildren())
+        }
+        provider
+    }
+    return s
+}

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/kotlin/LinkSqlite.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/kotlin/LinkSqlite.kt
@@ -1,15 +1,22 @@
 package app.cash.sqldelight.gradle.kotlin
 
 import org.gradle.api.Project
+import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
-fun Project.linkSqlite() {
-  val extension = project.extensions.findByType(KotlinMultiplatformExtension::class.java) ?: return
-  extension.targets
-    .filterIsInstance<KotlinNativeTarget>()
-    .flatMap { it.binaries }
-    .forEach { compilationUnit ->
-      compilationUnit.linkerOpts("-lsqlite3")
+fun Project.linkSqlite(linkSqlite: Provider<Boolean>) {
+  // https://youtrack.jetbrains.com/issue/KT-30081/Gradle-MPP-NativeBinary.linkerOpts-improvements
+  afterEvaluate {
+    if (linkSqlite.getOrElse(true)) {
+      val extension = project.extensions.findByType(KotlinMultiplatformExtension::class.java) 
+        ?: return@afterEvaluate
+      extension.targets
+        .filterIsInstance<KotlinNativeTarget>()
+        .flatMap { it.binaries }
+        .forEach { compilationUnit ->
+          compilationUnit.linkerOpts("-lsqlite3")
+        }
     }
+  }
 }

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/squash/MigrationSquashTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/squash/MigrationSquashTask.kt
@@ -34,11 +34,14 @@ abstract class MigrationSquashTask : SqlDelightWorkerTask() {
   @Input
   val pluginVersion = VERSION
 
-  @Input val projectName: Property<String> = project.objects.property(String::class.java)
+  @get:Input
+  abstract val projectName: Property<String>
 
-  @Nested lateinit var properties: SqlDelightDatabasePropertiesImpl
+  @get:Nested 
+  abstract val properties: Property<SqlDelightDatabasePropertiesImpl>
 
-  @Nested lateinit var compilationUnit: SqlDelightCompilationUnitImpl
+  @get:Nested
+  abstract val compilationUnit: Property<SqlDelightCompilationUnitImpl>
 
   @TaskAction
   fun generateSquashedMigrationFile() {


### PR DESCRIPTION
This change is now lazy, so some warnings `No databases were added` or `A dialect is needed for SQLDelight.` are now removed.