### PR TITLE
Include PRAGMAs from migrations in database create(SqlDriver)

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/DatabaseGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/DatabaseGenerator.kt
@@ -324,6 +324,7 @@ internal class DatabaseGenerator(
     dropTableStmt != null -> true
     dropTriggerStmt != null -> true
     dropViewStmt != null -> true
+    pragmaStmt != null -> true
     else -> false
   }
 }

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueryWrapperTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueryWrapperTest.kt
@@ -737,11 +737,11 @@ class QueryWrapperTest {
       |SELECT * FROM test;
       """.trimMargin(),
       tempFolder,
-      "Query.sq"
+      "Query.sq",
     )
     val result = FixtureCompiler.compileFixture(
       tempFolder.fixtureRoot().path,
-      deriveSchemaFromMigrations = true
+      deriveSchemaFromMigrations = true,
     )
 
     assertThat(result.errors).isEmpty()


### PR DESCRIPTION
PRAGMA statements defined in migrations, such as switching to WAL mode for SQLite, or toggling foreign keys, are executed as part of the migrate(SqlDriver, Int, Int) function, but are not executed as part of create(SqlDriver). They should be executed as part of both.

I suspect there may be a better way/location to write this test, and am happy to change it as requested.