### PR TITLE
[1.5 branch] documentation: do not output schema next to .db files

### DIFF
--- a/docs/common/gradle-common-groovy-properties.md
+++ b/docs/common/gradle-common-groovy-properties.md
@@ -11,7 +11,7 @@
     // of the project. These files are used to verify that migrations yield 
     // a database with the latest schema. Defaults to null so the verification 
     // tasks will not be created.
-    schemaOutputDirectory = file("src/main/sqldelight/databases")
+    schemaOutputDirectory = file("src/main/sqldelight-databases")
 
     // Optionally specify schema dependencies on other gradle projects
     dependency project(':OtherProject')


### PR DESCRIPTION
The configuration from the docs gives this error on Gradle 8:

```
* What went wrong:
A problem was found with the configuration of task ':foo:generateCommonMainBlob2DatabaseInterface' (type 'SqlDelightTask').
  - Gradle detected a problem with the following location: 'foo/src/commonMain/sqldelight/blob2'.
 
    Reason: Task ':foo:generateCommonMainBlob2DatabaseInterface' uses this output of task ':foo:generateCommonMainBlob2DatabaseSchema' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.

```

That's because the input to the codegen task is the whole directory, including the generated schema db (even if not used). Moving it to a sibling directory fixed the issue.