### PR TITLE
Add 2.0 upgrade doc and other misc. doc changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 See the [project website](https://cashapp.github.io/sqldelight/) for documentation and APIs
 
-SQLDelight generates typesafe kotlin APIs from your SQL statements. It verifies your schema, statements, and migrations at compile-time and provides IDE features like autocomplete and refactoring which make writing and maintaining SQL simple.
+SQLDelight generates typesafe Kotlin APIs from your SQL statements. It verifies your schema, statements, and migrations at compile-time and provides IDE features like autocomplete and refactoring which make writing and maintaining SQL simple.
 
 SQLDelight understands your existing SQL schema.
 
@@ -40,6 +40,8 @@ SQLite
 
 Snapshots of the development version (including the IDE plugin zip) are available in
 [Sonatype's `snapshots` repository](https://oss.sonatype.org/content/repositories/snapshots/). Note that the coordinates are all app.cash.sqldelight instead of com.squareup.cash for the 2.0.0+ SNAPSHOTs.
+
+Documentation pages for the latest snapshot version can be [found here](https://cashapp.github.io/sqldelight/snapshot).
 
 License
 =======

--- a/docs/common/coroutines-usage.md
+++ b/docs/common/coroutines-usage.md
@@ -2,7 +2,7 @@
 val players: Flow<List<HockeyPlayer>> = 
   playerQueries.selectAll()
     .asFlow()
-    .mapToList()
+    .mapToList(Dispatchers.IO)
 ```
 
 This flow emits the query result, and emits a new result every time the database changes for that query.

--- a/docs/common/coroutines.md
+++ b/docs/common/coroutines.md
@@ -1,6 +1,6 @@
 ## Flow
 
-To consume a query as a Flow, depend on the Coroutines extensions artifact and use the extension method it provides:
+To consume a query as a Flow, add the coroutines extensions artifact as a dependency and use the extension functions it provides:
 
 === "Kotlin"
     ```kotlin

--- a/docs/common/custom_projections.md
+++ b/docs/common/custom_projections.md
@@ -1,4 +1,4 @@
-# Projections
+# Type Projections
 
 By default queries will return a data class with your projection, but you can override the behavior with a typesafe mapper.
 

--- a/docs/common/grouping_statements.md
+++ b/docs/common/grouping_statements.md
@@ -1,3 +1,5 @@
+# Grouping Statements
+
 You can group multiple SQL statements together to be executed at once inside a transaction:
 
 ```sql

--- a/docs/common/index_gradle_database.md
+++ b/docs/common/index_gradle_database.md
@@ -15,7 +15,7 @@ First apply the gradle plugin in your project.
       databases {
         create("Database") {
           packageName.set("com.example"){% if dialect %}
-          dialect = "{{ dialect }}:{{ versions.sqldelight }}"{% endif %}
+          dialect("{{ dialect }}:{{ versions.sqldelight }}"){% endif %}
         }
       }
     }
@@ -35,7 +35,7 @@ First apply the gradle plugin in your project.
       databases {
         Database { // This will be the name of the generated database class.
           packageName = "com.example"{% if dialect %}
-          dialect = "{{ dialect }}:{{ versions.sqldelight }}"{% endif %}
+          dialect "{{ dialect }}:{{ versions.sqldelight }}"{% endif %}
         }
       }
     }

--- a/docs/common/index_server.md
+++ b/docs/common/index_server.md
@@ -24,8 +24,8 @@ First, configure gradle to use migrations to assemble the schema:
       databases {
         create("Database") {
           ...
-          sourceFolders = listOf("sqldelight")
-          deriveSchemaFromMigrations = true
+          sourceFolders.set(listOf("sqldelight"))
+          deriveSchemaFromMigrations.set(true)
         }
       }
     }

--- a/docs/css/app.css
+++ b/docs/css/app.css
@@ -54,3 +54,42 @@ button.dl {
 .md-typeset table:not([class]) th {
   color: black !important;
 }
+
+.cash-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1em;
+}
+
+.cash-grid-item {
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  width: calc(50% - 0.5em);
+  border: 2px solid var(--md-default-fg-color--light);
+  padding: 1em;
+  border-radius: 8px;
+}
+
+.cash-grid-title {
+  margin: 0;
+  font-size: 1.3em;
+}
+
+.cash-subtle {
+  opacity: 0.62;
+}
+
+.cash-grid-item hr {
+  margin: 0.5em 0;
+}
+
+.sqldelight {
+  color: var(--md-primary-fg-color);
+}
+
+@media only screen and (max-width: 960px) {
+  .cash-grid-item {
+    width: 100%;
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,8 @@
-SQLDelight generates typesafe kotlin APIs from your SQL statements. It verifies your schema, statements, and migrations at compile-time and provides IDE features like autocomplete and refactoring which make writing and maintaining SQL simple.
+!!! info "SQLDelight 2.0"
+
+    If you are currently using SQLDelight 1.x, [check out the docs](upgrading-2.0) on upgrading to SQLDelight 2.0!
+
+SQLDelight generates typesafe Kotlin APIs from your SQL statements. It verifies your schema, statements, and migrations at compile-time and provides IDE features like autocomplete and refactoring which make writing and maintaining SQL simple.
 
 SQLDelight understands your existing SQL schema.
 
@@ -16,26 +20,48 @@ It generates typesafe code for any labeled SQL statements.
 
 ---
 
-SQLDelight supports a variety of dialects and platforms:
+## Supported Dialects and Platforms
 
-SQLite
+SQLDelight supports a variety of SQL dialects and platforms.
 
-* [Android](android_sqlite)
-* [Native (iOS, macOS, or Windows)](native_sqlite)
-* [JVM](jvm_sqlite)
-* [Javascript](js_sqlite)
-* [Multiplatform](multiplatform_sqlite)
-
-[MySQL (JVM)](jvm_mysql)
-
-[PostgreSQL (JVM)](jvm_postgresql) (Experimental)
-
-[HSQL/H2 (JVM)](jvm_h2) (Experimental)
+<div class="cash-grid" markdown="1">
+<div class="cash-grid-item" markdown="1">
+<p class="cash-grid-title" markdown="1">:simple-sqlite:{ .lg .middle } __SQLite__</p>
+<hr />
+[:octicons-arrow-right-24: __Android__](android_sqlite)  
+[:octicons-arrow-right-24: __Native__ (iOS, macOS, Linux, Windows)](native_sqlite)  
+[:octicons-arrow-right-24: __JVM__](jvm_sqlite)  
+[:octicons-arrow-right-24: __JavaScript__ (Browser)](js_sqlite)  
+[:octicons-arrow-right-24: __Multiplatform__](multiplatform_sqlite)  
+</div>
+<div class="cash-grid-item" markdown="1">
+<p class="cash-grid-title" markdown="1">:simple-mysql:{ .lg .middle } __MySQL__</p>
+<hr />
+[:octicons-arrow-right-24: __JVM__ (JDBC)](jvm_mysql)  
+:octicons-arrow-right-24: __JVM__ (R2DBC)  
+</div>
+<div class="cash-grid-item" markdown="1">
+<p class="cash-grid-title" markdown="1">:simple-postgresql:{ .lg .middle } __PostgresSQL__ (Experimental)</p>
+<hr />
+[:octicons-arrow-right-24: __JVM__ (JDBC)](jvm_postgresql)  
+:octicons-arrow-right-24: __JVM__ (R2DBC)  
+[:octicons-link-external-16: __Native__ (macOS, Linux)](https://github.com/hfhbd/postgres-native-sqldelight)
+</div>
+<div class="cash-grid-item" markdown="1">
+<p class="cash-grid-title" markdown="1">__HSQL / H2__<br/>(Experimental)</p>
+<hr />
+[:octicons-arrow-right-24: __JVM__ (JDBC)](jvm_h2)  
+:octicons-arrow-right-24: __JVM__ (R2DBC)  
+</div>
+</div>
 
 ## Snapshots
 
 Snapshots of the development version (including the IDE plugin zip) are available in
 [Sonatype's `snapshots` repository](https://oss.sonatype.org/content/repositories/snapshots/com/squareup/sqldelight/). Note that all coordinates are app.cash.sqldelight instead of com.squareup.sqldelight for 2.0.0+ SNAPSHOTs.
+
+Documentation pages for the latest snapshot version can be [found here](https://cashapp.github.io/sqldelight/snapshot).
+
 === "Kotlin"
     ```kotlin
     // settings.gradle.kts

--- a/docs/jvm_sqlite/index.md
+++ b/docs/jvm_sqlite/index.md
@@ -1,4 +1,4 @@
-Getting Started on JVM with SQLite
+# Getting Started on JVM with SQLite
 
 {% include 'common/index_gradle_database.md' %}
 

--- a/docs/native_sqlite/index.md
+++ b/docs/native_sqlite/index.md
@@ -41,7 +41,11 @@ memory model may be deprecated or removed in future releases.
 Disk databases can (optionally) have multiple reader connections. To configure the reader pool, pass the `maxReaderConnections` parameter to the various constructors of `NativeSqliteDriver`:
 
 ```kotlin
-val driver: SqlDriver = NativeSqliteDriver(Database.Schema, "test.db", maxReaderConnections = 4)
+val driver: SqlDriver = NativeSqliteDriver(
+    Database.Schema, 
+    "test.db", 
+    maxReaderConnections = 4
+)
 ```
 
 Reader connections are only used to run queries outside of a transaction. Any write calls, and anything in a transaction, 

--- a/docs/upgrading-2.0.md
+++ b/docs/upgrading-2.0.md
@@ -1,0 +1,125 @@
+# Upgrading to 2.0
+
+SQLDelight 2.0 makes some breaking changes to the gradle plugin and runtime APIs.
+
+This page lists those breaking changes and their new 2.0 equivalents. 
+For a full list of new features and other changes, see the [changelog](../changelog).
+
+## New Package Name and Artifact Group
+
+All instances of `com.squareup.sqldelight` need to be replaced with `app.cash.sqldelight`.
+
+```diff title="Gradle Dependencies"
+plugins {
+-  id("com.squareup.sqldelight") version "{{ versions.sqldelight }}"
++  id("app.cash.sqldelight") version "{{ versions.sqldelight }}"
+}
+
+dependencies {
+-  implementation("com.squareup.sqldelight:sqlite-driver:{{ versions.sqldelight }}")
++  implementation("app.cash.sqldelight:sqlite-driver:{{ versions.sqldelight }}")
+}
+```
+
+```diff title="In Code"
+-import com.squareup.sqldelight.db.SqlDriver
++import app.cash.sqldelight.db.SqlDriver
+```
+
+## Gradle Configuration Changes
+
+* SQLDelight 2.0 requires Java 11 for building, and Java 8 for the runtime.
+* The SQLDelight configuration API now uses managed properties and a `DomainObjectCollection` for the databases.
+
+    === "Kotlin"
+        ```kotlin 
+        sqldelight {
+          database { // (1)!
+            create("Database") {
+              packageName.set("com.example") // (2)!
+            }
+          }
+        }
+        ```
+        
+        1. New `DomainObjectCollection` wrapper.
+        2. Now a `Property<String>`.
+    === "Groovy"
+        ```kotlin
+        sqldelight {
+          database { // (1)!
+            Database {
+              packageName = "com.example"
+            }
+          }
+        }
+        ```
+        
+        1. New `DomainObjectCollection` wrapper.
+
+* The SQL dialect of your database is now specified using a Gradle dependency.
+
+    === "Kotlin"
+        ```groovy
+        sqldelight {
+          databases {
+            create("MyDatabase") {
+              packageName.set("com.example")
+              dialect("app.cash.sqldelight:mysql-dialect:{{ versions.sqldelight }}")
+              
+              // Version catalogs also work!
+              dialect(libs.sqldelight.dialects.mysql)
+            }  
+          }  
+        }
+        ```
+    === "Groovy"
+        ```groovy
+        sqldelight {
+          databases {
+            MyDatabase {
+              packageName = "com.example"
+              dialect "app.cash.sqldelight:mysql-dialect:{{ versions.sqldelight }}"
+              
+              // Version catalogs also work!
+              dialect libs.sqldelight.dialects.mysql
+            }  
+          }  
+        }
+        ```
+    
+    The currently supported dialects are `mysql-dialect`, `postgresql-dialect`, `hsql-dialect`, `sqlite-3-18-dialect`, `sqlite-3-24-dialect`, `sqlite-3-25-dialect`, `sqlite-3-30-dialect`, `sqlite-3-35-dialect`, and `sqlite-3-38-dialect`
+
+## Runtime Changes
+
+* The `AfterVersionWithDriver` type was removed in favour of [`AfterVersion`](../2.x/runtime/app.cash.sqldelight.db/-after-version) which now always includes the driver, and the `migrateWithCallbacks` extension function was removed in favour of the main [`migrate`](../2.x/runtime/app.cash.sqldelight.db/-sql-schema/#-775472427%2FFunctions%2F-2112917107) method that now accepts callbacks.
+
+    ```diff
+    Database.Schema.{++migrate++}{--WithCallbacks--}(
+      driver = driver,
+      oldVersion = 1,
+      newVersion = Database.Schema.version,
+    -  {--AfterVersionWithDriver(3) { driver ->--}
+    -  {--  driver.execute(null, "INSERT INTO test (value) VALUES('hello')", 0)--}
+    -  {--}--}
+    +  {++AfterVersion(3) { driver ->++}
+    +  {++  driver.execute(null, "INSERT INTO test (value) VALUES('hello')", 0)++}
+    +  {++}++}
+    )
+    ```
+
+* The `Schema` type is no longer a nested type of `SqlDriver`, and is now called [`SqlSchema`](../2.x/runtime/app.cash.sqldelight.db/-sql-schema).
+
+    ```diff
+    -val schema: SqlDriver.Schema
+    +val schema: SqlSchema
+    ```
+  
+* The [paging3 extension API](../2.x/extensions/androidx-paging3/app.cash.sqldelight.paging3/) has changed to only allow int types for the count.
+* The [coroutines extension API](../2.x/extensions/coroutines-extensions/app.cash.sqldelight.coroutines/) now requires a dispatcher to be explicitly passed in.
+    ```diff
+    val players: Flow<List<HockeyPlayer>> =
+      playerQueries.selectAll()
+        .asFlow()
+    +   .mapToList({++Dispatchers.IO++})
+    ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,20 +4,21 @@ repo_name: sqldelight
 repo_url: https://github.com/cashapp/sqldelight
 site_description: "SQLDelight - Generates typesafe Kotlin APIs from SQL"
 site_author: Square, Inc.
-copyright: 'Copyright &copy; 2019 Square, Inc.'
+copyright: 'Copyright &copy; 2023 Square, Inc.'
 remote_branch: gh-pages
 
 nav:
   - 'SQLDelight':
     - 'Overview': index.md
+    - 'Upgrading to 2.0': upgrading-2.0.md
     - 'Changelog': changelog.md
     - 'Contributing': contributing.md
     - 'Code of Conduct': code_of_conduct.md
 
-  - 'Android':
+  - 'SQLite (Android)':
     - 'Getting Started': android_sqlite/index.md
     - 'SQL':
-      - 'Projections': android_sqlite/custom_projections.md
+      - 'Type Projections': android_sqlite/custom_projections.md
       - 'Arguments': android_sqlite/query_arguments.md
       - 'Types': android_sqlite/types.md
       - 'Transactions': android_sqlite/transactions.md
@@ -38,20 +39,13 @@ nav:
         - 'androidx-paging3': 2.x/extensions/androidx-paging3/index.html
         - 'android-driver': 2.x/drivers/android-driver/index.html
         - 'runtime': 2.x/runtime/index.html
-    - '1.x API':
-        - 'coroutines-extensions': 1.x/coroutines-extensions/index.md
-        - 'rxjava2-extensions': 1.x/rxjava2-extensions/index.md
-        - 'rxjava3-extensions': 1.x/rxjava3-extensions/index.md
-        - 'android-paging': 1.x/android-paging/index.md
-        - 'android-driver': 1.x/android-driver/index.md
-        - 'runtime': 1.x/runtime/index.md
     - 'Resources': android_sqlite/resources.md
 
 
-  - 'Multiplatform':
+  - 'SQLite (Multiplatform)':
       - 'Getting Started': multiplatform_sqlite/index.md
       - 'SQL':
-          - 'Projections': multiplatform_sqlite/custom_projections.md
+          - 'Type Projections': multiplatform_sqlite/custom_projections.md
           - 'Arguments': multiplatform_sqlite/query_arguments.md
           - 'Types': multiplatform_sqlite/types.md
           - 'Transactions': multiplatform_sqlite/transactions.md
@@ -65,14 +59,11 @@ nav:
       - '2.x API':
           - 'coroutines-extensions': 2.x/extensions/coroutines-extensions/index.html
           - 'runtime': 2.x/runtime/index.html
-      - '1.x API':
-          - 'coroutines-extensions': 1.x/coroutines-extensions/index.md
-          - 'runtime': 1.x/runtime/index.md
 
   - 'MySQL (JVM)':
       - 'Getting Started': jvm_mysql/index.md
       - 'SQL':
-          - 'Projections': jvm_mysql/custom_projections.md
+          - 'Type Projections': jvm_mysql/custom_projections.md
           - 'Arguments': jvm_mysql/query_arguments.md
           - 'Types': jvm_mysql/types.md
           - 'Transactions': jvm_mysql/transactions.md
@@ -83,14 +74,11 @@ nav:
       - '2.x API':
           - 'jdbc-driver': 2.x/drivers/jdbc-driver/index.html
           - 'runtime': 2.x/runtime/index.html
-      - '1.x API':
-          - 'jdbc-driver': 1.x/jdbc-driver/index.md
-          - 'runtime': 1.x/runtime/index.md
 
   - 'PostgreSQL (JVM)':
       - 'Getting Started': jvm_postgresql/index.md
       - 'SQL':
-          - 'Projections': jvm_postgresql/custom_projections.md
+          - 'Type Projections': jvm_postgresql/custom_projections.md
           - 'Arguments': jvm_postgresql/query_arguments.md
           - 'Types': jvm_postgresql/types.md
           - 'Transactions': jvm_postgresql/transactions.md
@@ -101,14 +89,11 @@ nav:
       - '2.x API':
           - 'jdbc-driver': 2.x/drivers/jdbc-driver/index.html
           - 'runtime': 2.x/runtime/index.html
-      - '1.x API':
-          - 'jdbc-driver': 1.x/jdbc-driver/index.md
-          - 'runtime': 1.x/runtime/index.md
 
   - 'HSQL (JVM)':
       - 'Getting Started': jvm_h2/index.md
       - 'SQL':
-          - 'Projections': jvm_h2/custom_projections.md
+          - 'Type Projections': jvm_h2/custom_projections.md
           - 'Arguments': jvm_h2/query_arguments.md
           - 'Types': jvm_h2/types.md
           - 'Transactions': jvm_h2/transactions.md
@@ -119,14 +104,11 @@ nav:
       - '2.x API':
           - 'jdbc-driver': 2.x/drivers/jdbc-driver/index.html
           - 'runtime': 2.x/runtime/index.html
-      - '1.x API':
-          - 'jdbc-driver': 1.x/jdbc-driver/index.md
-          - 'runtime': 1.x/runtime/index.md
 
   - 'SQLite (Native)':
     - 'Getting Started': native_sqlite/index.md
     - 'SQL':
-        - 'Projections': native_sqlite/custom_projections.md
+        - 'Type Projections': native_sqlite/custom_projections.md
         - 'Arguments': native_sqlite/query_arguments.md
         - 'Types': native_sqlite/types.md
         - 'Transactions': native_sqlite/transactions.md
@@ -140,15 +122,11 @@ nav:
         - 'coroutines-extensions': 2.x/extensions/coroutines-extensions/index.html
         - 'native-driver': 2.x/drivers/native-driver/index.html
         - 'runtime': 2.x/runtime/index.html
-    - '1.x API':
-      - 'coroutines-extensions': 1.x/coroutines-extensions/index.md
-      - 'native-driver': 1.x/native-driver/index.md
-      - 'runtime': 1.x/runtime/index.md
 
   - 'SQLite (JVM)':
     - 'Getting Started': jvm_sqlite/index.md
     - 'SQL':
-        - 'Projections': jvm_sqlite/custom_projections.md
+        - 'Type Projections': jvm_sqlite/custom_projections.md
         - 'Arguments': jvm_sqlite/query_arguments.md
         - 'Types': jvm_sqlite/types.md
         - 'Transactions': jvm_sqlite/transactions.md
@@ -165,19 +143,13 @@ nav:
         - 'rxjava3-extensions': 2.x/extensions/rxjava3-extensions/index.html
         - 'sqlite-driver': 2.x/drivers/sqlite-driver/index.html
         - 'runtime': 2.x/runtime/index.html
-    - '1.x API':
-        - 'coroutines-extensions': 1.x/coroutines-extensions/index.md
-        - 'rxjava2-extensions': 1.x/rxjava2-extensions/index.md
-        - 'rxjava3-extensions': 1.x/rxjava3-extensions/index.md
-        - 'sqlite-driver': 1.x/sqlite-driver/index.md
-        - 'runtime': 1.x/runtime/index.md
 
   - 'SQLite (JS)':
       - 'Getting Started': js_sqlite/index.md
       - 'Multiplatform': js_sqlite/multiplatform.md
       - 'Web Workers': js_sqlite/worker.md
       - 'SQL':
-          - 'Projections': js_sqlite/custom_projections.md
+          - 'Type Projections': js_sqlite/custom_projections.md
           - 'Arguments': js_sqlite/query_arguments.md
           - 'Types': js_sqlite/types.md
           - 'Transactions': js_sqlite/transactions.md
@@ -191,28 +163,8 @@ nav:
           - 'coroutines-extensions': 2.x/extensions/coroutines-extensions/index.html
           - 'sqljs-driver': 2.x/drivers/sqljs-driver/index.html
           - 'runtime': 2.x/runtime/index.html
-      - '1.x API':
-          - 'coroutines-extensions': 1.x/coroutines-extensions/index.md
-          - 'sqljs-driver': 1.x/sqljs-driver/index.md
-          - 'runtime': 1.x/runtime/index.md
 
   - '2.x API': 2.x/index.html
-
-  - '1.x API':
-      - 'android-driver': 1.x/android-driver/index.md
-      - 'android-paging': 1.x/android-paging/index.md
-      - 'coroutines-extensions': 1.x/coroutines-extensions/index.md
-      - 'jdbc-driver': 1.x/jdbc-driver/index.md
-      - 'native-driver': 1.x/native-driver/index.md
-      - 'runtime': 1.x/runtime/index.md
-      - 'rxjava2-extensions': 1.x/rxjava2-extensions/index.md
-      - 'rxjava3-extensions': 1.x/rxjava3-extensions/index.md
-      - 'sqlite-driver': 1.x/sqlite-driver/index.md
-      - 'sqljs-driver': 1.x/sqljs-driver/index.md
-      - 'Internal':
-        - 'sqldelight-compiler': 1.x/sqldelight-compiler/index.md
-        - 'sqldelight-gradle-plugin': 1.x/sqldelight-gradle-plugin/index.md
-        - 'sqlite-migrations': 1.x/sqlite-migrations/index.md
 
 theme:
   name: 'material'
@@ -239,6 +191,8 @@ theme:
   features:
     - navigation.tabs
     - content.tabs.link
+    - content.code.annotate
+    - content.action.view
 
 extra_css:
   - 'css/app.css'
@@ -251,6 +205,17 @@ markdown_extensions:
       guess_lang: false
   - pymdownx.tabbed:
       alternate_style: true
+  - pymdownx.critic
+  - pymdownx.critic
+  - admonition
+  - pymdownx.details
+  - toc:
+      permalink: true
+  - md_in_html
+  - attr_list
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
 
 plugins:
   - search


### PR DESCRIPTION
There may be some breaking changes missing. I'll have to do a full check at some point.

<img width="810" alt="image" src="https://user-images.githubusercontent.com/6743693/215371187-7c045a35-8ee3-4206-b008-00a8d0df7cdd.png">
<img width="795" alt="image" src="https://user-images.githubusercontent.com/6743693/215371279-244de85f-e0e7-4ec6-8c70-efd43b991df4.png">
<img width="823" alt="image" src="https://user-images.githubusercontent.com/6743693/215371209-ccd21313-39ac-44ee-bc78-d85a7f9b1b32.png">

* Add a 2.0 upgrade notice to the index page
<img width="803" alt="image" src="https://user-images.githubusercontent.com/6743693/215371056-32718d14-1210-4c4e-8bf2-8aca3990ab82.png">

* Add a better view of all supported dialects/platforms on the index page (I think we could technically gain access to the insiders version to use the built-in grids feature, but writing my own css seemed quicker than figuring out the access tokens for that).
<img width="804" alt="image" src="https://user-images.githubusercontent.com/6743693/215371132-c06d726f-ce70-4ee3-8942-4f7d7682086c.png">

* Fix missing 2.0 changes in various doc pages
* Add link to snapshot docs
* Add/fix broken titles on various pages