### PR TITLE
R2DB2 Driver: Expose the connection

### DIFF
--- a/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
+++ b/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.reactive.awaitSingle
 
-class R2dbcDriver(private val connection: Connection) : SqlDriver {
+class R2dbcDriver(public val connection: Connection) : SqlDriver {
   override fun <R> executeQuery(
     identifier: Int?,
     sql: String,

--- a/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
+++ b/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.reactive.awaitSingle
 
-class R2dbcDriver(public val connection: Connection) : SqlDriver {
+class R2dbcDriver(val connection: Connection) : SqlDriver {
   override fun <R> executeQuery(
     identifier: Int?,
     sql: String,

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql-async/src/test/kotlin/app/cash/sqldelight/postgresql/integration/async/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql-async/src/test/kotlin/app/cash/sqldelight/postgresql/integration/async/PostgreSqlTest.kt
@@ -40,6 +40,12 @@ class PostgreSqlTest {
       )
   }
 
+  @Test fun getConnection() = kotlinx.coroutines.test.runTest {
+    val connection = factory.create().awaitSingle()
+    val driver = R2dbcDriver(connection)
+    assertEquals(driver.connection, connection)
+  }
+
   @Test fun booleanSelect() = runTest { database ->
     database.dogQueries.insertDog("Tilda", "Pomeranian")
     assertThat(database.dogQueries.selectGoodDogs(true).awaitAsOne())

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql-async/src/test/kotlin/app/cash/sqldelight/postgresql/integration/async/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql-async/src/test/kotlin/app/cash/sqldelight/postgresql/integration/async/PostgreSqlTest.kt
@@ -43,7 +43,7 @@ class PostgreSqlTest {
   @Test fun getConnection() = kotlinx.coroutines.test.runTest {
     val connection = factory.create().awaitSingle()
     val driver = R2dbcDriver(connection)
-    assertEquals(driver.connection, connection)
+    assertThat(driver.connection).isEqualTo(connection)
   }
 
   @Test fun booleanSelect() = runTest { database ->


### PR DESCRIPTION
The JDBC driver exposes the connection, so the r2dbc driver should do this too.
Use-case: Use the copy api from postgres: https://github.com/pgjdbc/r2dbc-postgresql/blob/87a058ec52006e83746ecb07e85b82b972b35402/src/main/java/io/r2dbc/postgresql/PostgresqlConnection.java#L230


To compare:
https://github.com/cashapp/sqldelight/blob/master/drivers/jdbc-driver/src/main/kotlin/app/cash/sqldelight/driver/jdbc/JdbcDriver.kt