### PR TITLE
Reuse ConnectionManager in migration tasks

### DIFF
--- a/dialects/sqlite-3-18/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_18/SqliteConnectionManager.kt
+++ b/dialects/sqlite-3-18/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_18/SqliteConnectionManager.kt
@@ -3,6 +3,8 @@ package app.cash.sqldelight.dialects.sqlite_3_18
 import app.cash.sqldelight.dialect.api.ConnectionManager
 import app.cash.sqldelight.dialect.api.ConnectionManager.ConnectionProperties
 import com.intellij.openapi.project.Project
+import org.sqlite.SQLiteDataSource
+import java.io.*
 import java.sql.Connection
 import java.sql.DriverManager
 import java.sql.SQLException

--- a/dialects/sqlite-3-18/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_18/SqliteConnectionManager.kt
+++ b/dialects/sqlite-3-18/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_18/SqliteConnectionManager.kt
@@ -3,8 +3,6 @@ package app.cash.sqldelight.dialects.sqlite_3_18
 import app.cash.sqldelight.dialect.api.ConnectionManager
 import app.cash.sqldelight.dialect.api.ConnectionManager.ConnectionProperties
 import com.intellij.openapi.project.Project
-import org.sqlite.SQLiteDataSource
-import java.io.*
 import java.sql.Connection
 import java.sql.DriverManager
 import java.sql.SQLException

--- a/sqldelight-gradle-plugin/src/test/custom-dialect/dialect/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/custom-dialect/dialect/build.gradle
@@ -5,4 +5,5 @@ plugins {
 dependencies {
     api "app.cash.sqldelight:sqlite-3-18-dialect:${app.cash.sqldelight.VersionKt.VERSION}"
     compileOnly libs.intellij.coreImpl
+    compileOnly libs.sqliteJdbc
 }

--- a/sqlite-migrations/build.gradle
+++ b/sqlite-migrations/build.gradle
@@ -12,6 +12,8 @@ dependencies {
   compileOnly libs.schemaCrawler.tools
   compileOnly libs.schemaCrawler.sqlite
 
+  implementation projects.sqldelightCompiler.dialect
+
   implementation libs.sqlPsi
 }
 

--- a/sqlite-migrations/src/main/kotlin/app/cash/sqlite/migrations/CatalogDatabase.kt
+++ b/sqlite-migrations/src/main/kotlin/app/cash/sqlite/migrations/CatalogDatabase.kt
@@ -1,5 +1,6 @@
 package app.cash.sqlite.migrations
 
+import app.cash.sqldelight.dialect.api.ConnectionManager
 import schemacrawler.schema.Catalog
 import schemacrawler.schemacrawler.LimitOptionsBuilder
 import schemacrawler.schemacrawler.LoadOptionsBuilder
@@ -7,8 +8,6 @@ import schemacrawler.schemacrawler.SchemaCrawlerOptionsBuilder
 import schemacrawler.schemacrawler.SchemaInfoLevelBuilder
 import schemacrawler.tools.utility.SchemaCrawlerUtility
 import java.sql.Connection
-import java.sql.DriverManager
-import java.sql.SQLException
 
 class CatalogDatabase private constructor(
   internal val catalog: Catalog,
@@ -28,21 +27,13 @@ class CatalogDatabase private constructor(
           .toOptions(),
       )
 
-    fun withInitStatements(initStatements: List<InitStatement>): CatalogDatabase {
+    fun ConnectionManager.withInitStatements(initStatements: List<InitStatement>): CatalogDatabase {
       return fromFile("", initStatements)
     }
 
-    fun fromFile(path: String, initStatements: List<InitStatement>): CatalogDatabase {
-      return createConnection(path).init(initStatements).use {
+    fun ConnectionManager.fromFile(path: String, initStatements: List<InitStatement>): CatalogDatabase {
+      return getConnection(ConnectionManager.ConnectionProperties("path", path)).init(initStatements).use {
         CatalogDatabase(SchemaCrawlerUtility.getCatalog(it, schemaCrawlerOptions))
-      }
-    }
-
-    private fun createConnection(path: String): Connection {
-      return try {
-        DriverManager.getConnection("jdbc:sqlite:$path")
-      } catch (e: SQLException) {
-        DriverManager.getConnection("jdbc:sqlite:$path")
       }
     }
 


### PR DESCRIPTION
Another PR regarding the VerifyMigrationTask and its classpath... this time reusing the ConnectionManager and its existing dialect api.