### PR TITLE
Fixes #3915 - Move test dependencies for SQLite-JDBC to version catalog

### DIFF
--- a/sqldelight-gradle-plugin/src/test/integration-sqlite-3-24/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-sqlite-3-24/build.gradle
@@ -24,6 +24,5 @@ sqldelight {
 dependencies {
   implementation libs.sqliteJdbc
   implementation "app.cash.sqldelight:sqlite-driver:${app.cash.sqldelight.VersionKt.VERSION}"
-  implementation "org.xerial:sqlite-jdbc:3.40.1.0"
   implementation libs.truth
 }

--- a/sqldelight-gradle-plugin/src/test/integration-sqlite-3-35/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-sqlite-3-35/build.gradle
@@ -24,6 +24,5 @@ sqldelight {
 dependencies {
   implementation libs.sqliteJdbc
   implementation "app.cash.sqldelight:sqlite-driver:${app.cash.sqldelight.VersionKt.VERSION}"
-  implementation "org.xerial:sqlite-jdbc:3.40.1.0"
   implementation libs.truth
 }

--- a/sqldelight-gradle-plugin/src/test/multithreaded-sqlite/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/multithreaded-sqlite/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-  implementation "org.xerial:sqlite-jdbc:3.40.1.0"
+  implementation libs.sqliteJdbc
   implementation "app.cash.sqldelight:sqlite-driver:${app.cash.sqldelight.VersionKt.VERSION}"
   implementation libs.truth
 }


### PR DESCRIPTION
Fixes #3915 - Deleted two of the `org.xerial:sqlite-jdbc` dependency entries that were duplicates (version catalog entries already existed), and moved the dependency in `multithreaded-sqlite` to use the version catalog entry instead.