### PR TITLE
add support and test for gen_random_uuid()

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -87,6 +87,7 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
     "min" -> encapsulatingType(exprList, BLOB, TEXT, SMALL_INT, INTEGER, PostgreSqlType.INTEGER, BIG_INT, REAL).asNullable()
     "date_trunc" -> encapsulatingType(exprList, TIMESTAMP_TIMEZONE, TIMESTAMP)
     "now" -> IntermediateType(TIMESTAMP_TIMEZONE)
+    "gen_random_uuid" -> IntermediateType(PostgreSqlType.UUID)
     else -> null
   }
 

--- a/dialects/postgresql/src/test/fixtures_postgresql/uuids/Test.s
+++ b/dialects/postgresql/src/test/fixtures_postgresql/uuids/Test.s
@@ -1,0 +1,7 @@
+CREATE TABLE uuid_test (
+  pk uuid
+);
+
+SELECT gen_random_uuid(), pk FROM uuid_test;
+
+INSERT INTO uuid_test(pk) SELECT gen_random_uuid();

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Uuids.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Uuids.sq
@@ -1,0 +1,9 @@
+CREATE TABLE uuids(
+  key uuid NOT NULL
+);
+
+insertUuid:
+  INSERT INTO uuids (key) VALUES (:key);
+
+randomUuid:
+  SELECT gen_random_uuid();

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -188,7 +188,7 @@ class PostgreSqlTest {
   }
 
   @Test fun genRandomUuid() {
-    val uuid = database.datesQueries.randomUuid().executeAsOne()
+    val uuid : UUID = database.datesQueries.randomUuid().executeAsOne()
     assertThat(uuid).isNotNull()
   }
 }

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -16,6 +16,7 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
+import java.util.UUID
 
 class PostgreSqlTest {
   val conn = DriverManager.getConnection("jdbc:tc:postgresql:9.6.8:///my_db")

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -188,7 +188,7 @@ class PostgreSqlTest {
   }
 
   @Test fun genRandomUuid() {
-    val uuid : UUID = database.datesQueries.randomUuid().executeAsOne()
+    val uuid: UUID = database.datesQueries.randomUuid().executeAsOne()
     assertThat(uuid).isNotNull()
   }
 }

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -19,7 +19,7 @@ import java.time.ZoneOffset
 import java.util.UUID
 
 class PostgreSqlTest {
-  val conn = DriverManager.getConnection("jdbc:tc:postgresql:9.6.8:///my_db")
+  val conn = DriverManager.getConnection("jdbc:tc:postgresql:latest:///my_db")
   val driver = object : JdbcDriver() {
     override fun getConnection() = conn
     override fun closeConnection(connection: Connection) = Unit

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -189,7 +189,7 @@ class PostgreSqlTest {
   }
 
   @Test fun genRandomUuid() {
-    val uuid: UUID = database.datesQueries.randomUuid().executeAsOne()
+    val uuid: UUID = database.uuidsQueries.randomUuid().executeAsOne()
     assertThat(uuid).isNotNull()
   }
 }

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -186,4 +186,9 @@ class PostgreSqlTest {
       insertRef(RefTable(RefTable.Id(10), id))
     }
   }
+
+  @Test fun genRandomUuid() {
+    val uuid = database.datesQueries.randomUuid().executeAsOne()
+    assertThat(uuid).isNotNull()
+  }
 }


### PR DESCRIPTION
Adds support for [gen_random_uuid()](https://www.postgresql.org/docs/current/functions-uuid.html) postgres function, which comes out of the box since v13

I'm unable to run the build on my local (m1 mac) so I haven't been able to test it. Is there a way to build on m1 mac?