### PR TITLE
Fix for providing NULL to equality constraint parameters on Postgres

### DIFF
--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
@@ -245,7 +245,7 @@ public class PlayerQueries(
         driver.executeQuery(null, """
     |SELECT *
     |FROM player
-    |WHERE team ${ if (team == null) "IS" else "=" } ?
+    |WHERE team IS NOT DISTINCT FROM ?
     """.trimMargin(), mapper, 1) {
       bindString(0, team?.let { it.name })
     }

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TeamQueries.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TeamQueries.kt
@@ -112,7 +112,7 @@ public class TeamQueries(
         driver.executeQuery(null, """
     |SELECT *
     |FROM team
-    |WHERE inner_type ${ if (inner_type == null) "IS" else "=" } ?
+    |WHERE inner_type IS NOT DISTINCT FROM ?
     """.trimMargin(), mapper, 1) {
       bindString(0, inner_type?.let { teamAdapter.inner_typeAdapter.encode(it) })
     }

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/QueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/QueryGenerator.kt
@@ -191,14 +191,12 @@ abstract class QueryGenerator(
               var symbol = parent.childOfType(SqlTypes.EQ) ?: parent.childOfType(SqlTypes.EQ2)
               val nullableEquality: String
               if (symbol != null) {
-                nullableEquality = "${symbol.leftWhitspace()}IS${symbol.rightWhitespace()}"
+                nullableEquality = "${symbol.leftWhitspace()}IS NOT DISTINCT FROM${symbol.rightWhitespace()}"
               } else {
                 symbol = parent.childOfType(SqlTypes.NEQ) ?: parent.childOfType(SqlTypes.NEQ2)!!
-                nullableEquality = "${symbol.leftWhitspace()}IS NOT${symbol.rightWhitespace()}"
+                nullableEquality = "${symbol.leftWhitspace()}IS DISTINCT FROM${symbol.rightWhitespace()}"
               }
-
-              val block = CodeBlock.of("if (${type.name} == null) \"$nullableEquality\" else \"${symbol.text}\"")
-              replacements.add(symbol.range to "\${ $block }")
+              replacements.add(symbol.range to nullableEquality)
             }
           }
 

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
@@ -830,9 +830,8 @@ class InterfaceGeneration {
       |    }
       |
       |    public override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> =
-      |        driver.executeQuery(null,
-      |        ""${'"'}SELECT * FROM song WHERE album_id ${'$'}{ if (album_id == null) "IS" else "=" } ?""${'"'}, mapper,
-      |        1) {
+      |        driver.executeQuery(null, ""${'"'}SELECT * FROM song WHERE album_id IS NOT DISTINCT FROM ?""${'"'},
+      |        mapper, 1) {
       |      bindLong(0, album_id)
       |    }
       |

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/MutatorQueryFunctionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/MutatorQueryFunctionTest.kt
@@ -184,7 +184,7 @@ class MutatorQueryFunctionTest {
       |  driver.execute(null, ""${'"'}
       |      |UPDATE data
       |      |SET value = ?
-      |      |WHERE value ${"$"}{ if (oldValue == null) "IS" else "=" } ?
+      |      |WHERE value IS NOT DISTINCT FROM ?
       |      ""${'"'}.trimMargin(), 2) {
       |        bindString(0, newValue?.let { data_Adapter.value_Adapter.encode(it) })
       |        bindString(1, oldValue?.let { data_Adapter.value_Adapter.encode(it) })

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/SelectQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/SelectQueryTypeTest.kt
@@ -381,7 +381,7 @@ class SelectQueryTypeTest {
        |    driver.removeListener(listener, arrayOf("socialFeedItem"))
        |  }
        |
-       |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(null, ""${'"'}SELECT * FROM socialFeedItem WHERE message IS NOT NULL AND userId ${"$"}{ if (userId == null) "IS" else "=" } ? ORDER BY datetime(creation_time) DESC""${'"'}, mapper, 1) {
+       |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(null, ""${'"'}SELECT * FROM socialFeedItem WHERE message IS NOT NULL AND userId IS NOT DISTINCT FROM ? ORDER BY datetime(creation_time) DESC""${'"'}, mapper, 1) {
        |    bindString(0, userId)
        |  }
        |
@@ -475,7 +475,7 @@ class SelectQueryTypeTest {
        |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(null, ""${'"'}
        |  |SELECT _id, username
        |  |FROM Friend
-       |  |WHERE userId${'$'}{ if (userId == null) " IS " else "=" }? OR username=? LIMIT 2
+       |  |WHERE userId IS NOT DISTINCT FROM ? OR username=? LIMIT 2
        |  ""${'"'}.trimMargin(), mapper, 2) {
        |    bindString(0, userId)
        |    bindString(1, username)
@@ -586,10 +586,10 @@ class SelectQueryTypeTest {
       |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(null, ""${'"'}
       |  |SELECT *
       |  |FROM data
-      |  |WHERE val ${"$"}{ if (val_ == null) "IS" else "=" } ?
-      |  |AND val ${"$"}{ if (val__ == null) "IS" else "==" } ?
-      |  |AND val ${"$"}{ if (val___ == null) "IS NOT" else "<>" } ?
-      |  |AND val ${"$"}{ if (val____ == null) "IS NOT" else "!=" } ?
+      |  |WHERE val IS NOT DISTINCT FROM ?
+      |  |AND val IS NOT DISTINCT FROM ?
+      |  |AND val IS DISTINCT FROM ?
+      |  |AND val IS DISTINCT FROM ?
       |  |AND val IS ?
       |  |AND val IS NOT ?
       |  ""${'"'}.trimMargin(), mapper, 6) {
@@ -886,10 +886,10 @@ class SelectQueryTypeTest {
       |  }
       |
       |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(null, ""${'"'}
-      |  |WITH child_ids AS (SELECT id FROM data WHERE id ${'$'}{ if (id == null) "IS" else "=" } ?)
+      |  |WITH child_ids AS (SELECT id FROM data WHERE id IS NOT DISTINCT FROM ?)
       |  |SELECT *
       |  |FROM data
-      |  |WHERE id ${'$'}{ if (id == null) "IS" else "=" } ? OR id IN child_ids
+      |  |WHERE id IS NOT DISTINCT FROM ? OR id IN child_ids
       |  |LIMIT ?
       |  |OFFSET ?
       |  ""${'"'}.trimMargin(), mapper, 4) {
@@ -1069,7 +1069,7 @@ class SelectQueryTypeTest {
       |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(null, ""${'"'}
       |  |SELECT *
       |  |FROM data
-      |  |WHERE token ${"$"}{ if (token == null) "IS" else "=" } ? OR ? IS NULL
+      |  |WHERE token IS NOT DISTINCT FROM ? OR ? IS NULL
       |  ""${'"'}.trimMargin(), mapper, 2) {
       |    ${binderCheck}bindString(0, token)
       |    bindString(1, token)

--- a/sqldelight-gradle-plugin/src/test/integration-hsql/src/main/sqldelight/app/cash/sqldelight/hsql/integration/NullableValue.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-hsql/src/main/sqldelight/app/cash/sqldelight/hsql/integration/NullableValue.sq
@@ -1,0 +1,9 @@
+CREATE TABLE nullableValue (
+  val text
+);
+
+insertValue:
+  INSERT INTO nullableValue (val) VALUES (:value);
+
+selectValue:
+  SELECT * FROM nullableValue WHERE val = :value;

--- a/sqldelight-gradle-plugin/src/test/integration-hsql/src/test/kotlin/app/cash/sqldelight/hsql/integration/HsqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-hsql/src/test/kotlin/app/cash/sqldelight/hsql/integration/HsqlTest.kt
@@ -41,4 +41,18 @@ class HsqlTest {
         ),
       )
   }
+
+  @Test fun selectWhereNullable() {
+    database.nullableValueQueries.insertValue("abc")
+    database.nullableValueQueries.insertValue(null)
+
+    assertThat(database.nullableValueQueries.selectValue("abc").executeAsOne())
+      .isEqualTo(
+        NullableValue("abc"),
+      )
+    assertThat(database.nullableValueQueries.selectValue(null).executeAsOne())
+      .isEqualTo(
+        NullableValue(null),
+      )
+  }
 }

--- a/sqldelight-gradle-plugin/src/test/integration-mysql/src/main/sqldelight/app/cash/sqldelight/mysql/integration/NullableValue.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-mysql/src/main/sqldelight/app/cash/sqldelight/mysql/integration/NullableValue.sq
@@ -1,0 +1,9 @@
+CREATE TABLE nullableValue (
+  val text
+);
+
+insertValue:
+  INSERT INTO nullableValue (val) VALUES (:value);
+
+selectValue:
+  SELECT * FROM nullableValue WHERE val = :value;

--- a/sqldelight-gradle-plugin/src/test/integration-mysql/src/test/kotlin/app/cash/sqldelight/mysql/integration/MySqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-mysql/src/test/kotlin/app/cash/sqldelight/mysql/integration/MySqlTest.kt
@@ -22,6 +22,7 @@ class MySqlTest {
   lateinit var connection: Connection
   lateinit var dogQueries: DogQueries
   lateinit var datesQueries: DatesQueries
+  lateinit var nullableValueQueries: NullableValueQueries
   lateinit var driver: JdbcDriver
 
   @Before
@@ -39,6 +40,7 @@ class MySqlTest {
     MyDatabase.Schema.create(driver)
     dogQueries = database.dogQueries
     datesQueries = database.datesQueries
+    nullableValueQueries = database.nullableValueQueries
   }
 
   @After
@@ -121,6 +123,20 @@ class MySqlTest {
         driver.execute(null, "CREATE TABLE throw_test(some Text)", 0, null)
       }
     }
+  }
+
+  @Test fun selectWhereNullable() {
+    nullableValueQueries.insertValue("abc")
+    nullableValueQueries.insertValue(null)
+
+    assertThat(nullableValueQueries.selectValue("abc").executeAsOne())
+      .isEqualTo(
+        NullableValue("abc"),
+      )
+    assertThat(nullableValueQueries.selectValue(null).executeAsOne())
+      .isEqualTo(
+        NullableValue(null),
+      )
   }
 
   private class ExpectedException : Exception()

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/NullableValue.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/NullableValue.sq
@@ -1,0 +1,9 @@
+CREATE TABLE nullableValue (
+  val text
+);
+
+insertValue:
+  INSERT INTO nullableValue (val) VALUES (:value);
+
+selectValue:
+  SELECT * FROM nullableValue WHERE val = :value;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -192,4 +192,18 @@ class PostgreSqlTest {
     val uuid: UUID = database.uuidsQueries.randomUuid().executeAsOne()
     assertThat(uuid).isNotNull()
   }
+
+  @Test fun selectWhereNullable() {
+    database.nullableValueQueries.insertValue("abc")
+    database.nullableValueQueries.insertValue(null)
+
+    assertThat(database.nullableValueQueries.selectValue("abc").executeAsOne())
+      .isEqualTo(
+        NullableValue("abc"),
+      )
+    assertThat(database.nullableValueQueries.selectValue(null).executeAsOne())
+      .isEqualTo(
+        NullableValue(null),
+      )
+  }
 }

--- a/sqldelight-gradle-plugin/src/test/integration-sqlite-3-24/src/main/sqldelight/app/cash/sqldelight/integration/NullableValue.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-sqlite-3-24/src/main/sqldelight/app/cash/sqldelight/integration/NullableValue.sq
@@ -1,0 +1,9 @@
+CREATE TABLE nullableValue (
+  val text
+);
+
+insertValue:
+  INSERT INTO nullableValue (val) VALUES (:value);
+
+selectValue:
+  SELECT * FROM nullableValue WHERE val = :value;

--- a/sqldelight-gradle-plugin/src/test/integration-sqlite-3-24/src/test/java/app/cash/sqldelight/integration/IntegrationTests.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-sqlite-3-24/src/test/java/app/cash/sqldelight/integration/IntegrationTests.kt
@@ -44,4 +44,18 @@ class IntegrationTests {
         Person(4, "Bob", "Bob"),
       )
   }
+
+  @Test fun selectWhereNullable() {
+    database.nullableValueQueries.insertValue("abc")
+    database.nullableValueQueries.insertValue(null)
+
+    assertThat(database.nullableValueQueries.selectValue("abc").executeAsOne())
+      .isEqualTo(
+        NullableValue("abc"),
+      )
+    assertThat(database.nullableValueQueries.selectValue(null).executeAsOne())
+      .isEqualTo(
+        NullableValue(null),
+      )
+  }
 }

--- a/sqldelight-gradle-plugin/src/test/integration-sqlite-3-35/src/main/sqldelight/app/cash/sqldelight/integration/NullableValue.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-sqlite-3-35/src/main/sqldelight/app/cash/sqldelight/integration/NullableValue.sq
@@ -1,0 +1,9 @@
+CREATE TABLE nullableValue (
+  val text
+);
+
+insertValue:
+  INSERT INTO nullableValue (val) VALUES (:value);
+
+selectValue:
+  SELECT * FROM nullableValue WHERE val = :value;

--- a/sqldelight-gradle-plugin/src/test/integration-sqlite-3-35/src/test/java/app/cash/sqldelight/integration/IntegrationTests.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-sqlite-3-35/src/test/java/app/cash/sqldelight/integration/IntegrationTests.kt
@@ -24,4 +24,18 @@ class IntegrationTests {
         Person(1, "Alec", "Strong"),
       )
   }
+
+  @Test fun selectWhereNullable() {
+    database.nullableValueQueries.insertValue("abc")
+    database.nullableValueQueries.insertValue(null)
+
+    assertThat(database.nullableValueQueries.selectValue("abc").executeAsOne())
+      .isEqualTo(
+        NullableValue("abc"),
+      )
+    assertThat(database.nullableValueQueries.selectValue(null).executeAsOne())
+      .isEqualTo(
+        NullableValue(null),
+      )
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/cashapp/sqldelight/issues/3863

SQLDelight currently performs a small transformation of `=` operator to `IS` where the parameter is allowed to be null, presumably intended to improve developer experience. However, the SQL standard defines `IS NULL` and `IS NOT NULL` as a unary operator, and there is no `IS` binary operator, so PostgreSQL has some ground in rejecting syntax `WHERE column IS $1` (see [related issue](https://github.com/cashapp/sqldelight/issues/3863) for more details). 

A standard-compliant approach to solve this is to use `IS [NOT] DISTINCT FROM`, which is what I've implemented here, however unfortunately not every database is standards compliant. Notably, this approach fails for MySQL, which uses `<=>` rather than `IS [NOT] DISTINCT FROM` (see [here](https://modern-sql.com/caniuse/spaceship-operator)). This approach also has the benefit of supporting params on LHS `WHERE :param = column`, but I don't think `WHERE NULL IS column` (current approach) is valid SQL. 

### Outstanding work

Is there a way to add an override for MySQL so it uses `<=>` instead? 
