### PR TITLE
Use a PEP440 compliant Python version constraint for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
     "config:base"
   ],
   "constraints": {
-      "python": "3.11"
+    "python": "==3.11"
   },
   "ignoreDeps": [ "com.jetbrains.intellij.platform", "com.jetbrains.intellij.java", "com.jetbrains.intellij.platform:analysis",
                   "com.jetbrains.intellij.platform:test-framework", "com.jetbrains.intellij.platform:lang-impl",


### PR DESCRIPTION
Fixes a slight configuration error introduced in e2a9d627b8a74bc227340ae4600d67e2368d8341. Renovate does not validate the constraint and, thus, deems the configuration valid. However, this leads to failure further down the road for some dependency updates (see #3816).

(I suggested a potential documentation fix upstream https://github.com/renovatebot/renovate/pull/19855 to stop others from running into this.)