### PR TITLE
Use Azul JDK for toolchains

### DIFF
--- a/adapters/primitive-adapters/build.gradle
+++ b/adapters/primitive-adapters/build.gradle
@@ -6,7 +6,10 @@ plugins {
   id("app.cash.sqldelight.multiplatform")
 }
 
-kotlin.jvmToolchain(8)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(8))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 archivesBaseName = 'sqldelight-primitive-adapters'
 

--- a/adapters/primitive-adapters/build.gradle
+++ b/adapters/primitive-adapters/build.gradle
@@ -4,11 +4,7 @@ plugins {
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
   id("app.cash.sqldelight.multiplatform")
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(8))
-  vendor.set(JvmVendorSpec.AZUL)
+  id("app.cash.sqldelight.toolchain.runtime")
 }
 
 archivesBaseName = 'sqldelight-primitive-adapters'

--- a/buildLogic/settings.gradle
+++ b/buildLogic/settings.gradle
@@ -19,3 +19,4 @@ dependencyResolutionManagement {
 }
 
 include(":multiplatform-convention")
+include(":toolchain-convention")

--- a/buildLogic/toolchain-convention/build.gradle
+++ b/buildLogic/toolchain-convention/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+  alias(libs.plugins.kotlin.jvm)
+  id("java-gradle-plugin")
+}
+
+gradlePlugin {
+  plugins {
+    runtime {
+      id = "app.cash.sqldelight.toolchain.runtime"
+      implementationClass = "app.cash.sqldelight.toolchain.RuntimeToolchainConventions"
+    }
+    compiler {
+      id = "app.cash.sqldelight.toolchain.compiler"
+      implementationClass = "app.cash.sqldelight.toolchain.CompilerToolchainConventions"
+    }
+  }
+}
+
+dependencies {
+  compileOnly libs.kotlin.plugin
+}

--- a/buildLogic/toolchain-convention/src/main/kotlin/app/cash/sqldelight/toolchain/ToolchainConventions.kt
+++ b/buildLogic/toolchain-convention/src/main/kotlin/app/cash/sqldelight/toolchain/ToolchainConventions.kt
@@ -1,0 +1,20 @@
+package app.cash.sqldelight.toolchain
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JvmVendorSpec
+import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
+
+abstract class ToolchainConventions(private val jdkVersion: Int) : Plugin<Project> {
+  override fun apply(project: Project) {
+    project.kotlinExtension.jvmToolchain { spec ->
+      spec.languageVersion.set(JavaLanguageVersion.of(jdkVersion))
+      spec.vendor.set(JvmVendorSpec.AZUL)
+    }
+  }
+}
+
+class RuntimeToolchainConventions : ToolchainConventions(8)
+
+class CompilerToolchainConventions : ToolchainConventions(11)

--- a/dialects/hsql/build.gradle
+++ b/dialects/hsql/build.gradle
@@ -9,7 +9,10 @@ grammarKit {
   intellijRelease.set(libs.versions.idea)
 }
 
-kotlin.jvmToolchain(11)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(11))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 dependencies {
   api project(':sqldelight-compiler:dialect')

--- a/dialects/hsql/build.gradle
+++ b/dialects/hsql/build.gradle
@@ -3,15 +3,11 @@ plugins {
   alias(libs.plugins.grammarKitComposer)
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
+  id("app.cash.sqldelight.toolchain.compiler")
 }
 
 grammarKit {
   intellijRelease.set(libs.versions.idea)
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(11))
-  vendor.set(JvmVendorSpec.AZUL)
 }
 
 dependencies {

--- a/dialects/mysql/build.gradle
+++ b/dialects/mysql/build.gradle
@@ -10,7 +10,10 @@ grammarKit {
   intellijRelease.set(libs.versions.idea)
 }
 
-kotlin.jvmToolchain(11)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(11))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 dependencies {
   ksp libs.moshiCodegen

--- a/dialects/mysql/build.gradle
+++ b/dialects/mysql/build.gradle
@@ -4,15 +4,11 @@ plugins {
   alias(libs.plugins.grammarKitComposer)
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
+  id("app.cash.sqldelight.toolchain.compiler")
 }
 
 grammarKit {
   intellijRelease.set(libs.versions.idea)
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(11))
-  vendor.set(JvmVendorSpec.AZUL)
 }
 
 dependencies {

--- a/dialects/postgresql/build.gradle
+++ b/dialects/postgresql/build.gradle
@@ -10,7 +10,10 @@ grammarKit {
   intellijRelease.set(libs.versions.idea)
 }
 
-kotlin.jvmToolchain(11)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(11))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 dependencies {
   ksp libs.moshiCodegen

--- a/dialects/postgresql/build.gradle
+++ b/dialects/postgresql/build.gradle
@@ -4,15 +4,11 @@ plugins {
   alias(libs.plugins.grammarKitComposer)
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
+  id("app.cash.sqldelight.toolchain.compiler")
 }
 
 grammarKit {
   intellijRelease.set(libs.versions.idea)
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(11))
-  vendor.set(JvmVendorSpec.AZUL)
 }
 
 dependencies {

--- a/dialects/sqlite-3-18/build.gradle
+++ b/dialects/sqlite-3-18/build.gradle
@@ -8,7 +8,10 @@ grammarKit {
   intellijRelease.set(libs.versions.idea)
 }
 
-kotlin.jvmToolchain(11)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(11))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 dependencies {
   api project(':sqldelight-compiler:dialect')

--- a/dialects/sqlite-3-18/build.gradle
+++ b/dialects/sqlite-3-18/build.gradle
@@ -2,15 +2,11 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.grammarKitComposer)
   alias(libs.plugins.publish)
+  id("app.cash.sqldelight.toolchain.compiler")
 }
 
 grammarKit {
   intellijRelease.set(libs.versions.idea)
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(11))
-  vendor.set(JvmVendorSpec.AZUL)
 }
 
 dependencies {

--- a/dialects/sqlite-3-24/build.gradle
+++ b/dialects/sqlite-3-24/build.gradle
@@ -8,7 +8,10 @@ grammarKit {
   intellijRelease.set(libs.versions.idea)
 }
 
-kotlin.jvmToolchain(11)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(11))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 dependencies {
   api project(':dialects:sqlite-3-18')

--- a/dialects/sqlite-3-24/build.gradle
+++ b/dialects/sqlite-3-24/build.gradle
@@ -2,15 +2,11 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.grammarKitComposer)
   alias(libs.plugins.publish)
+  id("app.cash.sqldelight.toolchain.compiler")
 }
 
 grammarKit {
   intellijRelease.set(libs.versions.idea)
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(11))
-  vendor.set(JvmVendorSpec.AZUL)
 }
 
 dependencies {

--- a/dialects/sqlite-3-25/build.gradle
+++ b/dialects/sqlite-3-25/build.gradle
@@ -8,7 +8,10 @@ grammarKit {
   intellijRelease.set(libs.versions.idea)
 }
 
-kotlin.jvmToolchain(11)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(11))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 dependencies {
   api project(':dialects:sqlite-3-24')

--- a/dialects/sqlite-3-25/build.gradle
+++ b/dialects/sqlite-3-25/build.gradle
@@ -2,15 +2,11 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.grammarKitComposer)
   alias(libs.plugins.publish)
+  id("app.cash.sqldelight.toolchain.compiler")
 }
 
 grammarKit {
   intellijRelease.set(libs.versions.idea)
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(11))
-  vendor.set(JvmVendorSpec.AZUL)
 }
 
 dependencies {

--- a/dialects/sqlite-3-30/build.gradle
+++ b/dialects/sqlite-3-30/build.gradle
@@ -8,7 +8,10 @@ grammarKit {
   intellijRelease.set(libs.versions.idea)
 }
 
-kotlin.jvmToolchain(11)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(11))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 dependencies {
   api project(':dialects:sqlite-3-25')

--- a/dialects/sqlite-3-30/build.gradle
+++ b/dialects/sqlite-3-30/build.gradle
@@ -2,15 +2,11 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.grammarKitComposer)
   alias(libs.plugins.publish)
+  id("app.cash.sqldelight.toolchain.compiler")
 }
 
 grammarKit {
   intellijRelease.set(libs.versions.idea)
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(11))
-  vendor.set(JvmVendorSpec.AZUL)
 }
 
 dependencies {

--- a/dialects/sqlite-3-33/build.gradle
+++ b/dialects/sqlite-3-33/build.gradle
@@ -8,7 +8,10 @@ grammarKit {
   intellijRelease.set(libs.versions.idea)
 }
 
-kotlin.jvmToolchain(11)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(11))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 dependencies {
   api project(':dialects:sqlite-3-30')

--- a/dialects/sqlite-3-33/build.gradle
+++ b/dialects/sqlite-3-33/build.gradle
@@ -2,15 +2,11 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.grammarKitComposer)
   alias(libs.plugins.publish)
+  id("app.cash.sqldelight.toolchain.compiler")
 }
 
 grammarKit {
   intellijRelease.set(libs.versions.idea)
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(11))
-  vendor.set(JvmVendorSpec.AZUL)
 }
 
 dependencies {

--- a/dialects/sqlite-3-35/build.gradle
+++ b/dialects/sqlite-3-35/build.gradle
@@ -8,7 +8,10 @@ grammarKit {
   intellijRelease.set(libs.versions.idea)
 }
 
-kotlin.jvmToolchain(11)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(11))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 dependencies {
   api project(':dialects:sqlite-3-33')

--- a/dialects/sqlite-3-35/build.gradle
+++ b/dialects/sqlite-3-35/build.gradle
@@ -2,15 +2,11 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.grammarKitComposer)
   alias(libs.plugins.publish)
+  id("app.cash.sqldelight.toolchain.compiler")
 }
 
 grammarKit {
   intellijRelease.set(libs.versions.idea)
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(11))
-  vendor.set(JvmVendorSpec.AZUL)
 }
 
 dependencies {

--- a/dialects/sqlite-3-38/build.gradle
+++ b/dialects/sqlite-3-38/build.gradle
@@ -8,7 +8,10 @@ grammarKit {
   intellijRelease.set(libs.versions.idea)
 }
 
-kotlin.jvmToolchain(11)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(11))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 dependencies {
   api project(':dialects:sqlite-3-35')

--- a/dialects/sqlite-3-38/build.gradle
+++ b/dialects/sqlite-3-38/build.gradle
@@ -2,15 +2,11 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.grammarKitComposer)
   alias(libs.plugins.publish)
+  id("app.cash.sqldelight.toolchain.compiler")
 }
 
 grammarKit {
   intellijRelease.set(libs.versions.idea)
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(11))
-  vendor.set(JvmVendorSpec.AZUL)
 }
 
 dependencies {

--- a/dialects/sqlite/json-module/build.gradle
+++ b/dialects/sqlite/json-module/build.gradle
@@ -9,7 +9,10 @@ grammarKit {
   intellijRelease.set(libs.versions.idea)
 }
 
-kotlin.jvmToolchain(11)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(11))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 dependencies {
   api project(':sqldelight-compiler:dialect')

--- a/dialects/sqlite/json-module/build.gradle
+++ b/dialects/sqlite/json-module/build.gradle
@@ -3,15 +3,11 @@ plugins {
   alias(libs.plugins.grammarKitComposer)
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
+  id("app.cash.sqldelight.toolchain.compiler")
 }
 
 grammarKit {
   intellijRelease.set(libs.versions.idea)
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(11))
-  vendor.set(JvmVendorSpec.AZUL)
 }
 
 dependencies {

--- a/drivers/android-driver/build.gradle
+++ b/drivers/android-driver/build.gradle
@@ -5,7 +5,10 @@ plugins {
   alias(libs.plugins.dokka)
 }
 
-kotlin.jvmToolchain(8)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(8))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 archivesBaseName = 'sqldelight-android-driver'
 

--- a/drivers/android-driver/build.gradle
+++ b/drivers/android-driver/build.gradle
@@ -3,11 +3,7 @@ plugins {
   alias(libs.plugins.kotlin.android)
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(8))
-  vendor.set(JvmVendorSpec.AZUL)
+  id("app.cash.sqldelight.toolchain.runtime")
 }
 
 archivesBaseName = 'sqldelight-android-driver'

--- a/drivers/driver-test/build.gradle
+++ b/drivers/driver-test/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id("app.cash.sqldelight.multiplatform")
+  id("app.cash.sqldelight.toolchain.runtime")
 }
 
 // https://youtrack.jetbrains.com/issue/KTIJ-14471
@@ -8,8 +9,6 @@ sourceSets {
 }
 
 kotlin {
-  jvmToolchain(8)
-  
   mingwX86()
 
   sourceSets {

--- a/drivers/jdbc-driver/build.gradle
+++ b/drivers/jdbc-driver/build.gradle
@@ -6,7 +6,10 @@ plugins {
   alias(libs.plugins.dokka)
 }
 
-kotlin.jvmToolchain(8)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(8))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 archivesBaseName = 'sqldelight-jdbc-driver'
 

--- a/drivers/jdbc-driver/build.gradle
+++ b/drivers/jdbc-driver/build.gradle
@@ -1,14 +1,8 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(8))
-  vendor.set(JvmVendorSpec.AZUL)
+  id("app.cash.sqldelight.toolchain.runtime")
 }
 
 archivesBaseName = 'sqldelight-jdbc-driver'

--- a/drivers/r2dbc-driver/build.gradle
+++ b/drivers/r2dbc-driver/build.gradle
@@ -6,7 +6,10 @@ plugins {
   alias(libs.plugins.dokka)
 }
 
-kotlin.jvmToolchain(8)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(8))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 archivesBaseName = 'sqldelight-r2dbc-driver'
 

--- a/drivers/r2dbc-driver/build.gradle
+++ b/drivers/r2dbc-driver/build.gradle
@@ -4,11 +4,7 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(8))
-  vendor.set(JvmVendorSpec.AZUL)
+  id("app.cash.sqldelight.toolchain.runtime")
 }
 
 archivesBaseName = 'sqldelight-r2dbc-driver'

--- a/drivers/sqlite-driver/build.gradle
+++ b/drivers/sqlite-driver/build.gradle
@@ -4,7 +4,10 @@ plugins {
   alias(libs.plugins.dokka)
 }
 
-kotlin.jvmToolchain(8)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(8))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 archivesBaseName = 'sqldelight-sqlite-driver'
 

--- a/drivers/sqlite-driver/build.gradle
+++ b/drivers/sqlite-driver/build.gradle
@@ -2,11 +2,7 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(8))
-  vendor.set(JvmVendorSpec.AZUL)
+  id("app.cash.sqldelight.toolchain.runtime")
 }
 
 archivesBaseName = 'sqldelight-sqlite-driver'

--- a/extensions/androidx-paging3/build.gradle
+++ b/extensions/androidx-paging3/build.gradle
@@ -6,7 +6,10 @@ plugins {
 
 archivesBaseName = 'sqldelight-androidx-paging3'
 
-kotlin.jvmToolchain(8)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(8))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 kotlin {
   ios()

--- a/extensions/androidx-paging3/build.gradle
+++ b/extensions/androidx-paging3/build.gradle
@@ -2,14 +2,10 @@ plugins {
   alias(libs.plugins.kotlin.multiplatform)
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
+  id("app.cash.sqldelight.toolchain.runtime")
 }
 
 archivesBaseName = 'sqldelight-androidx-paging3'
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(8))
-  vendor.set(JvmVendorSpec.AZUL)
-}
 
 kotlin {
   ios()

--- a/extensions/async-extensions/build.gradle
+++ b/extensions/async-extensions/build.gradle
@@ -4,7 +4,10 @@ plugins {
   id("app.cash.sqldelight.multiplatform")
 }
 
-kotlin.jvmToolchain(8)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(8))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 archivesBaseName = 'sqldelight-async-extensions'
 

--- a/extensions/async-extensions/build.gradle
+++ b/extensions/async-extensions/build.gradle
@@ -2,11 +2,7 @@ plugins {
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
   id("app.cash.sqldelight.multiplatform")
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(8))
-  vendor.set(JvmVendorSpec.AZUL)
+  id("app.cash.sqldelight.toolchain.runtime")
 }
 
 archivesBaseName = 'sqldelight-async-extensions'

--- a/extensions/coroutines-extensions/build.gradle
+++ b/extensions/coroutines-extensions/build.gradle
@@ -4,7 +4,10 @@ plugins {
   id("app.cash.sqldelight.multiplatform")
 }
 
-kotlin.jvmToolchain(8)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(8))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 archivesBaseName = 'sqldelight-coroutines-extensions'
 

--- a/extensions/coroutines-extensions/build.gradle
+++ b/extensions/coroutines-extensions/build.gradle
@@ -2,11 +2,7 @@ plugins {
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
   id("app.cash.sqldelight.multiplatform")
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(8))
-  vendor.set(JvmVendorSpec.AZUL)
+  id("app.cash.sqldelight.toolchain.runtime")
 }
 
 archivesBaseName = 'sqldelight-coroutines-extensions'

--- a/extensions/rxjava2-extensions/build.gradle
+++ b/extensions/rxjava2-extensions/build.gradle
@@ -4,7 +4,10 @@ plugins {
   alias(libs.plugins.dokka)
 }
 
-kotlin.jvmToolchain(8)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(8))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 archivesBaseName = 'sqldelight-rxjava2-extensions'
 

--- a/extensions/rxjava2-extensions/build.gradle
+++ b/extensions/rxjava2-extensions/build.gradle
@@ -2,11 +2,7 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(8))
-  vendor.set(JvmVendorSpec.AZUL)
+  id("app.cash.sqldelight.toolchain.runtime")
 }
 
 archivesBaseName = 'sqldelight-rxjava2-extensions'

--- a/extensions/rxjava3-extensions/build.gradle
+++ b/extensions/rxjava3-extensions/build.gradle
@@ -4,7 +4,10 @@ plugins {
   alias(libs.plugins.dokka)
 }
 
-kotlin.jvmToolchain(8)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(8))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 archivesBaseName = 'sqldelight-rxjava3-extensions'
 

--- a/extensions/rxjava3-extensions/build.gradle
+++ b/extensions/rxjava3-extensions/build.gradle
@@ -2,11 +2,7 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(8))
-  vendor.set(JvmVendorSpec.AZUL)
+  id("app.cash.sqldelight.toolchain.runtime")
 }
 
 archivesBaseName = 'sqldelight-rxjava3-extensions'

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -9,7 +9,10 @@ sourceSets {
   main
 }
 
-kotlin.jvmToolchain(8)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(8))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 kotlin {
   mingwX86()

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -2,16 +2,12 @@ plugins {
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
   id("app.cash.sqldelight.multiplatform")
+  id("app.cash.sqldelight.toolchain.runtime")
 }
 
 // https://youtrack.jetbrains.com/issue/KTIJ-14471
 sourceSets {
   main
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(8))
-  vendor.set(JvmVendorSpec.AZUL)
 }
 
 kotlin {

--- a/sample/android/build.gradle
+++ b/sample/android/build.gradle
@@ -3,7 +3,10 @@ plugins {
   alias(libs.plugins.kotlin.android)
 }
 
-kotlin.jvmToolchain(8)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(8))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 android {
   compileSdk libs.versions.compileSdk.get() as int

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,7 @@ pluginManagement {
 
 plugins {
     id "com.gradle.enterprise" version "3.12.3"
+    id "org.gradle.toolchains.foojay-resolver-convention" version "0.4.0"
 }
 
 gradleEnterprise {

--- a/sqldelight-compiler/build.gradle
+++ b/sqldelight-compiler/build.gradle
@@ -15,7 +15,10 @@ tasks.named('test') {
   }
 }
 
-kotlin.jvmToolchain(11)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(11))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 sourceSets {
   main.java.srcDir "gen"

--- a/sqldelight-compiler/build.gradle
+++ b/sqldelight-compiler/build.gradle
@@ -3,6 +3,7 @@ plugins {
   alias(libs.plugins.grammarKitComposer)
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
+  id("app.cash.sqldelight.toolchain.compiler")
 }
 
 tasks.named('test') {
@@ -13,11 +14,6 @@ tasks.named('test') {
     showStackTraces true
     showCauses true
   }
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(11))
-  vendor.set(JvmVendorSpec.AZUL)
 }
 
 sourceSets {

--- a/sqldelight-compiler/dialect/build.gradle
+++ b/sqldelight-compiler/dialect/build.gradle
@@ -4,7 +4,10 @@ plugins {
   alias(libs.plugins.dokka)
 }
 
-kotlin.jvmToolchain(11)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(11))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 dependencies {
   api libs.sqlPsi

--- a/sqldelight-compiler/dialect/build.gradle
+++ b/sqldelight-compiler/dialect/build.gradle
@@ -2,11 +2,7 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(11))
-  vendor.set(JvmVendorSpec.AZUL)
+  id("app.cash.sqldelight.toolchain.compiler")
 }
 
 dependencies {

--- a/sqldelight-compiler/integration-tests/build.gradle
+++ b/sqldelight-compiler/integration-tests/build.gradle
@@ -2,7 +2,10 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
 }
 
-kotlin.jvmToolchain(11)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(11))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 dependencies {
   testImplementation project(':runtime')

--- a/sqldelight-compiler/integration-tests/build.gradle
+++ b/sqldelight-compiler/integration-tests/build.gradle
@@ -1,10 +1,6 @@
 plugins {
   alias(libs.plugins.kotlin.jvm)
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(11))
-  vendor.set(JvmVendorSpec.AZUL)
+  id("app.cash.sqldelight.toolchain.compiler")
 }
 
 dependencies {

--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -9,7 +9,10 @@ plugins {
   id("jvm-test-suite")
 }
 
-kotlin.jvmToolchain(11)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(11))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 testing {
   suites {

--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -7,11 +7,7 @@ plugins {
   alias(libs.plugins.dokka)
   id("java-gradle-plugin")
   id("jvm-test-suite")
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(11))
-  vendor.set(JvmVendorSpec.AZUL)
+  id("app.cash.sqldelight.toolchain.compiler")
 }
 
 testing {

--- a/sqldelight-idea-plugin/build.gradle
+++ b/sqldelight-idea-plugin/build.gradle
@@ -7,7 +7,10 @@ plugins {
   alias(libs.plugins.ksp)
 }
 
-kotlin.jvmToolchain(11)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(11))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 intellij {
   updateSinceUntilBuild = false

--- a/sqldelight-idea-plugin/build.gradle
+++ b/sqldelight-idea-plugin/build.gradle
@@ -5,11 +5,7 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.changelog)
   alias(libs.plugins.ksp)
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(11))
-  vendor.set(JvmVendorSpec.AZUL)
+  id("app.cash.sqldelight.toolchain.compiler")
 }
 
 intellij {

--- a/sqlite-migrations/build.gradle
+++ b/sqlite-migrations/build.gradle
@@ -4,7 +4,10 @@ plugins {
   alias(libs.plugins.dokka)
 }
 
-kotlin.jvmToolchain(11)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(11))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 dependencies {
   // These dependencies will not be shadowed by sqldelight-gradle-plugin

--- a/sqlite-migrations/build.gradle
+++ b/sqlite-migrations/build.gradle
@@ -2,11 +2,7 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(11))
-  vendor.set(JvmVendorSpec.AZUL)
+  id("app.cash.sqldelight.toolchain.compiler")
 }
 
 dependencies {

--- a/test-util/build.gradle
+++ b/test-util/build.gradle
@@ -2,7 +2,10 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
 }
 
-kotlin.jvmToolchain(11)
+kotlin.jvmToolchain {
+  languageVersion.set(JavaLanguageVersion.of(11))
+  vendor.set(JvmVendorSpec.AZUL)
+}
 
 dependencies {
   api project(':sqldelight-compiler')

--- a/test-util/build.gradle
+++ b/test-util/build.gradle
@@ -1,10 +1,6 @@
 plugins {
   alias(libs.plugins.kotlin.jvm)
-}
-
-kotlin.jvmToolchain {
-  languageVersion.set(JavaLanguageVersion.of(11))
-  vendor.set(JvmVendorSpec.AZUL)
+  id("app.cash.sqldelight.toolchain.compiler")
 }
 
 dependencies {


### PR DESCRIPTION
Gradle JVM toolchains use Adoptium by default which doesn't have a JDK 8 builds for Apple Silicon. Azul does!