### PR TITLE
CI: Clean Gradle home before uploading caches & cache dokkaHtml

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -26,11 +26,21 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v3
-      - name: Set up JDK 17
+      # https://github.com/gradle/gradle-build-action/issues/561
+      - name: Create Gradle files
+        run: |
+          cd ~
+          mkdir -p .gradle/ && touch .gradle/gradle.properties
+      - name: Set up Java
+        id: setup-java
         uses: actions/setup-java@v3.11.0
         with:
           distribution: 'zulu'
           java-version: 17
+      - name: Setup Gradle Java installations paths
+        run: |
+          cd ~/.gradle
+          echo "org.gradle.java.installations.paths=${{ steps.setup-java.outputs.path }}" >> gradle.properties
       - name: Setup gradle
         uses: gradle/gradle-build-action@v2
         env:

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -33,6 +33,8 @@ jobs:
           java-version: 17
       - name: Setup gradle
         uses: gradle/gradle-build-action@v2
+        env:
+          GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
 
       - name: Run spotless
         run: ./gradlew spotlessCheck

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -43,8 +43,6 @@ jobs:
           echo "org.gradle.java.installations.paths=${{ steps.setup-java.outputs.path }}" >> gradle.properties
       - name: Setup gradle
         uses: gradle/gradle-build-action@v2
-        env:
-          GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
 
       - name: Run spotless
         run: ./gradlew spotlessCheck

--- a/.github/workflows/Publish-Website.yml
+++ b/.github/workflows/Publish-Website.yml
@@ -26,12 +26,22 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v3
-      - uses: actions/configure-pages@v3  
-      - name: Set up JDK 17
+      - uses: actions/configure-pages@v3
+      # https://github.com/gradle/gradle-build-action/issues/561    
+      - name: Create Gradle files
+        run: |
+          cd ~
+          mkdir -p .gradle/ && touch .gradle/gradle.properties
+      - name: Set up Java
+        id: setup-java
         uses: actions/setup-java@v3.11.0
         with:
           distribution: 'zulu'
           java-version: 17
+      - name: Setup Gradle Java installations paths
+        run: |
+          cd ~/.gradle
+          echo "org.gradle.java.installations.paths=${{ steps.setup-java.outputs.path }}" >> gradle.properties
       - name: Setup gradle
         uses: gradle/gradle-build-action@v2
 

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -32,9 +32,11 @@ jobs:
           java-version: 17
       - name: Setup gradle
         uses: gradle/gradle-build-action@v2
+        with:
+          gradle-home-cache-cleanup: true
 
       - name: Assemble in parallel
-        run: ./gradlew assemble
+        run: ./gradlew assemble dokkaHtml
       - name: Publish the macOS artifacts
         if: matrix.os == 'macOS-latest'
         env:
@@ -73,9 +75,11 @@ jobs:
           java-version: 17
       - name: Setup gradle
         uses: gradle/gradle-build-action@v2
+        with:
+          gradle-home-cache-cleanup: true
 
       - name: Assemble in parallel
-        run: ./gradlew assemble
+        run: ./gradlew assemble dokkaHtml
       - name: Publish the plugin artifacts
         env:
           ORG_GRADLE_PROJECT_SQLDELIGHT_BUGSNAG_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SQLDELIGHT_BUGSNAG_KEY }}

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -25,11 +25,21 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v3
-      - name: Set up JDK 17
+      # https://github.com/gradle/gradle-build-action/issues/561
+      - name: Create Gradle files
+        run: |
+          cd ~
+          mkdir -p .gradle/ && touch .gradle/gradle.properties
+      - name: Set up Java
+        id: setup-java
         uses: actions/setup-java@v3.11.0
         with:
           distribution: 'zulu'
           java-version: 17
+      - name: Setup Gradle Java installations paths
+        run: |
+          cd ~/.gradle
+          echo "org.gradle.java.installations.paths=${{ steps.setup-java.outputs.path }}" >> gradle.properties
       - name: Setup gradle
         uses: gradle/gradle-build-action@v2
         with:
@@ -68,11 +78,21 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v3
-      - name: Set up JDK 17
+      # https://github.com/gradle/gradle-build-action/issues/561
+      - name: Create Gradle files
+        run: |
+          cd ~
+          mkdir -p .gradle/ && touch .gradle/gradle.properties
+      - name: Set up Java
+        id: setup-java
         uses: actions/setup-java@v3.11.0
         with:
           distribution: 'zulu'
           java-version: 17
+      - name: Setup Gradle Java installations paths
+        run: |
+          cd ~/.gradle
+          echo "org.gradle.java.installations.paths=${{ steps.setup-java.outputs.path }}" >> gradle.properties
       - name: Setup gradle
         uses: gradle/gradle-build-action@v2
         with:


### PR DESCRIPTION
Don't execute all tests in the gradle-plugin again during instrumentation, we already test them on linux.
Idea: Put all tests requiring a real device into instrumentationTest and remove the existing `Instrumentation` annotation.