### PR TITLE
Small Gradle plugin QoL improvements

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
@@ -33,15 +33,9 @@ abstract class SqlDelightDatabase @Inject constructor(
   val migrationOutputFileFormat: Property<String> = project.objects.property(String::class.java).convention(".sql")
   val generateAsync: Property<Boolean> = project.objects.property(Boolean::class.java).convention(false)
 
-  internal val configuration = project.configurations.create("${name}DialectClasspath").apply {
-    isCanBeConsumed = false
-    isVisible = false
-  }
+  internal val configuration = project.configurations.detachedConfiguration()
 
-  internal val moduleConfiguration = project.configurations.create("${name}ModuleClasspath").apply {
-    isCanBeConsumed = false
-    isVisible = false
-  }
+  internal val moduleConfiguration = project.configurations.detachedConfiguration()
 
   internal var addedDialect: Boolean = false
 

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
@@ -24,22 +24,14 @@ abstract class SqlDelightDatabase @Inject constructor(
   val name: String,
 ) {
 
-  init {
-    deriveSchemaFromMigrations.convention(false)
-    verifyMigrations.convention(false)
-    migrationOutputFileFormat.convention(".sql")
-    generateAsync.convention(false)
-    treatNullAsUnknownForEquality.convention(false)
-  }
-
   abstract val packageName: Property<String>
   abstract val schemaOutputDirectory: DirectoryProperty
   abstract val srcDirs: ConfigurableFileCollection
-  abstract val deriveSchemaFromMigrations: Property<Boolean>
-  abstract val verifyMigrations: Property<Boolean>
+  val deriveSchemaFromMigrations: Property<Boolean> = project.objects.property(Boolean::class.java).convention(false)
+  val verifyMigrations: Property<Boolean> = project.objects.property(Boolean::class.java).convention(false)
   abstract val migrationOutputDirectory: DirectoryProperty
-  abstract val migrationOutputFileFormat: Property<String>
-  abstract val generateAsync: Property<Boolean>
+  val migrationOutputFileFormat: Property<String> = project.objects.property(String::class.java).convention(".sql")
+  val generateAsync: Property<Boolean> = project.objects.property(Boolean::class.java).convention(false)
 
   internal val configuration = project.configurations.create("${name}DialectClasspath").apply {
     isCanBeConsumed = false
@@ -99,7 +91,7 @@ abstract class SqlDelightDatabase @Inject constructor(
    * @see <a href="https://github.com/cashapp/sqldelight/issues/1490">sqldelight#1490</a>
    * @see <a href="https://en.wikipedia.org/wiki/Null_%28SQL%29#Null-specific_and_3VL-specific_comparison_predicates">Wikipedia entry on null specific comparisons in SQL</a>
    */
-  abstract val treatNullAsUnknownForEquality: Property<Boolean>
+  val treatNullAsUnknownForEquality: Property<Boolean> = project.objects.property(Boolean::class.java).convention(false)
 
   private val generatedSourcesDirectory
     get() = File(project.buildDir, "generated/sqldelight/code/$name")

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
@@ -33,9 +33,15 @@ abstract class SqlDelightDatabase @Inject constructor(
   val migrationOutputFileFormat: Property<String> = project.objects.property(String::class.java).convention(".sql")
   val generateAsync: Property<Boolean> = project.objects.property(Boolean::class.java).convention(false)
 
-  internal val configuration = project.configurations.detachedConfiguration()
+  internal val configuration = project.configurations.create("${name}DialectClasspath").apply {
+    isCanBeConsumed = false
+    isVisible = false
+  }
 
-  internal val moduleConfiguration = project.configurations.detachedConfiguration()
+  internal val moduleConfiguration = project.configurations.create("${name}ModuleClasspath").apply {
+    isCanBeConsumed = false
+    isVisible = false
+  }
 
   internal var addedDialect: Boolean = false
 

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
@@ -18,6 +18,7 @@ import org.gradle.api.provider.Provider
 import java.io.File
 import javax.inject.Inject
 
+@SqlDelightDsl
 abstract class SqlDelightDatabase @Inject constructor(
   val project: Project,
   val name: String,

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightExtension.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightExtension.kt
@@ -3,6 +3,10 @@ package app.cash.sqldelight.gradle
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.provider.Property
 
+@DslMarker
+annotation class SqlDelightDsl
+
+@SqlDelightDsl
 interface SqlDelightExtension {
   val databases: NamedDomainObjectContainer<SqlDelightDatabase>
   val linkSqlite: Property<Boolean>


### PR DESCRIPTION
Just a few small things I thought I'd toss up for consideration

- Add `@SqlDelightDsl` DSL marker. This prevents accidentally nesting multiple sqldelight DSL calls.
- Use `project.objects` for initializing properties with conventions, allowing `SqlDelightDatabase` to avoid "accessing non-final property in constructor" warnings.
- Use `detachedConfiguration()`, which is functionally achieving the same as before but a first-party API from gradle for accomplishing the same thing (i.e. plugin-internal configurations).