### PR TITLE
driverFactory variable in docs missing the type of the variable.

### DIFF
--- a/docs/multiplatform_sqlite/index.md
+++ b/docs/multiplatform_sqlite/index.md
@@ -65,7 +65,7 @@ expect class DriverFactory {
   expect fun createDriver(): SqlDriver
 }
 
-fun createDatabase(driverFactory): Database {
+fun createDatabase(driverFactory: DriverFactory): Database {
   val driver = driverFactory.createDriver()
   val database = Database(driver)
 


### PR DESCRIPTION
Had a great day. everything in life is going so well 

woke up today and chose to build a multiplatform app. 

while copy-pasting the code from docs for the sqldelight setup in my multiplatform project

suddenly my brain was trying to figure out why the code from the docs is giving error.

Ah, the missing variable type.  

I'd let others have a great day with this PR.