### PR TITLE
Support SQLite's VIRTUAL and STORED options on GENERATED columns

### DIFF
--- a/dialects/sqlite-3-18/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_18/grammar/sqlite.bnf
+++ b/dialects/sqlite-3-18/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_18/grammar/sqlite.bnf
@@ -12,9 +12,19 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.DIGIT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.DOT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.TABLE"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.GENERATED"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.ALWAYS"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.AS"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.LP"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.RP"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.VIRTUAL"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.STORED"
   ]
 }
-overrides ::= type_name | bind_parameter | alter_table_stmt
+overrides ::= type_name
+  | bind_parameter
+  | alter_table_stmt
+  | generated_clause
 
 type_name ::= text_data_type | blob_data_type | int_data_type | real_data_type {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlTypeNameImpl"
@@ -38,5 +48,11 @@ alter_table_stmt ::= ALTER TABLE [ {database_name} DOT ] {table_name} {alter_tab
   elementTypeClass = "app.cash.sqldelight.dialects.sqlite_3_18.grammar.mixins.AlterTableElementType"
   stubClass = "com.alecstrong.sql.psi.core.psi.mixins.AlterTableStmtStub"
   pin = 1
+  override = true
+}
+
+generated_clause ::= [ GENERATED ALWAYS ] AS LP <<expr '-1'>> RP [ VIRTUAL | STORED ] {
+  extends = "com.alecstrong.sql.psi.core.psi.impl.SqlGeneratedClauseImpl"
+  implements = "com.alecstrong.sql.psi.core.psi.SqlGeneratedClause"
   override = true
 }

--- a/dialects/sqlite-3-18/src/test/fixtures_sqlite_3_18/generated_columns/Test.s
+++ b/dialects/sqlite-3-18/src/test/fixtures_sqlite_3_18/generated_columns/Test.s
@@ -1,4 +1,7 @@
 CREATE TABLE test (
   id INTEGER,
+  id_stored INTEGER AS (id * 2) STORED,
+  id_virtual INTEGER AS (id * 2) VIRTUAL,
+  id_no_storage INTEGER AS (id * 2),
   id_bigger_than_ten INTEGER GENERATED ALWAYS AS (id > 10) NOT NULL
 );


### PR DESCRIPTION
See https://www.sqlite.org/syntax/column-constraint.html for grammar.

Also makes the prefix for generated columns match SQLite's grammar (`[ GENERATED ALWAYS ] AS ...`) instead of ANSI's (`[ GENERATED ] ALWAYS AS ...`)