### PR TITLE
Make Kotlin Gradle Plugin compileOnly

### DIFF
--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -78,7 +78,7 @@ dependencies {
     transitive = false
   }
 
-  implementation libs.kotlin.plugin
+  compileOnly libs.kotlin.plugin
   compileOnly libs.android.plugin
 
   implementation libs.jna


### PR DESCRIPTION
Similarly to AGP, I think KGP can be a compileOnly dependency? No strong impact, I was just debugging something and was surprised to see sqldelight pull KGP.