### PR TITLE
Dont generate types for virtual tables

### DIFF
--- a/sqldelight-compiler/integration-tests/src/test/kotlin/app/cash/sqldelight/core/integration/IntegrationTest.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/app/cash/sqldelight/core/integration/IntegrationTest.kt
@@ -138,6 +138,14 @@ class IntegrationTest {
         |selectAll:
         |SELECT `index` FROM `group`;
         |
+        |CREATE VIRTUAL TABLE myftstable USING fts5(something, nice);
+        |
+        |CREATE VIRTUAL TABLE myftstable2 USING fts5(something TEXT, nice TEXT);
+        |
+        |selectFromTable2:
+        |SELECT *
+        |FROM myftstable2;
+        |
       """.trimMargin(),
       temporaryFolder,
       "Group.sq",

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/GroupQueries.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/GroupQueries.kt
@@ -3,7 +3,9 @@ package com.example
 import app.cash.sqldelight.Query
 import app.cash.sqldelight.TransacterImpl
 import app.cash.sqldelight.db.SqlDriver
+import kotlin.Any
 import kotlin.Long
+import kotlin.String
 
 public class GroupQueries(
   driver: SqlDriver,
@@ -11,5 +13,23 @@ public class GroupQueries(
   public fun selectAll(): Query<Long> = Query(165688501, arrayOf("group"), driver, "Group.sq",
       "selectAll", "SELECT `index` FROM `group`") { cursor ->
     cursor.getLong(0)!!
+  }
+
+  public fun <T : Any> selectFromTable2(mapper: (something: String?, nice: String?) -> T): Query<T>
+      = Query(-620576550, arrayOf("myftstable2"), driver, "Group.sq", "selectFromTable2", """
+  |SELECT *
+  |FROM myftstable2
+  """.trimMargin()) { cursor ->
+    mapper(
+      cursor.getString(0),
+      cursor.getString(1)
+    )
+  }
+
+  public fun selectFromTable2(): Query<Myftstable2> = selectFromTable2 { something, nice ->
+    Myftstable2(
+      something,
+      nice
+    )
   }
 }

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/SelectFromTable2.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/SelectFromTable2.kt
@@ -1,0 +1,8 @@
+package com.example
+
+import kotlin.String
+
+public data class SelectFromTable2(
+  public val something: String?,
+  public val nice: String?,
+)

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/testmodule/TestDatabaseImpl.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/testmodule/TestDatabaseImpl.kt
@@ -59,6 +59,8 @@ private class TestDatabaseImpl(
           |)
           """.trimMargin(), 0)
       driver.execute(null, "INSERT INTO `group` VALUES (1), (2), (3)", 0)
+      driver.execute(null, "CREATE VIRTUAL TABLE myftstable USING fts5(something, nice)", 0)
+      driver.execute(null, "CREATE VIRTUAL TABLE myftstable2 USING fts5(something, nice)", 0)
       driver.execute(null, """
           |INSERT INTO player
           |VALUES ('Ryan Getzlaf', 15, 'Anaheim Ducks', 'RIGHT'),

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SqlDelightCompiler.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SqlDelightCompiler.kt
@@ -28,6 +28,7 @@ import app.cash.sqldelight.dialect.api.SqlDelightDialect
 import com.alecstrong.sql.psi.core.psi.InvalidElementDetectedException
 import com.alecstrong.sql.psi.core.psi.NamedElement
 import com.alecstrong.sql.psi.core.psi.SqlCreateViewStmt
+import com.alecstrong.sql.psi.core.psi.SqlCreateVirtualTableStmt
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.psi.PsiElement
@@ -135,6 +136,8 @@ object SqlDelightCompiler {
           .writeQueryInterfaces(file, output)
         return@forEach
       }
+
+      if (statement is SqlCreateVirtualTableStmt) return@forEach
 
       val fileSpec = FileSpec.builder(packageName, allocateName(query.tableName))
         .apply {

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/model/NamedQuery.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/model/NamedQuery.kt
@@ -40,6 +40,7 @@ import app.cash.sqldelight.dialect.api.SelectQueryable
 import com.alecstrong.sql.psi.core.psi.NamedElement
 import com.alecstrong.sql.psi.core.psi.QueryElement
 import com.alecstrong.sql.psi.core.psi.SqlCompoundSelectStmt
+import com.alecstrong.sql.psi.core.psi.SqlCreateVirtualTableStmt
 import com.alecstrong.sql.psi.core.psi.SqlExpr
 import com.alecstrong.sql.psi.core.psi.SqlPragmaName
 import com.alecstrong.sql.psi.core.psi.SqlValuesExpression
@@ -123,7 +124,8 @@ data class NamedQuery(
   /**
    * @return true if this query needs its own interface generated.
    */
-  internal fun needsInterface() = needsWrapper() && pureTable == null
+  internal fun needsInterface() = needsWrapper() &&
+    (pureTable == null || pureTable?.parent is SqlCreateVirtualTableStmt)
 
   internal fun needsWrapper() = (resultColumns.size > 1 || resultColumns[0].javaType.isNullable)
 


### PR DESCRIPTION
Closes #4001

You can still query/insert them, they just wont have table-specific types for them.

This enables using virtual tables with incompatible modules / columns that are never used from kotlin