### PR TITLE
Fix typo

### DIFF
--- a/docs/jvm_mysql/index.md
+++ b/docs/jvm_mysql/index.md
@@ -1,5 +1,5 @@
 ---
-dialect: "app.cash.sqldeight:mysql-dialect"
+dialect: "app.cash.sqldelight:mysql-dialect"
 ---
 # Getting Started with MySQL
 


### PR DESCRIPTION
"delight" was spelled wrong. 

When I copy this from from https://cashapp.github.io/sqldelight/2.0.0-alpha05/jvm_mysql/, I got

   > Could not find app.cash.sqldeight:mysql-dialect:2.0.0-alpha05.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/app/cash/sqldeight/mysql-dialect/2.0.0-alpha05/mysql-dialect-2.0.0-alpha05.pom

With the typo fixed, I was able to install https://repo.maven.apache.org/maven2/app/cash/sqldelight/mysql-dialect/2.0.0-alpha05/mysql-dialect-2.0.0-alpha05.pom