### PR TITLE
Move SelectQueryable to Dialect module

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,6 +59,7 @@ intellij-analysisImpl = { module = "com.jetbrains.intellij.platform:analysis-imp
 intellij-android = { module = "com.jetbrains.intellij.android:android-adt-ui-model", version.ref = "idea" }
 intellij-projectModel = { module = "com.jetbrains.intellij.platform:project-model", version.ref = "idea" }
 intellij-projectModelImpl = { module = "com.jetbrains.intellij.platform:project-model-impl", version.ref = "idea" }
+intellij-utilEx = { module = "com.jetbrains.intellij.platform:util-ex", version.ref = "idea" }
 
 jna = { module = "net.java.dev.jna:jna", version = "5.13.0" }
 

--- a/sqldelight-compiler/dialect/build.gradle
+++ b/sqldelight-compiler/dialect/build.gradle
@@ -11,6 +11,7 @@ dependencies {
   api libs.kotlinPoet
 
   compileOnly libs.intellij.coreImpl
+  compileOnly libs.intellij.utilEx
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"

--- a/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/PragmaWithResults.kt
+++ b/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/PragmaWithResults.kt
@@ -1,6 +1,5 @@
-package app.cash.sqldelight.core.compiler.model
+package app.cash.sqldelight.dialect.api
 
-import app.cash.sqldelight.dialect.api.QueryWithResults
 import com.alecstrong.sql.psi.core.psi.NamedElement
 import com.alecstrong.sql.psi.core.psi.QueryElement
 import com.alecstrong.sql.psi.core.psi.QueryElement.QueryResult
@@ -9,13 +8,13 @@ import com.alecstrong.sql.psi.core.psi.SqlPragmaStmt
 import com.alecstrong.sql.psi.core.psi.impl.SqlPragmaNameImpl
 import com.intellij.lang.ASTNode
 
-class PragmaWithResults(private val pragmaStmt: SqlPragmaStmt) : QueryWithResults {
+class PragmaWithResults(pragmaStmt: SqlPragmaStmt) : QueryWithResults {
   override var statement: SqlAnnotatedElement = pragmaStmt
   override val select: QueryElement = pragmaStmt.pragmaName as SqlDelightPragmaName
   override val pureTable: NamedElement? = null
 }
 
-internal class SqlDelightPragmaName(node: ASTNode?) : SqlPragmaNameImpl(node), QueryElement {
+class SqlDelightPragmaName(node: ASTNode?) : SqlPragmaNameImpl(node), QueryElement {
   override fun queryExposed() = listOf(
     QueryResult(
       column = this,

--- a/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/SelectQueryable.kt
+++ b/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/SelectQueryable.kt
@@ -1,7 +1,5 @@
-package app.cash.sqldelight.core.compiler.model
+package app.cash.sqldelight.dialect.api
 
-import app.cash.sqldelight.core.lang.util.parentOfType
-import app.cash.sqldelight.dialect.api.QueryWithResults
 import com.alecstrong.sql.psi.core.psi.NamedElement
 import com.alecstrong.sql.psi.core.psi.QueryElement.QueryColumn
 import com.alecstrong.sql.psi.core.psi.Queryable
@@ -11,6 +9,7 @@ import com.alecstrong.sql.psi.core.psi.SqlCreateViewStmt
 import com.alecstrong.sql.psi.core.psi.SqlCteTableName
 import com.alecstrong.sql.psi.core.psi.SqlViewName
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.parentOfType
 
 class SelectQueryable(
   override val select: SqlCompoundSelectStmt,

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SqlDelightCompiler.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SqlDelightCompiler.kt
@@ -18,12 +18,12 @@ package app.cash.sqldelight.core.compiler
 import app.cash.sqldelight.core.SqlDelightFileIndex
 import app.cash.sqldelight.core.capitalize
 import app.cash.sqldelight.core.compiler.model.NamedQuery
-import app.cash.sqldelight.core.compiler.model.SelectQueryable
 import app.cash.sqldelight.core.lang.MigrationFile
 import app.cash.sqldelight.core.lang.SqlDelightFile
 import app.cash.sqldelight.core.lang.SqlDelightQueriesFile
 import app.cash.sqldelight.core.lang.queriesName
 import app.cash.sqldelight.core.lang.util.sqFile
+import app.cash.sqldelight.dialect.api.SelectQueryable
 import app.cash.sqldelight.dialect.api.SqlDelightDialect
 import com.alecstrong.sql.psi.core.psi.InvalidElementDetectedException
 import com.alecstrong.sql.psi.core.psi.NamedElement

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/model/NamedQuery.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/model/NamedQuery.kt
@@ -36,6 +36,7 @@ import app.cash.sqldelight.dialect.api.PrimitiveType.NULL
 import app.cash.sqldelight.dialect.api.PrimitiveType.REAL
 import app.cash.sqldelight.dialect.api.PrimitiveType.TEXT
 import app.cash.sqldelight.dialect.api.QueryWithResults
+import app.cash.sqldelight.dialect.api.SelectQueryable
 import com.alecstrong.sql.psi.core.psi.NamedElement
 import com.alecstrong.sql.psi.core.psi.QueryElement
 import com.alecstrong.sql.psi.core.psi.SqlCompoundSelectStmt

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/ParserUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/ParserUtil.kt
@@ -2,10 +2,10 @@ package app.cash.sqldelight.core.lang
 
 import app.cash.sqldelight.core.SqlDelightProjectService
 import app.cash.sqldelight.core.SqldelightParserUtil
-import app.cash.sqldelight.core.compiler.model.SqlDelightPragmaName
 import app.cash.sqldelight.core.lang.psi.FunctionExprMixin
 import app.cash.sqldelight.dialect.api.SqlDelightDialect
 import app.cash.sqldelight.dialect.api.SqlDelightModule
+import app.cash.sqldelight.dialect.api.SqlDelightPragmaName
 import com.alecstrong.sql.psi.core.SqlParserUtil
 import com.alecstrong.sql.psi.core.psi.SqlTypes
 import com.intellij.openapi.project.Project

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/SqlDelightQueriesFile.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/SqlDelightQueriesFile.kt
@@ -26,7 +26,6 @@ import app.cash.sqldelight.core.compiler.model.NamedMutator.Update
 import app.cash.sqldelight.core.compiler.model.NamedQuery
 import app.cash.sqldelight.core.lang.psi.StmtIdentifierMixin
 import app.cash.sqldelight.core.lang.util.argumentType
-import app.cash.sqldelight.core.lang.util.parentOfTypeOrNull
 import app.cash.sqldelight.core.lang.util.table
 import app.cash.sqldelight.core.psi.SqlDelightStmtList
 import com.alecstrong.sql.psi.core.SqlAnnotationHolder
@@ -38,6 +37,7 @@ import com.intellij.psi.FileViewProvider
 import com.intellij.psi.PsiDirectory
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.parentOfType
 
 class SqlDelightQueriesFile(
   viewProvider: FileViewProvider,
@@ -114,7 +114,7 @@ class SqlDelightQueriesFile(
   internal val requiredAdapters by lazy {
     val binders = PsiTreeUtil.findChildrenOfType(this, SqlBindExpr::class.java)
     val argumentAdapters = binders.mapNotNull {
-      it.parentOfTypeOrNull<SqlInsertStmt>()?.let {
+      it.parentOfType<SqlInsertStmt>()?.let {
         if (it.acceptsTableInterface() && it.table.needsAdapters()) return@mapNotNull it.table.adapterProperty()
       }
       typeResolver.argumentType(it).parentAdapter()

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/psi/ColumnTypeMixin.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/psi/ColumnTypeMixin.kt
@@ -18,7 +18,6 @@ package app.cash.sqldelight.core.lang.psi
 import app.cash.sqldelight.core.capitalize
 import app.cash.sqldelight.core.compiler.SqlDelightCompiler.allocateName
 import app.cash.sqldelight.core.lang.types.typeResolver
-import app.cash.sqldelight.core.lang.util.parentOfType
 import app.cash.sqldelight.core.lang.util.sqFile
 import app.cash.sqldelight.core.psi.SqlDelightAnnotation
 import app.cash.sqldelight.core.psi.SqlDelightAnnotationValue
@@ -42,6 +41,7 @@ import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.tree.TokenSet
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.parentOfType
 import com.intellij.util.castSafelyTo
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
@@ -166,7 +166,7 @@ internal abstract class ColumnTypeMixin(
   }
 
   private fun SqlDelightJavaType.type(): ClassName {
-    parentOfType<SqlDelightStmtList>().importStmtList.importStmtList.forEach { import ->
+    parentOfType<SqlDelightStmtList>()!!.importStmtList.importStmtList.forEach { import ->
       val typePrefix = text.substringBefore('.')
       if (import.javaType.text.endsWith(".$typePrefix")) {
         return text.split(".").drop(1).fold(import.javaType.type()) { current, nested ->

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/Arguments.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/Arguments.kt
@@ -16,7 +16,6 @@
 package app.cash.sqldelight.core.lang.util
 
 import app.cash.sqldelight.core.compiler.model.NamedQuery
-import app.cash.sqldelight.core.compiler.model.SelectQueryable
 import app.cash.sqldelight.core.lang.types.typeResolver
 import app.cash.sqldelight.dialect.api.IntermediateType
 import app.cash.sqldelight.dialect.api.PrimitiveType
@@ -24,6 +23,7 @@ import app.cash.sqldelight.dialect.api.PrimitiveType.ARGUMENT
 import app.cash.sqldelight.dialect.api.PrimitiveType.INTEGER
 import app.cash.sqldelight.dialect.api.PrimitiveType.NULL
 import app.cash.sqldelight.dialect.api.PrimitiveType.TEXT
+import app.cash.sqldelight.dialect.api.SelectQueryable
 import com.alecstrong.sql.psi.core.psi.SqlBetweenExpr
 import com.alecstrong.sql.psi.core.psi.SqlBinaryExpr
 import com.alecstrong.sql.psi.core.psi.SqlBinaryLikeExpr

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/ExprUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/ExprUtil.kt
@@ -16,10 +16,9 @@
 package app.cash.sqldelight.core.lang.util
 
 import app.cash.sqldelight.core.compiler.SqlDelightCompiler.allocateName
-import app.cash.sqldelight.core.compiler.model.PragmaWithResults
-import app.cash.sqldelight.core.compiler.model.SelectQueryable
 import app.cash.sqldelight.core.lang.types.typeResolver
 import app.cash.sqldelight.dialect.api.IntermediateType
+import app.cash.sqldelight.dialect.api.PragmaWithResults
 import app.cash.sqldelight.dialect.api.PrimitiveType
 import app.cash.sqldelight.dialect.api.PrimitiveType.ARGUMENT
 import app.cash.sqldelight.dialect.api.PrimitiveType.BLOB
@@ -28,6 +27,7 @@ import app.cash.sqldelight.dialect.api.PrimitiveType.NULL
 import app.cash.sqldelight.dialect.api.PrimitiveType.REAL
 import app.cash.sqldelight.dialect.api.PrimitiveType.TEXT
 import app.cash.sqldelight.dialect.api.QueryWithResults
+import app.cash.sqldelight.dialect.api.SelectQueryable
 import app.cash.sqldelight.dialect.api.TypeResolver
 import app.cash.sqldelight.dialect.api.encapsulatingType
 import com.alecstrong.sql.psi.core.psi.SqlBetweenExpr

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/TreeUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/TreeUtil.kt
@@ -52,14 +52,6 @@ import org.jgrapht.graph.DefaultEdge
 import org.jgrapht.graph.DirectedAcyclicGraph
 import org.jgrapht.traverse.TopologicalOrderIterator
 
-internal inline fun <reified R : PsiElement> PsiElement.parentOfType(): R {
-  return PsiTreeUtil.getParentOfType(this, R::class.java)!!
-}
-
-internal inline fun <reified R : PsiElement> PsiElement.parentOfTypeOrNull(): R? {
-  return PsiTreeUtil.getParentOfType(this, R::class.java)
-}
-
 internal fun PsiElement.type(): IntermediateType = when (this) {
   is ExposableType -> type()
   is SqlTypeName -> sqFile().typeResolver.definitionType(this)

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/validation/OptimisticLockValidator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/validation/OptimisticLockValidator.kt
@@ -2,7 +2,6 @@ package app.cash.sqldelight.core.lang.validation
 
 import app.cash.sqldelight.core.lang.util.columnDefSource
 import app.cash.sqldelight.core.lang.util.findChildrenOfType
-import app.cash.sqldelight.core.lang.util.parentOfType
 import com.alecstrong.sql.psi.core.SqlAnnotationHolder
 import com.alecstrong.sql.psi.core.SqlCompilerAnnotator
 import com.alecstrong.sql.psi.core.psi.NamedElement
@@ -20,6 +19,7 @@ import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.psi.PsiElement
+import com.intellij.psi.util.parentOfType
 
 open class OptimisticLockValidator : Annotator, SqlCompilerAnnotator {
   open fun quickFix(element: PsiElement, lock: ColumnDefMixin): IntentionAction? = null


### PR DESCRIPTION
Use-case:
Implement  `QueryWithResults` defined in `dialect` module in the DB2 dialect but I also need to create SelectQueryable

```kotlin
override fun queryWithResults(sqlStmt: SqlStmt): QueryWithResults? {
  val ext = sqlStmt.extensionStmt
  if (ext != null) {
    val set = (ext as Db2ExtensionStmt).setStmt
    set.compoundSelectStmtInternal?.let { SelectQueryable(it) }
    return Db2SetQueryWithResults(set)
  }
  val compoundSelectStmt = sqlStmt.compoundSelectStmt
  return if (compoundSelectStmt is Db2CompoundSelectMixin) {
    return compoundSelectStmt.queryWithResults()
  } else parentResolver.queryWithResults(sqlStmt)
}
```