### PR TITLE
Support R2DBC 1.0

### DIFF
--- a/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
+++ b/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
@@ -48,7 +48,7 @@ class R2dbcDriver(private val connection: Connection) : SqlDriver {
 
     return QueryResult.AsyncValue {
       val result = prepared.execute().awaitSingle()
-      return@AsyncValue result.rowsUpdated.awaitFirstOrNull()?.toLong() ?: 0
+      return@AsyncValue result.rowsUpdated.awaitFirstOrNull() ?: 0L
     }
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -83,7 +83,7 @@ testhelp = { module = "co.touchlab:testhelp", version.ref = "testhelp" }
 burst = { module = "com.squareup.burst:burst-junit4", version = "1.2.0" }
 testParameterInjector = { module = "com.google.testparameterinjector:test-parameter-injector", version = "1.10" }
 
-r2dbc = { module = "io.r2dbc:r2dbc-spi", version = "0.9.1.RELEASE" }
+r2dbc = { module = "io.r2dbc:r2dbc-spi", version = "1.0.0.RELEASE" }
 
 [plugins]
 android-library = { id = "com.android.library", version.ref = "agp" }

--- a/sqldelight-gradle-plugin/src/test/integration-mysql-async/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-mysql-async/build.gradle
@@ -26,7 +26,7 @@ dependencies {
   implementation libs.mysqlJdbc
   implementation "org.testcontainers:mysql:1.16.2"
   implementation "org.testcontainers:r2dbc:1.16.2"
-  implementation "dev.miku:r2dbc-mysql:0.8.2.RELEASE"
+  implementation "org.mariadb:r2dbc-mariadb:1.1.3"
   implementation "app.cash.sqldelight:r2dbc-driver:${app.cash.sqldelight.VersionKt.VERSION}"
   implementation "app.cash.sqldelight:async-extensions:${app.cash.sqldelight.VersionKt.VERSION}"
   implementation libs.truth

--- a/sqldelight-gradle-plugin/src/test/integration-mysql-async/src/test/kotlin/app/cash/sqldelight/mysql/integration/async/MySqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-mysql-async/src/test/kotlin/app/cash/sqldelight/mysql/integration/async/MySqlTest.kt
@@ -8,16 +8,26 @@ import com.google.common.truth.Truth.assertThat
 import io.r2dbc.spi.ConnectionFactories
 import kotlinx.coroutines.reactive.awaitSingle
 import org.junit.Test
+import org.testcontainers.containers.MySQLContainer
 
 class MySqlTest {
-  private val factory = ConnectionFactories.get("r2dbc:tc:mysql:///myDb?TC_IMAGE_TAG=8.0")
-
   private fun runTest(block: suspend (MyDatabase) -> Unit) = kotlinx.coroutines.test.runTest {
-    val connection = factory.create().awaitSingle()
-    val driver = R2dbcDriver(connection)
+    MySQLContainer("mysql:8.0").use { mySqlJdbcContainer ->
+      mySqlJdbcContainer.start()
+      println(mySqlJdbcContainer.jdbcUrl)
+      val factory = with(mySqlJdbcContainer) {
+        val mariaDBUrl =
+          "r2dbc:mariadb://$username:$password@$host:$firstMappedPort/$databaseName?sslMode=TRUST&tinyInt1isBit=false"
+        println(mariaDBUrl)
+        ConnectionFactories.get(mariaDBUrl)
+      }
 
-    val db = MyDatabase(driver).also { MyDatabase.Schema.awaitCreate(driver) }
-    block(db)
+      val connection = factory.create().awaitSingle()
+      val driver = R2dbcDriver(connection)
+
+      val db = MyDatabase(driver).also { MyDatabase.Schema.awaitCreate(driver) }
+      block(db)
+    }
   }
 
   @Test fun simpleSelect() = runTest { database ->

--- a/sqldelight-gradle-plugin/src/test/integration-mysql-async/src/test/kotlin/app/cash/sqldelight/mysql/integration/async/MySqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-mysql-async/src/test/kotlin/app/cash/sqldelight/mysql/integration/async/MySqlTest.kt
@@ -14,11 +14,9 @@ class MySqlTest {
   private fun runTest(block: suspend (MyDatabase) -> Unit) = kotlinx.coroutines.test.runTest {
     MySQLContainer("mysql:8.0").use { mySqlJdbcContainer ->
       mySqlJdbcContainer.start()
-      println(mySqlJdbcContainer.jdbcUrl)
       val factory = with(mySqlJdbcContainer) {
         val mariaDBUrl =
           "r2dbc:mariadb://$username:$password@$host:$firstMappedPort/$databaseName?sslMode=TRUST&tinyInt1isBit=false"
-        println(mariaDBUrl)
         ConnectionFactories.get(mariaDBUrl)
       }
 

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql-async/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql-async/build.gradle
@@ -26,7 +26,7 @@ dependencies {
   implementation libs.postgresJdbc
   implementation "org.testcontainers:postgresql:1.16.2"
   implementation "org.testcontainers:r2dbc:1.16.2"
-  implementation "org.postgresql:r2dbc-postgresql:0.9.2.RELEASE"
+  implementation "org.postgresql:r2dbc-postgresql:1.0.0.RELEASE"
   implementation "app.cash.sqldelight:r2dbc-driver:${app.cash.sqldelight.VersionKt.VERSION}"
   implementation "app.cash.sqldelight:async-extensions:${app.cash.sqldelight.VersionKt.VERSION}"
   implementation libs.truth


### PR DESCRIPTION
I replaced the MySQL driver with the [MariaDB driver](https://github.com/mariadb-corporation/mariadb-connector-r2dbc), because the development of the MySQL one looks stopped: https://github.com/mirromutth/r2dbc-mysql
