### PR TITLE
Make `QueryResult` implementations value classes

### DIFF
--- a/runtime/src/commonMain/kotlin/app/cash/sqldelight/db/QueryResult.kt
+++ b/runtime/src/commonMain/kotlin/app/cash/sqldelight/db/QueryResult.kt
@@ -1,5 +1,7 @@
 package app.cash.sqldelight.db
 
+import kotlin.jvm.JvmInline
+
 /**
  * The returned [value] is the result of a database query or other database operation.
  *
@@ -24,11 +26,13 @@ sealed interface QueryResult<T> {
 
   suspend fun await(): T
 
-  data class Value<T>(override val value: T) : QueryResult<T> {
+  @JvmInline
+  value class Value<T>(override val value: T) : QueryResult<T> {
     override suspend fun await() = value
   }
 
-  class AsyncValue<T>(private inline val getter: suspend () -> T) : QueryResult<T> {
+  @JvmInline
+  value class AsyncValue<T>(private inline val getter: suspend () -> T) : QueryResult<T> {
     override suspend fun await() = getter()
   }
 


### PR DESCRIPTION
Kotlin 1.8 lifted the restriction on generic value classes.

In almost all cases, these classes will still be boxed anyway since the return types of any relevant methods will be the `QueryResult` interface. We _could_ narrow the return types on specific driver implementations, and the Kotlin compiler can statically dispatch method calls to those specialized driver types and keep these classes inlined, but it's not generally applicable.