### PR TITLE
R2DBC: Fix primitive null values in bindStatement

### DIFF
--- a/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
+++ b/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
@@ -99,6 +99,7 @@ class R2dbcDriver(val connection: Connection) : SqlDriver {
   }
 }
 
+// R2DBC uses boxed Java classes instead primitives: https://r2dbc.io/spec/1.0.0.RELEASE/spec/html/#datatypes
 class R2dbcPreparedStatement(private val statement: Statement) : SqlPreparedStatement {
   override fun bindBytes(index: Int, bytes: ByteArray?) {
     if (bytes == null) {
@@ -110,7 +111,7 @@ class R2dbcPreparedStatement(private val statement: Statement) : SqlPreparedStat
 
   override fun bindLong(index: Int, long: Long?) {
     if (long == null) {
-      statement.bindNull(index, Long::class.java)
+      statement.bindNull(index, java.lang.Long::class.java)
     } else {
       statement.bind(index, long)
     }
@@ -118,7 +119,7 @@ class R2dbcPreparedStatement(private val statement: Statement) : SqlPreparedStat
 
   override fun bindDouble(index: Int, double: Double?) {
     if (double == null) {
-      statement.bindNull(index, Double::class.java)
+      statement.bindNull(index, java.lang.Double::class.java)
     } else {
       statement.bind(index, double)
     }
@@ -134,7 +135,7 @@ class R2dbcPreparedStatement(private val statement: Statement) : SqlPreparedStat
 
   override fun bindBoolean(index: Int, boolean: Boolean?) {
     if (boolean == null) {
-      statement.bindNull(index, Boolean::class.java)
+      statement.bindNull(index, java.lang.Boolean::class.java)
     } else {
       statement.bind(index, boolean)
     }

--- a/sqldelight-gradle-plugin/src/test/integration-mysql-async/src/main/sqldelight/app/cash/sqldelight/mysql/integration/async/Dog.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-mysql-async/src/main/sqldelight/app/cash/sqldelight/mysql/integration/async/Dog.sq
@@ -1,12 +1,13 @@
 CREATE TABLE dog (
   name VARCHAR(8) NOT NULL,
   breed TEXT NOT NULL,
-  is_good BOOLEAN NOT NULL DEFAULT 1
+  is_good BOOLEAN NOT NULL DEFAULT 1,
+  age INTEGER
 );
 
 insertDog:
 INSERT INTO dog
-VALUES (?, ?, DEFAULT);
+VALUES (?, ?, DEFAULT, ?);
 
 selectDogs:
 SELECT *

--- a/sqldelight-gradle-plugin/src/test/integration-mysql-async/src/test/kotlin/app/cash/sqldelight/mysql/integration/async/MySqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-mysql-async/src/test/kotlin/app/cash/sqldelight/mysql/integration/async/MySqlTest.kt
@@ -28,14 +28,15 @@ class MySqlTest {
     }
   }
 
-  @Test fun simpleSelect() = runTest { database ->
-    database.dogQueries.insertDog("Tilda", "Pomeranian")
+  @Test fun simpleSelectWithNullPrimitive() = runTest { database ->
+    database.dogQueries.insertDog("Tilda", "Pomeranian", null)
     assertThat(database.dogQueries.selectDogs().awaitAsOne())
       .isEqualTo(
         Dog(
           name = "Tilda",
           breed = "Pomeranian",
           is_good = true,
+          age = null,
         ),
       )
   }
@@ -43,10 +44,10 @@ class MySqlTest {
   @Test
   fun simpleSelectWithIn() = runTest { database ->
     with(database) {
-      dogQueries.insertDog("Tilda", "Pomeranian")
-      dogQueries.insertDog("Tucker", "Portuguese Water Dog")
-      dogQueries.insertDog("Cujo", "Pomeranian")
-      dogQueries.insertDog("Buddy", "Pomeranian")
+      dogQueries.insertDog("Tilda", "Pomeranian", null)
+      dogQueries.insertDog("Tucker", "Portuguese Water Dog", null)
+      dogQueries.insertDog("Cujo", "Pomeranian", null)
+      dogQueries.insertDog("Buddy", "Pomeranian", null)
       assertThat(
         dogQueries.selectDogsByBreedAndNames(
           breed = "Pomeranian",
@@ -58,11 +59,13 @@ class MySqlTest {
             name = "Tilda",
             breed = "Pomeranian",
             is_good = true,
+            age = null,
           ),
           Dog(
             name = "Buddy",
             breed = "Pomeranian",
             is_good = true,
+            age = null,
           ),
         )
     }

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql-async/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/async/Dog.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql-async/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/async/Dog.sq
@@ -1,12 +1,13 @@
 CREATE TABLE dog (
   name VARCHAR(8) NOT NULL,
   breed TEXT NOT NULL,
-  is_good INTEGER NOT NULL DEFAULT 1
+  is_good INTEGER NOT NULL DEFAULT 1,
+  age INTEGER
 );
 
 insertDog:
 INSERT INTO dog
-VALUES (?, ?, DEFAULT);
+VALUES (?, ?, DEFAULT, ?);
 
 selectDogs:
 SELECT *
@@ -19,5 +20,5 @@ WHERE :someBoolean AND 1 = 1;
 
 insertAndReturn:
 INSERT INTO dog
-VALUES (?, ?, DEFAULT)
+VALUES (?, ?, DEFAULT, ?)
 RETURNING *;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql-async/src/test/kotlin/app/cash/sqldelight/postgresql/integration/async/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql-async/src/test/kotlin/app/cash/sqldelight/postgresql/integration/async/PostgreSqlTest.kt
@@ -27,15 +27,16 @@ class PostgreSqlTest {
     block(db)
   }
 
-  @Test fun simpleSelect() = runTest { database ->
+  @Test fun simpleSelectWithNullPrimitive() = runTest { database ->
     Assert.assertEquals(0, database.dogQueries.selectDogs().awaitAsList().size)
-    database.dogQueries.insertDog("Tilda", "Pomeranian")
+    database.dogQueries.insertDog("Tilda", "Pomeranian", null)
     assertThat(database.dogQueries.selectDogs().awaitAsOne())
       .isEqualTo(
         Dog(
           name = "Tilda",
           breed = "Pomeranian",
           is_good = 1,
+          age = null,
         ),
       )
   }
@@ -47,24 +48,26 @@ class PostgreSqlTest {
   }
 
   @Test fun booleanSelect() = runTest { database ->
-    database.dogQueries.insertDog("Tilda", "Pomeranian")
+    database.dogQueries.insertDog("Tilda", "Pomeranian", null)
     assertThat(database.dogQueries.selectGoodDogs(true).awaitAsOne())
       .isEqualTo(
         Dog(
           name = "Tilda",
           breed = "Pomeranian",
           is_good = 1,
+          age = null,
         ),
       )
   }
 
   @Test fun returningInsert() = runTest { database ->
-    assertThat(database.dogQueries.insertAndReturn("Tilda", "Pomeranian").awaitAsOne())
+    assertThat(database.dogQueries.insertAndReturn("Tilda", "Pomeranian", null).awaitAsOne())
       .isEqualTo(
         Dog(
           name = "Tilda",
           breed = "Pomeranian",
           is_good = 1,
+          age = null,
         ),
       )
   }


### PR DESCRIPTION
R2DBC requires boxed primitives, otherwise, the driver cannot encode a null value.