### PR TITLE
Revert "Update dependency com.squareup:kotlinpoet to v1.13.0"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ androidx-paging3-runtime = { module = "androidx.paging:paging-runtime", version.
 androidx-recyclerView = { module = "androidx.recyclerview:recyclerview", version = "1.3.0" }
 android-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 
-kotlinPoet = { module = "com.squareup:kotlinpoet", version = "1.13.0" }
+kotlinPoet = { module = "com.squareup:kotlinpoet", version = "1.12.0" }
 junit = { module = "junit:junit", version = "4.13.2" }
 jgrapht = { module = "org.jgrapht:jgrapht-core", version = "1.5.1" }
 truth = { module = "com.google.truth:truth", version = "1.1.3" }


### PR DESCRIPTION
Reverts cashapp/sqldelight#4042

We should fix the integer handling first, otherwise following PRs/local testing fails.