### PR TITLE
Add support for IntelliJ 2023.1

### DIFF
--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/SqlDelightFindUsagesHandlerFactory.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/SqlDelightFindUsagesHandlerFactory.kt
@@ -5,6 +5,7 @@ import app.cash.sqldelight.core.lang.SqlDelightFile
 import app.cash.sqldelight.core.lang.psi.StmtIdentifierMixin
 import app.cash.sqldelight.core.lang.queriesName
 import app.cash.sqldelight.core.psi.SqlDelightStmtIdentifier
+import app.cash.sqldelight.intellij.usages.KotlinFindUsagesHandlerFactory
 import com.alecstrong.sql.psi.core.psi.SqlColumnName
 import com.intellij.find.findUsages.FindUsagesHandler
 import com.intellij.find.findUsages.FindUsagesHandlerFactory
@@ -20,7 +21,6 @@ import com.intellij.psi.PsiManager
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.usageView.UsageInfo
 import com.intellij.util.Processor
-import org.jetbrains.kotlin.idea.findUsages.KotlinFindUsagesHandlerFactory
 import org.jetbrains.kotlin.idea.findUsages.KotlinReferenceUsageInfo
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtFile

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/gradle/FileIndexMap.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/gradle/FileIndexMap.kt
@@ -22,6 +22,7 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.ui.EditorNotifications
+import com.intellij.util.lang.ClassPath
 import com.intellij.util.lang.UrlClassLoader
 import org.jetbrains.plugins.gradle.service.execution.GradleExecutionHelper
 import org.jetbrains.plugins.gradle.settings.DistributionType
@@ -100,6 +101,8 @@ internal class FileIndexMap {
                 ?: ExternalSystemJdkUtil.getAvailableJdk(project).second.homePath
               )?.let { File(it) }
 
+            Timber.i("Using JAVA_HOME at %s", javaHome?.absolutePath)
+
             val properties =
               connection.action(FetchProjectModelsBuildAction).setJavaHome(javaHome).run()
 
@@ -135,6 +138,8 @@ internal class FileIndexMap {
         EditorNotifications.getInstance(module.project).updateAllNotifications()
       } catch (externalException: ExternalSystemException) {
         // It's a gradle error, ignore and let the user fix when they try and build the project
+        Timber.i("sqldelight model gen failed")
+        Timber.i(externalException)
 
         FileIndexingNotification.getInstance(project).unconfiguredReason =
           FileIndexingNotification.UnconfiguredReason.Incompatible(
@@ -161,22 +166,45 @@ internal class FileIndexMap {
       val pluginClassLoader = pluginClassLoader as UrlClassLoader
 
       // We need to remove the last loaded dialect as well as add our new one.
-      val files = UrlClassLoader::class.java.getDeclaredField("files").let { field ->
-        field.isAccessible = true
-        val result = field.get(pluginClassLoader) as MutableList<Path>
-        field.isAccessible = false
-        return@let result
+      val files = try {
+        UrlClassLoader::class.java.getDeclaredField("files").let { field ->
+          field.isAccessible = true
+          val result = field.get(pluginClassLoader) as List<Path>
+          field.isAccessible = false
+          return@let result
+        }
+      } catch (e: NoSuchFieldException) {
+        // This is a newer version of IntelliJ that doesn't have the files field on UrlClassLoader,
+        // reflect on Classpath instead.
+        ClassPath::class.java.getDeclaredField("files").let { field ->
+          field.isAccessible = true
+          val result = (field.get(pluginClassLoader.classPath) as Array<Path>).toList()
+          field.isAccessible = false
+          return@let result
+        }
       }
 
-      // Remove the last loaded dialect.
-      previouslyAddedDialect?.let {
-        files.removeAll(it)
-      }
+      // Filter out the last loaded dialect.
+      val filtered = files.filter { it != previouslyAddedDialect }
+      val newClasspath = filtered + dialectPath
       previouslyAddedDialect = dialectPath
 
       // Add the new one in.
-      files.addAll(dialectPath)
-      pluginClassLoader.classPath.reset(files)
+      try {
+        pluginClassLoader.classPath.reset(newClasspath)
+      } catch (e: NoSuchMethodError) {
+        // classPath.reset is hidden in newer versions of IntelliJ, set files reflectively.
+        ClassPath::class.java.getDeclaredMethod("reset").let { method ->
+          method.isAccessible = true
+          method.invoke(pluginClassLoader.classPath)
+          method.isAccessible = false
+        }
+        ClassPath::class.java.getDeclaredField("files").let { field ->
+          field.isAccessible = true
+          field.set(pluginClassLoader.classPath, newClasspath.toTypedArray())
+          field.isAccessible = false
+        }
+      }
 
       return shouldInvalidate
     }

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/usages/KotlinFindUsagesHandlerFactory.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/usages/KotlinFindUsagesHandlerFactory.kt
@@ -1,0 +1,22 @@
+package app.cash.sqldelight.intellij.usages
+
+import com.intellij.find.findUsages.FindUsagesHandler
+import com.intellij.find.findUsages.FindUsagesHandlerFactory
+import com.intellij.find.findUsages.FindUsagesOptions
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+
+interface KotlinFindUsagesHandlerFactory {
+  fun createFindUsagesHandler(element: PsiElement, forHighlightUsages: Boolean): FindUsagesHandler
+  val findFunctionOptions: FindUsagesOptions
+  val findPropertyOptions: FindUsagesOptions
+}
+
+fun KotlinFindUsagesHandlerFactory(project: Project): KotlinFindUsagesHandlerFactory {
+  return try {
+    val factory = Class.forName("org.jetbrains.kotlin.idea.base.searching.usages.KotlinFindUsagesHandlerFactory")
+    ReflectiveKotlinFindUsagesFactory(factory.getConstructor(Project::class.java).newInstance(project) as FindUsagesHandlerFactory)
+  } catch (e: ClassNotFoundException) {
+    LegacyKotlinFindUsagesFactory(org.jetbrains.kotlin.idea.findUsages.KotlinFindUsagesHandlerFactory(project))
+  }
+}

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/usages/LegacyKotlinFindUsagesFactory.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/usages/LegacyKotlinFindUsagesFactory.kt
@@ -1,0 +1,14 @@
+package app.cash.sqldelight.intellij.usages
+
+import com.intellij.find.findUsages.FindUsagesHandler
+import com.intellij.psi.PsiElement
+
+class LegacyKotlinFindUsagesFactory(
+  private val wrapped: org.jetbrains.kotlin.idea.findUsages.KotlinFindUsagesHandlerFactory
+) : KotlinFindUsagesHandlerFactory {
+  override fun createFindUsagesHandler(element: PsiElement, forHighlightUsages: Boolean): FindUsagesHandler {
+    return wrapped.createFindUsagesHandler(element, forHighlightUsages)
+  }
+  override val findFunctionOptions get() = wrapped.findFunctionOptions
+  override val findPropertyOptions get() = wrapped.findPropertyOptions
+}

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/usages/ReflectiveKotlinFindUsagesFactory.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/usages/ReflectiveKotlinFindUsagesFactory.kt
@@ -1,0 +1,21 @@
+package app.cash.sqldelight.intellij.usages
+
+import com.intellij.find.findUsages.FindUsagesHandler
+import com.intellij.find.findUsages.FindUsagesHandlerFactory
+import com.intellij.find.findUsages.FindUsagesOptions
+import com.intellij.psi.PsiElement
+import java.lang.reflect.Method
+
+class ReflectiveKotlinFindUsagesFactory(
+  private val wrapped: FindUsagesHandlerFactory
+) : KotlinFindUsagesHandlerFactory {
+  private val findFunctionOptionsMethod: Method = wrapped.javaClass.getMethod("getFindFunctionOptions")
+  private val findPropertyOptionsMethod: Method = wrapped.javaClass.getMethod("getFindPropertyOptions")
+
+  override fun createFindUsagesHandler(element: PsiElement, forHighlightUsages: Boolean): FindUsagesHandler {
+    return wrapped.createFindUsagesHandler(element, forHighlightUsages)!!
+  }
+
+  override val findFunctionOptions get() = findFunctionOptionsMethod.invoke(wrapped) as FindUsagesOptions
+  override val findPropertyOptions get() = findPropertyOptionsMethod.invoke(wrapped) as FindUsagesOptions
+}


### PR DESCRIPTION
Fixes #4025 

Two incompatibilities:

- `pluginClassLoader` reflection hack didn't work any more - `files` field had been removed and it looks like the functionality now depends on the internal `ClassPath` field. The method is quite naughty indeed :p
- `KotlinFindUsagesHandlerFactory` changed it's package. I added a layer of indirection and some reflection on the newer versions, but there could be better strategies here.

Feedback welcome as both of these are quite ugly hacks!