### PR TITLE
Fix build cache misses

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -83,10 +83,8 @@ jobs:
       # Build the sample
       - name: Build the sample
         if: matrix.os == 'macOS-latest' && matrix.job == 'gradle-plugin-tests'
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: build --stacktrace
-          build-root-directory: sample
+        run: ./gradlew build --stacktrace
+        working-directory: ./sample
 
       - name: Bundle the build report
         if: failure()


### PR DESCRIPTION
Although we use the build cache, we still have many cache misses and many compile tasks are executed again : https://scans.gradle.com/s/vwgolr4morjno/performance/execution

Only a guess, maybe using `gradle/gradle-build-action` twice uploads the wrong folder...
Unfortunately, you can't download the cache for diagnostics.