### PR TITLE
Fixed bytes in WebWorkerDriver being converted from ByteArray to Array<Byte>

### DIFF
--- a/drivers/web-worker-driver/src/main/kotlin/app/cash/sqldelight/driver/worker/WebWorkerDriver.kt
+++ b/drivers/web-worker-driver/src/main/kotlin/app/cash/sqldelight/driver/worker/WebWorkerDriver.kt
@@ -186,7 +186,7 @@ internal class JsWorkerSqlPreparedStatement : SqlPreparedStatement {
   val parameters = mutableListOf<Any?>()
 
   override fun bindBytes(index: Int, bytes: ByteArray?) {
-    parameters.add(bytes?.toTypedArray())
+    parameters.add(bytes)
   }
 
   override fun bindLong(index: Int, long: Long?) {


### PR DESCRIPTION
Fixed bytes in WebWorkerDriver being converted from ByteArray to Array<Byte> (toTypedArray()) which translates to Array of numbers instead of Int8Array in JS and therefore cannot be read by sqlite-wasm.