### PR TITLE
Configure Renovate to ignore compiled pip dependencies

### DIFF
--- a/.github/workflows/Publish-Website.yml
+++ b/.github/workflows/Publish-Website.yml
@@ -33,7 +33,7 @@ jobs:
           distribution: 'zulu'
           java-version: 17
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: 3.11 # See the pinned version in renovate.json too

--- a/.github/workflows/Publish-Website.yml
+++ b/.github/workflows/Publish-Website.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.11 # See the pinned version in renovate.json too
 
       - name: Get Docs Version
         run: cat gradle.properties | grep --color=never VERSION_NAME >> $GITHUB_OUTPUT

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,9 @@
   "extends": [
     "config:base"
   ],
+  "constraints": {
+      "python": "3.11"
+  },
   "ignoreDeps": [ "com.jetbrains.intellij.platform", "com.jetbrains.intellij.java", "com.jetbrains.intellij.platform:analysis",
                   "com.jetbrains.intellij.platform:test-framework", "com.jetbrains.intellij.platform:lang-impl",
                   "com.jetbrains.intellij.platform:core-ui", "com.jetbrains.intellij.platform:core-impl",

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,12 @@
                   "com.jetbrains.intellij.platform:test-framework", "com.jetbrains.intellij.platform:lang-impl",
                   "com.jetbrains.intellij.platform:core-ui", "com.jetbrains.intellij.platform:core-impl",
                   "com.jetbrains.intellij.java:java-psi" ],
-    "pip-compile": {
-        "fileMatch": [".github/workflows/requirements.in"]
-    }
+  "ignorePaths": [
+    ".github/workflows/requirements.txt"
+  ],
+  "pip-compile": {
+    "fileMatch": [
+      ".github/workflows/requirements.in"
+    ]
+  }
 }


### PR DESCRIPTION
Follow-up for #3793 to prevent Renovate from updating the compiled requirements (`pip-compile` output) independently. (Sorry again. I should've caught this initially.)