### PR TITLE
Don't use + as sqldelight version in tests

### DIFF
--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -133,6 +133,7 @@ tasks.named('test') {
       excludeCategories 'app.cash.sqldelight.Instrumentation'
     }
   }
+  environment("ORG_GRADLE_PROJECT_sqldelightVersion", project.version)
 }
 
 tasks.named('check') {
@@ -154,6 +155,7 @@ tasks.named('dockerTest') {
       ":drivers:r2dbc-driver:publishAllPublicationsToInstallLocallyRepository",
       ":extensions:async-extensions:publishAllPublicationsToInstallLocallyRepository",
   )
+  environment("ORG_GRADLE_PROJECT_sqldelightVersion", project.version)
 }
 
 tasks.named("grammarkitTest") {
@@ -163,6 +165,7 @@ tasks.named("grammarkitTest") {
       ":runtime:publishKotlinMultiplatformPublicationToInstallLocallyRepository",
       ":runtime:publishJvmPublicationToInstallLocallyRepository",
       ":drivers:sqlite-driver:publishAllPublicationsToInstallLocallyRepository",
+      ":drivers:jdbc-driver:publishAllPublicationsToInstallLocallyRepository",    
       ":sqlite-migrations:publishAllPublicationsToInstallLocallyRepository",
       ":sqldelight-compiler:publishAllPublicationsToInstallLocallyRepository",
       ":sqldelight-gradle-plugin:publishAllPublicationsToInstallLocallyRepository",
@@ -170,6 +173,7 @@ tasks.named("grammarkitTest") {
   javaLauncher = javaToolchains.launcherFor {
     languageVersion = JavaLanguageVersion.of(17)
   }
+  environment("ORG_GRADLE_PROJECT_sqldelightVersion", project.version)
 }
 
 tasks.named('validatePlugins') {

--- a/sqldelight-gradle-plugin/src/grammarkitTest/kotlin/app/cash/sqldelight/GrammarkitDialectIntegrationTests.kt
+++ b/sqldelight-gradle-plugin/src/grammarkitTest/kotlin/app/cash/sqldelight/GrammarkitDialectIntegrationTests.kt
@@ -5,7 +5,7 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.Test
 import java.io.File
 
-class DialectIntegrationTests {
+class GrammarkitDialectIntegrationTests {
   @Test
   fun customFunctionDialect() {
     val runner = GradleRunner.create()

--- a/sqldelight-gradle-plugin/src/test/buildscript.gradle
+++ b/sqldelight-gradle-plugin/src/test/buildscript.gradle
@@ -9,7 +9,7 @@
   }
 
   project.buildscript.dependencies {
-    classpath 'app.cash.sqldelight:gradle-plugin:+'
+    classpath libs.sqldelight
     classpath libs.kotlin.plugin
     classpath libs.android.plugin
   }

--- a/sqldelight-gradle-plugin/src/test/settings.gradle
+++ b/sqldelight-gradle-plugin/src/test/settings.gradle
@@ -6,6 +6,14 @@ dependencyResolutionManagement {
             if (overwriteKotlinVersion != null) {
                 version("kotlin", overwriteKotlinVersion)
             }
+
+            // This version is set in the GradleRunner during test setup using the current (SNAPSHOT) version.
+            // If you want to use the test projects as standalone samples, link the Gradle project in IntelliJ 
+            // and overwrite this version.
+            String sqldelightVersion = settings.sqldelightVersion
+
+            library("sqldelight", "app.cash.sqldelight", "gradle-plugin")
+                    .versionRef(version("sqldelightVersion", sqldelightVersion))
         }
     }
 }


### PR DESCRIPTION
Instead, specify the version explicitly. For example, using `+` does not work when adding the snapshot repo because there is a 2.1.0-SNAPSHOT version.