### PR TITLE
Add runtime APIs to support batching

### DIFF
--- a/drivers/web-worker-driver/src/main/kotlin/app/cash/sqldelight/driver/worker/api/WorkerAction.kt
+++ b/drivers/web-worker-driver/src/main/kotlin/app/cash/sqldelight/driver/worker/api/WorkerAction.kt
@@ -8,6 +8,11 @@ internal sealed interface WorkerAction {
     inline val exec: WorkerAction get() = WorkerAction("exec")
 
     /**
+     * Execute a batch of SQL statements.
+     */
+    inline val execBatch: WorkerAction get() = WorkerAction("exec_batch")
+
+    /**
      * Begin a transaction in the underlying SQL implementation.
      */
     inline val beginTransaction: WorkerAction get() = WorkerAction("begin_transaction")

--- a/runtime/src/commonMain/kotlin/app/cash/sqldelight/db/BatchingSqlPreparedStatement.kt
+++ b/runtime/src/commonMain/kotlin/app/cash/sqldelight/db/BatchingSqlPreparedStatement.kt
@@ -1,0 +1,11 @@
+package app.cash.sqldelight.db
+
+/**
+ * A [SqlPreparedStatement] that supports batching.
+ */
+interface BatchingSqlPreparedStatement : SqlPreparedStatement {
+  /**
+   * Adds the current set of bound parameters to the batch of commands that will be executed with this statement.
+   */
+  fun addBatch()
+}

--- a/runtime/src/commonMain/kotlin/app/cash/sqldelight/db/SqlDriver.kt
+++ b/runtime/src/commonMain/kotlin/app/cash/sqldelight/db/SqlDriver.kt
@@ -68,6 +68,25 @@ interface SqlDriver : Closeable {
   ): QueryResult<Long>
 
   /**
+   * Execute a SQL statement in batch mode.
+   *
+   * @param [identifier] An opaque, unique value that can be used to implement any driver-side
+   *   caching of prepared statements. If [identifier] is null, a fresh statement is required.
+   * @param [sql] The SQL string to be executed.
+   * @param [parameters] The number of bindable parameters [sql] contains.
+   * @param [binders] A lambda which is called before execution to bind any parameters to the SQL
+   *   statement and set up the batches.
+   *
+   * @return A list containing the number of rows updated for each batch that was executed.
+   */
+  fun executeBatch(
+    identifier: Int?,
+    sql: String,
+    parameters: Int,
+    binders: (BatchingSqlPreparedStatement.() -> Unit)? = null,
+  ): QueryResult<List<Long>> = throw UnsupportedOperationException()
+
+  /**
    * Start a new [Transacter.Transaction] on the database.
    *
    * It's up to the implementor how this method behaves for different connection/threading patterns.


### PR DESCRIPTION
Implemented `executeBatch()` on both the JDBC and WebWorker drivers.