### PR TITLE
Improve async support for Cursors

### DIFF
--- a/drivers/android-driver/src/main/java/app/cash/sqldelight/driver/android/AndroidSqliteDriver.kt
+++ b/drivers/android-driver/src/main/java/app/cash/sqldelight/driver/android/AndroidSqliteDriver.kt
@@ -141,7 +141,7 @@ class AndroidSqliteDriver private constructor(
     createStatement: () -> AndroidStatement,
     binders: (SqlPreparedStatement.() -> Unit)?,
     result: AndroidStatement.() -> T,
-  ): QueryResult<T> {
+  ): QueryResult.Value<T> {
     var statement: AndroidStatement? = null
     if (identifier != null) {
       statement = statements.remove(identifier)
@@ -171,10 +171,10 @@ class AndroidSqliteDriver private constructor(
   override fun <R> executeQuery(
     identifier: Int?,
     sql: String,
-    mapper: (SqlCursor) -> R,
+    mapper: (SqlCursor) -> QueryResult<R>,
     parameters: Int,
     binders: (SqlPreparedStatement.() -> Unit)?,
-  ) = execute(identifier, { AndroidQuery(sql, database, parameters) }, binders) { executeQuery(mapper) }
+  ) = execute(identifier, { AndroidQuery(sql, database, parameters) }, binders) { executeQuery(mapper) }.value
 
   override fun close() {
     statements.evictAll()
@@ -303,7 +303,7 @@ private class AndroidQuery(
 private class AndroidCursor(
   private val cursor: Cursor,
 ) : SqlCursor {
-  override fun next() = cursor.moveToNext()
+  override fun next(): QueryResult.Value<Boolean> = QueryResult.Value(cursor.moveToNext())
   override fun getString(index: Int) = if (cursor.isNull(index)) null else cursor.getString(index)
   override fun getLong(index: Int) = if (cursor.isNull(index)) null else cursor.getLong(index)
   override fun getBytes(index: Int) = if (cursor.isNull(index)) null else cursor.getBlob(index)

--- a/drivers/android-driver/src/main/java/app/cash/sqldelight/driver/android/AndroidSqliteDriver.kt
+++ b/drivers/android-driver/src/main/java/app/cash/sqldelight/driver/android/AndroidSqliteDriver.kt
@@ -174,7 +174,7 @@ class AndroidSqliteDriver private constructor(
     mapper: (SqlCursor) -> QueryResult<R>,
     parameters: Int,
     binders: (SqlPreparedStatement.() -> Unit)?,
-  ) = execute(identifier, { AndroidQuery(sql, database, parameters) }, binders) { executeQuery(mapper) }.value
+  ) = execute(identifier, { AndroidQuery(sql, database, parameters) }, binders) { executeQuery(mapper) }
 
   override fun close() {
     statements.evictAll()
@@ -207,7 +207,7 @@ class AndroidSqliteDriver private constructor(
 
 internal interface AndroidStatement : SqlPreparedStatement {
   fun execute(): Long
-  fun <R> executeQuery(mapper: (SqlCursor) -> R): R
+  fun <R> executeQuery(mapper: (SqlCursor) -> QueryResult<R>): R
   fun close()
 }
 
@@ -238,7 +238,7 @@ private class AndroidPreparedStatement(
     }
   }
 
-  override fun <R> executeQuery(mapper: (SqlCursor) -> R): R = throw UnsupportedOperationException()
+  override fun <R> executeQuery(mapper: (SqlCursor) -> QueryResult<R>): R = throw UnsupportedOperationException()
 
   override fun execute(): Long {
     return statement.executeUpdateDelete().toLong()
@@ -284,9 +284,9 @@ private class AndroidQuery(
 
   override fun execute() = throw UnsupportedOperationException()
 
-  override fun <R> executeQuery(mapper: (SqlCursor) -> R): R {
+  override fun <R> executeQuery(mapper: (SqlCursor) -> QueryResult<R>): R {
     return database.query(this)
-      .use { cursor -> mapper(AndroidCursor(cursor)) }
+      .use { cursor -> mapper(AndroidCursor(cursor)).value }
   }
 
   override fun bindTo(statement: SupportSQLiteProgram) {

--- a/drivers/android-driver/src/test/java/com/squareup/sqldelight/android/AndroidDriverTest.kt
+++ b/drivers/android-driver/src/test/java/com/squareup/sqldelight/android/AndroidDriverTest.kt
@@ -26,12 +26,12 @@ class AndroidDriverTest : DriverTest() {
   fun `cached statement can be reused`() {
     val driver = AndroidSqliteDriver(schema, getApplicationContext(), cacheSize = 1)
     lateinit var bindable: SqlPreparedStatement
-    driver.executeQuery(1, "SELECT * FROM test", {}, 0, { bindable = this })
+    driver.executeQuery(1, "SELECT * FROM test", { QueryResult.Unit }, 0, { bindable = this })
 
     driver.executeQuery(
       1,
       "SELECT * FROM test",
-      {},
+      { QueryResult.Unit },
       0,
       {
         assertSame(bindable, this)
@@ -43,14 +43,14 @@ class AndroidDriverTest : DriverTest() {
   fun `cached statement is evicted and closed`() {
     val driver = AndroidSqliteDriver(schema, getApplicationContext(), cacheSize = 1)
     lateinit var bindable: SqlPreparedStatement
-    driver.executeQuery(1, "SELECT * FROM test", {}, 0, { bindable = this })
+    driver.executeQuery(1, "SELECT * FROM test", { QueryResult.Unit }, 0, { bindable = this })
 
-    driver.executeQuery(2, "SELECT * FROM test", {}, 0)
+    driver.executeQuery(2, "SELECT * FROM test", { QueryResult.Unit }, 0)
 
     driver.executeQuery(
       1,
       "SELECT * FROM test",
-      {},
+      { QueryResult.Unit },
       0,
       {
         assertNotSame(bindable, this)

--- a/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/QueryTest.kt
+++ b/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/QueryTest.kt
@@ -174,7 +174,7 @@ abstract class QueryTest {
 
   private fun testDataQuery(): Query<TestData> {
     return object : Query<TestData>(mapper) {
-      override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> {
+      override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> {
         return driver.executeQuery(0, "SELECT * FROM test", mapper, 0, null)
       }
 

--- a/drivers/native-driver/src/nativeMain/kotlin/app/cash/sqldelight/driver/native/NativeSqlDatabase.kt
+++ b/drivers/native-driver/src/nativeMain/kotlin/app/cash/sqldelight/driver/native/NativeSqlDatabase.kt
@@ -63,14 +63,12 @@ sealed class ConnectionWrapper : SqlDriver {
   final override fun <R> executeQuery(
     identifier: Int?,
     sql: String,
-    mapper: (SqlCursor) -> R,
+    mapper: (SqlCursor) -> QueryResult<R>,
     parameters: Int,
     binders: (SqlPreparedStatement.() -> Unit)?,
-  ): QueryResult<R> = QueryResult.Value(
-    accessStatement(true, identifier, sql, binders) { statement ->
-      mapper(SqliterSqlCursor(statement.query()))
-    },
-  )
+  ): QueryResult<R> = accessStatement(true, identifier, sql, binders) { statement ->
+    mapper(SqliterSqlCursor(statement.query()))
+  }
 }
 
 /**

--- a/drivers/native-driver/src/nativeMain/kotlin/app/cash/sqldelight/driver/native/SqliterSqlCursor.kt
+++ b/drivers/native-driver/src/nativeMain/kotlin/app/cash/sqldelight/driver/native/SqliterSqlCursor.kt
@@ -1,5 +1,6 @@
 package app.cash.sqldelight.driver.native
 
+import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlCursor
 import co.touchlab.sqliter.Cursor
 import co.touchlab.sqliter.getBytesOrNull
@@ -25,5 +26,5 @@ internal class SqliterSqlCursor(private val cursor: Cursor) : SqlCursor {
     return (cursor.getLongOrNull(index) ?: return null) == 1L
   }
 
-  override fun next(): Boolean = cursor.next()
+  override fun next(): QueryResult.Value<Boolean> = QueryResult.Value(cursor.next())
 }

--- a/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/connectionpool/BaseConcurrencyTest.kt
+++ b/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/connectionpool/BaseConcurrencyTest.kt
@@ -20,7 +20,7 @@ abstract class BaseConcurrencyTest {
     return myDriver.executeQuery(
       0,
       "SELECT count(*) FROM test",
-      { it.next(); it.getLong(0)!! },
+      { it.next(); QueryResult.Value(it.getLong(0)!!) },
       0,
     ).value
   }

--- a/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/connectionpool/WalConcurrencyTest.kt
+++ b/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/connectionpool/WalConcurrencyTest.kt
@@ -103,7 +103,7 @@ class WalConcurrencyTest : BaseConcurrencyTest() {
 
   private fun testDataQuery(): Query<TestData> {
     return object : Query<TestData>(mapper) {
-      override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> {
+      override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> {
         return driver.executeQuery(0, "SELECT * FROM test", mapper, 0, null)
       }
 

--- a/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
+++ b/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
@@ -17,7 +17,7 @@ class R2dbcDriver(val connection: Connection) : SqlDriver {
   override fun <R> executeQuery(
     identifier: Int?,
     sql: String,
-    mapper: (SqlCursor) -> R,
+    mapper: (SqlCursor) -> QueryResult<R>,
     parameters: Int,
     binders: (SqlPreparedStatement.() -> Unit)?,
   ): QueryResult<R> {
@@ -32,7 +32,7 @@ class R2dbcDriver(val connection: Connection) : SqlDriver {
         List(rowMetadata.columnMetadatas.size) { index -> row.get(index) }
       }.asFlow().toList()
 
-      return@AsyncValue mapper(R2dbcCursor(rowSet))
+      return@AsyncValue mapper(R2dbcCursor(rowSet)).await()
     }
   }
 
@@ -157,7 +157,7 @@ class R2dbcCursor(val rowSet: List<List<Any?>>) : SqlCursor {
   var row = -1
     private set
 
-  override fun next(): Boolean = ++row < rowSet.size
+  override fun next(): QueryResult.Value<Boolean> = QueryResult.Value(++row < rowSet.size)
 
   override fun getString(index: Int): String? = rowSet[row][index] as String?
 

--- a/drivers/sqljs-driver/src/jsMain/kotlin/app/cash/sqldelight/driver/sqljs/JsSqlDriver.kt
+++ b/drivers/sqljs-driver/src/jsMain/kotlin/app/cash/sqldelight/driver/sqljs/JsSqlDriver.kt
@@ -50,7 +50,7 @@ class JsSqlDriver(private val db: Database) : SqlDriver {
   override fun <R> executeQuery(
     identifier: Int?,
     sql: String,
-    mapper: (SqlCursor) -> R,
+    mapper: (SqlCursor) -> QueryResult<R>,
     parameters: Int,
     binders: (SqlPreparedStatement.() -> Unit)?,
   ): QueryResult<R> {
@@ -60,7 +60,7 @@ class JsSqlDriver(private val db: Database) : SqlDriver {
     }
 
     return try {
-      QueryResult.Value(mapper(cursor))
+      mapper(cursor)
     } finally {
       cursor.close()
     }
@@ -120,7 +120,7 @@ class JsSqlDriver(private val db: Database) : SqlDriver {
 }
 
 private class JsSqlCursor(private val statement: Statement) : SqlCursor {
-  override fun next(): Boolean = statement.step()
+  override fun next(): QueryResult.Value<Boolean> = QueryResult.Value(statement.step())
   override fun getString(index: Int): String? = statement.get()[index]
   override fun getLong(index: Int): Long? = (statement.get()[index] as? Double)?.toLong()
   override fun getBytes(index: Int): ByteArray? = (statement.get()[index] as? Uint8Array)?.let {

--- a/drivers/sqljs-driver/src/jsTest/kotlin/com/squareup/sqldelight/drivers/sqljs/JsQueryTest.kt
+++ b/drivers/sqljs-driver/src/jsTest/kotlin/com/squareup/sqldelight/drivers/sqljs/JsQueryTest.kt
@@ -173,7 +173,7 @@ class JsQueryTest {
 
   private fun SqlDriver.testDataQuery(): Query<TestData> {
     return object : Query<TestData>(mapper) {
-      override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> {
+      override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> {
         return executeQuery(0, "SELECT * FROM test", mapper, 0, null)
       }
 

--- a/drivers/web-worker-driver/src/jsTest/kotlin/app/cash/sqldelight/drivers/worker/WebWorkerDriverTest.kt
+++ b/drivers/web-worker-driver/src/jsTest/kotlin/app/cash/sqldelight/drivers/worker/WebWorkerDriverTest.kt
@@ -78,16 +78,16 @@ class WebWorkerDriverTest {
       driver.await(2, "INSERT INTO test VALUES (?, ?);", 2, binders)
     }
 
-    suspend fun query(mapper: (SqlCursor) -> Unit) {
+    suspend fun query(mapper: suspend (SqlCursor) -> Unit) {
       driver.awaitQuery(3, "SELECT * FROM test", mapper, 0)
     }
 
-    suspend fun changes(mapper: (SqlCursor) -> Long?): Long? {
+    suspend fun changes(mapper: suspend (SqlCursor) -> Long?): Long? {
       return driver.awaitQuery(4, "SELECT changes()", mapper, 0)
     }
 
     query {
-      assertFalse(it.next())
+      assertFalse(it.next().await())
     }
 
     insert {
@@ -96,14 +96,14 @@ class WebWorkerDriverTest {
     }
 
     query {
-      assertTrue(it.next())
-      assertFalse(it.next())
+      assertTrue(it.next().await())
+      assertFalse(it.next().await())
     }
 
     assertEquals(1, changes { it.next(); it.getLong(0) })
 
     query {
-      assertTrue(it.next())
+      assertTrue(it.next().await())
       assertEquals(1, it.getLong(0))
       assertEquals("Alec", it.getString(1))
     }
@@ -115,10 +115,10 @@ class WebWorkerDriverTest {
     assertEquals(1, changes { it.next(); it.getLong(0) })
 
     query {
-      assertTrue(it.next())
+      assertTrue(it.next().await())
       assertEquals(1, it.getLong(0))
       assertEquals("Alec", it.getString(1))
-      assertTrue(it.next())
+      assertTrue(it.next().await())
       assertEquals(2, it.getLong(0))
       assertEquals("Jake", it.getString(1))
     }
@@ -127,7 +127,7 @@ class WebWorkerDriverTest {
     assertEquals(2, changes { it.next(); it.getLong(0) })
 
     query {
-      assertFalse(it.next())
+      assertFalse(it.next().await())
     }
   }
 
@@ -153,7 +153,7 @@ class WebWorkerDriverTest {
     }
     assertEquals(1, changes { it.next(); it.getLong(0) })
 
-    suspend fun query(binders: SqlPreparedStatement.() -> Unit, mapper: (SqlCursor) -> Unit) {
+    suspend fun query(binders: SqlPreparedStatement.() -> Unit, mapper: suspend (SqlCursor) -> Unit) {
       driver.awaitQuery(6, "SELECT * FROM test WHERE value = ?", mapper, 1, binders)
     }
     query(
@@ -161,7 +161,7 @@ class WebWorkerDriverTest {
         bindString(0, "Jake")
       },
       mapper = {
-        assertTrue(it.next())
+        assertTrue(it.next().await())
         assertEquals(2, it.getLong(0))
         assertEquals("Jake", it.getString(1))
       },
@@ -173,7 +173,7 @@ class WebWorkerDriverTest {
         bindString(0, "Jake")
       },
       mapper = {
-        assertTrue(it.next())
+        assertTrue(it.next().await())
         assertEquals(2, it.getLong(0))
         assertEquals("Jake", it.getString(1))
       },
@@ -198,8 +198,8 @@ class WebWorkerDriverTest {
       bindDouble(4, null)
     }
 
-    val mapper: (SqlCursor) -> Unit = {
-      assertTrue(it.next())
+    val mapper: suspend (SqlCursor) -> Unit = {
+      assertTrue(it.next().await())
       assertEquals(1, it.getLong(0))
       assertNull(it.getLong(1))
       assertNull(it.getString(2))
@@ -224,8 +224,8 @@ class WebWorkerDriverTest {
       bindDouble(4, Float.MAX_VALUE.toDouble())
     }
 
-    val mapper: (SqlCursor) -> Unit = {
-      assertTrue(it.next())
+    val mapper: suspend (SqlCursor) -> Unit = {
+      assertTrue(it.next().await())
       assertEquals(1, it.getLong(0))
       assertEquals(Long.MAX_VALUE, it.getLong(1))
       assertEquals("Hello", it.getString(2))

--- a/extensions/androidx-paging3/src/commonMain/kotlin/app/cash/sqldelight/paging3/QueryPagingSource.kt
+++ b/extensions/androidx-paging3/src/commonMain/kotlin/app/cash/sqldelight/paging3/QueryPagingSource.kt
@@ -19,6 +19,7 @@ import app.cash.paging.PagingConfig
 import app.cash.paging.PagingSource
 import app.cash.sqldelight.Query
 import app.cash.sqldelight.Transacter
+import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlCursor
 import kotlin.coroutines.CoroutineContext
 import kotlin.jvm.JvmName
@@ -97,7 +98,7 @@ fun <RowType : Any> QueryPagingSource(
 
 private fun Query<Long>.toInt(): Query<Int> =
   object : Query<Int>({ cursor -> mapper(cursor).toInt() }) {
-    override fun <R> execute(mapper: (SqlCursor) -> R) = this@toInt.execute(mapper)
+    override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>) = this@toInt.execute(mapper)
     override fun addListener(listener: Listener) = this@toInt.addListener(listener)
     override fun removeListener(listener: Listener) = this@toInt.removeListener(listener)
   }

--- a/extensions/androidx-paging3/src/commonTest/kotlin/app/cash/sqldelight/paging3/KeyedQueryPagingSourceTest.kt
+++ b/extensions/androidx-paging3/src/commonTest/kotlin/app/cash/sqldelight/paging3/KeyedQueryPagingSourceTest.kt
@@ -22,6 +22,7 @@ import app.cash.paging.PagingState
 import app.cash.sqldelight.Query
 import app.cash.sqldelight.Transacter
 import app.cash.sqldelight.TransacterImpl
+import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlCursor
 import app.cash.sqldelight.db.SqlDriver
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -143,7 +144,7 @@ class KeyedQueryPagingSourceTest : DbTest {
     """.trimMargin()
 
     return object : Query<Long>({ cursor -> cursor.getLong(0)!! }) {
-      override fun <R> execute(mapper: (SqlCursor) -> R) = driver.executeQuery(identifier = 3, sql = sql, mapper = mapper, parameters = 2) {
+      override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>) = driver.executeQuery(identifier = 3, sql = sql, mapper = mapper, parameters = 2) {
         bindLong(0, limit)
         bindLong(1, anchor)
       }
@@ -163,7 +164,7 @@ class KeyedQueryPagingSourceTest : DbTest {
     return object : Query<Long>(
       { cursor -> cursor.getLong(0)!! },
     ) {
-      override fun <R> execute(mapper: (SqlCursor) -> R) = driver.executeQuery(identifier = 2, sql = sql, mapper = mapper, parameters = 2) {
+      override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>) = driver.executeQuery(identifier = 2, sql = sql, mapper = mapper, parameters = 2) {
         bindLong(0, beginInclusive)
         bindLong(1, endExclusive)
       }

--- a/extensions/androidx-paging3/src/commonTest/kotlin/app/cash/sqldelight/paging3/OffsetQueryPagingSourceTest.kt
+++ b/extensions/androidx-paging3/src/commonTest/kotlin/app/cash/sqldelight/paging3/OffsetQueryPagingSourceTest.kt
@@ -518,7 +518,7 @@ class OffsetQueryPagingSourceTest : DbTest {
       TestItem(cursor.getLong(0)!!)
     },
   ) {
-    override fun <R> execute(mapper: (SqlCursor) -> R) = driver.executeQuery(20, "SELECT id FROM TestItem LIMIT ? OFFSET ?", mapper, 2) {
+    override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>) = driver.executeQuery(20, "SELECT id FROM TestItem LIMIT ? OFFSET ?", mapper, 2) {
       bindLong(0, limit)
       bindLong(1, offset)
     }

--- a/extensions/androidx-paging3/src/commonTest/kotlin/app/cash/sqldelight/paging3/OffsetQueryPagingSourceTest.kt
+++ b/extensions/androidx-paging3/src/commonTest/kotlin/app/cash/sqldelight/paging3/OffsetQueryPagingSourceTest.kt
@@ -31,6 +31,7 @@ import app.cash.paging.PagingState
 import app.cash.sqldelight.Query
 import app.cash.sqldelight.Transacter
 import app.cash.sqldelight.TransacterImpl
+import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlCursor
 import app.cash.sqldelight.db.SqlDriver
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/extensions/async-extensions/src/commonMain/kotlin/app/cash/sqldelight/async/coroutines/DriverExtensions.kt
+++ b/extensions/async-extensions/src/commonMain/kotlin/app/cash/sqldelight/async/coroutines/DriverExtensions.kt
@@ -1,5 +1,6 @@
 package app.cash.sqldelight.async.coroutines
 
+import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlCursor
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlPreparedStatement
@@ -8,10 +9,10 @@ import app.cash.sqldelight.db.SqlSchema
 suspend fun <R> SqlDriver.awaitQuery(
   identifier: Int?,
   sql: String,
-  mapper: (SqlCursor) -> R,
+  mapper: suspend (SqlCursor) -> R,
   parameters: Int,
   binders: (SqlPreparedStatement.() -> Unit)? = null,
-): R = executeQuery<R>(identifier, sql, mapper, parameters, binders).await()
+): R = executeQuery<R>(identifier, sql, { QueryResult.AsyncValue { mapper(it) } }, parameters, binders).await()
 
 suspend fun SqlDriver.await(
   identifier: Int?,

--- a/extensions/async-extensions/src/commonMain/kotlin/app/cash/sqldelight/async/coroutines/QueryExtensions.kt
+++ b/extensions/async-extensions/src/commonMain/kotlin/app/cash/sqldelight/async/coroutines/QueryExtensions.kt
@@ -4,10 +4,20 @@ import app.cash.sqldelight.ExecutableQuery
 import app.cash.sqldelight.db.QueryResult
 
 suspend fun <T : Any> ExecutableQuery<T>.awaitAsList(): List<T> = execute { cursor ->
-  QueryResult.AsyncValue {
-    val result = mutableListOf<T>()
-    while (cursor.next().await()) result.add(mapper(cursor))
-    result
+  val first = cursor.next()
+  val result = mutableListOf<T>()
+
+  // If the cursor isn't async, we want to preserve the blocking semantics and execute it synchronously
+  if (first is QueryResult.AsyncValue) {
+    QueryResult.AsyncValue {
+      if (first.await()) result.add(mapper(cursor)) else return@AsyncValue result
+      while (cursor.next().value) result.add(mapper(cursor))
+      result
+    }
+  } else {
+    if (first.value) result.add(mapper(cursor)) else return@execute QueryResult.Value(result)
+    while (cursor.next().value) result.add(mapper(cursor))
+    QueryResult.Value(result)
   }
 }.await()
 
@@ -17,10 +27,20 @@ suspend fun <T : Any> ExecutableQuery<T>.awaitAsOne(): T {
 }
 
 suspend fun <T : Any> ExecutableQuery<T>.awaitAsOneOrNull(): T? = execute { cursor ->
-  QueryResult.AsyncValue {
-    if (!cursor.next().await()) return@AsyncValue null
+  val next = cursor.next()
+
+  // If the cursor isn't async, we want to preserve the blocking semantics and execute it synchronously
+  if (next is QueryResult.AsyncValue) {
+    QueryResult.AsyncValue {
+      if (!next.await()) return@AsyncValue null
+      val value = mapper(cursor)
+      check(!cursor.next().value) { "ResultSet returned more than 1 row for $this" }
+      value
+    }
+  } else {
+    if (!next.value) return@execute QueryResult.Value(null)
     val value = mapper(cursor)
-    check(!cursor.next().await()) { "ResultSet returned more than 1 row for $this" }
-    value
+    check(!cursor.next().value) { "ResultSet returned more than 1 row for $this" }
+    QueryResult.Value(value)
   }
 }.await()

--- a/extensions/async-extensions/src/commonMain/kotlin/app/cash/sqldelight/async/coroutines/QueryExtensions.kt
+++ b/extensions/async-extensions/src/commonMain/kotlin/app/cash/sqldelight/async/coroutines/QueryExtensions.kt
@@ -11,7 +11,7 @@ suspend fun <T : Any> ExecutableQuery<T>.awaitAsList(): List<T> = execute { curs
   if (first is QueryResult.AsyncValue) {
     QueryResult.AsyncValue {
       if (first.await()) result.add(mapper(cursor)) else return@AsyncValue result
-      while (cursor.next().value) result.add(mapper(cursor))
+      while (cursor.next().await()) result.add(mapper(cursor))
       result
     }
   } else {
@@ -34,7 +34,7 @@ suspend fun <T : Any> ExecutableQuery<T>.awaitAsOneOrNull(): T? = execute { curs
     QueryResult.AsyncValue {
       if (!next.await()) return@AsyncValue null
       val value = mapper(cursor)
-      check(!cursor.next().value) { "ResultSet returned more than 1 row for $this" }
+      check(!cursor.next().await()) { "ResultSet returned more than 1 row for $this" }
       value
     }
   } else {

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/app/cash/sqldelight/coroutines/MappingTest.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/app/cash/sqldelight/coroutines/MappingTest.kt
@@ -48,7 +48,7 @@ class MappingTest : DbTest {
     val expected = IllegalStateException("test exception")
 
     val query = object : Query<Any>({ fail() }) {
-      override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> = throw expected
+      override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> = throw expected
       override fun addListener(listener: Listener) = Unit
       override fun removeListener(listener: Listener) = Unit
     }
@@ -101,7 +101,7 @@ class MappingTest : DbTest {
     val expected = IllegalStateException("test exception")
 
     val query = object : Query<Any>({ fail() }) {
-      override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> = throw expected
+      override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> = throw expected
       override fun addListener(listener: Listener) = Unit
       override fun removeListener(listener: Listener) = Unit
     }
@@ -173,7 +173,7 @@ class MappingTest : DbTest {
     val expected = IllegalStateException("test exception")
 
     val query = object : Query<Any>({ fail() }) {
-      override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> = throw expected
+      override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> = throw expected
       override fun addListener(listener: Listener) = Unit
       override fun removeListener(listener: Listener) = Unit
     }
@@ -225,7 +225,7 @@ class MappingTest : DbTest {
     val expected = IllegalStateException("test exception")
 
     val query = object : Query<Any>({ fail() }) {
-      override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> = throw expected
+      override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> = throw expected
       override fun addListener(listener: Listener) = Unit
       override fun removeListener(listener: Listener) = Unit
     }
@@ -288,7 +288,7 @@ class MappingTest : DbTest {
     val expected = IllegalStateException("test exception")
 
     val query = object : Query<Any>({ fail() }) {
-      override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> = throw expected
+      override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> = throw expected
       override fun addListener(listener: Listener) = Unit
       override fun removeListener(listener: Listener) = Unit
     }

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/app/cash/sqldelight/coroutines/QueryAssert.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/app/cash/sqldelight/coroutines/QueryAssert.kt
@@ -16,6 +16,7 @@
 package app.cash.sqldelight.coroutines
 
 import app.cash.sqldelight.Query
+import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlCursor
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -24,7 +25,7 @@ fun <T : Any> Query<T>.assert(body: QueryAssert.() -> Unit) {
   execute { cursor ->
     QueryAssert(cursor).apply(body)
     val remainingRows = mutableListOf<String>()
-    while (cursor.next()) {
+    while (cursor.next().value) {
       remainingRows += buildString {
         try {
           for (i in 0..Int.MAX_VALUE) {
@@ -39,6 +40,7 @@ fun <T : Any> Query<T>.assert(body: QueryAssert.() -> Unit) {
       }
     }
     assertEquals(emptyList<String>(), remainingRows, "remaining cursor rows")
+    QueryResult.Unit
   }
 }
 
@@ -48,7 +50,7 @@ class QueryAssert(private val cursor: SqlCursor) {
   fun hasRow(vararg values: String) {
     row += 1
 
-    assertTrue(cursor.next(), "row $row does not exist")
+    assertTrue(cursor.next().value, "row $row does not exist")
     for (i in values.indices) {
       assertEquals(values[i], cursor.getString(i), "row $row column '$i'")
     }

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/app/cash/sqldelight/coroutines/TestDb.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/app/cash/sqldelight/coroutines/TestDb.kt
@@ -33,7 +33,7 @@ class TestDb(
 
   fun <T : Any> createQuery(key: String, query: String, mapper: (SqlCursor) -> T): Query<T> {
     return object : Query<T>(mapper) {
-      override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> {
+      override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> {
         return db.executeQuery(null, query, mapper, 0, null)
       }
 
@@ -71,9 +71,9 @@ class TestDb(
     notify(TABLE_EMPLOYEE)
     // last_insert_rowid is connection-specific, so run it in the transaction thread/connection
     return transactionWithResult {
-      val mapper: (SqlCursor) -> Long = {
+      val mapper: (SqlCursor) -> QueryResult<Long> = {
         it.next()
-        it.getLong(0)!!
+        QueryResult.Value(it.getLong(0)!!)
       }
       db.executeQuery(2, "SELECT last_insert_rowid()", mapper, 0).value
     }
@@ -98,9 +98,9 @@ class TestDb(
     notify(TABLE_MANAGER)
     // last_insert_rowid is connection-specific, so run it in the transaction thread/connection
     return transactionWithResult {
-      val mapper: (SqlCursor) -> Long = {
+      val mapper: (SqlCursor) -> QueryResult<Long> = {
         it.next()
-        it.getLong(0)!!
+        QueryResult.Value(it.getLong(0)!!)
       }
       db.executeQuery(2, "SELECT last_insert_rowid()", mapper, 0).value
     }

--- a/extensions/rxjava2-extensions/src/test/kotlin/app/cash/sqldelight/rx2/QueryObservableTest.kt
+++ b/extensions/rxjava2-extensions/src/test/kotlin/app/cash/sqldelight/rx2/QueryObservableTest.kt
@@ -1,6 +1,7 @@
 package app.cash.sqldelight.rx2
 
 import app.cash.sqldelight.Query
+import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlCursor
 import app.cash.sqldelight.rx2.Employee.Companion.SELECT_EMPLOYEES
 import app.cash.sqldelight.rx2.TestDb.Companion.TABLE_EMPLOYEE
@@ -13,7 +14,7 @@ class QueryObservableTest {
     val error = IllegalStateException("test exception")
 
     val query = object : Query<Any>({ throw AssertionError("Must not be called") }) {
-      override fun <R> execute(mapper: (SqlCursor) -> R) = throw error
+      override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>) = throw error
       override fun addListener(listener: Listener) = throw error
       override fun removeListener(listener: Listener) = throw error
     }
@@ -42,7 +43,7 @@ class QueryObservableTest {
     val queriesWithListeners = mutableListOf<Query.Listener>()
 
     val query = object : Query<Any>({ throw AssertionError("Must not be called") }) {
-      override fun <R> execute(mapper: (SqlCursor) -> R) = error("Must not be called")
+      override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>) = error("Must not be called")
       override fun addListener(listener: Listener) = error("Must not be called")
       override fun removeListener(listener: Listener) = error("Must not be called")
     }

--- a/extensions/rxjava2-extensions/src/test/kotlin/app/cash/sqldelight/rx2/RecordingObserver.kt
+++ b/extensions/rxjava2-extensions/src/test/kotlin/app/cash/sqldelight/rx2/RecordingObserver.kt
@@ -16,6 +16,7 @@
 package app.cash.sqldelight.rx2
 
 import app.cash.sqldelight.Query
+import app.cash.sqldelight.db.QueryResult
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import io.reactivex.observers.DisposableObserver
@@ -37,9 +38,9 @@ internal class RecordingObserver(val numberOfColumns: Int) : DisposableObserver<
   override fun onNext(value: Query<*>) {
     val allRows = value.execute { cursor ->
       val data = mutableListOf<List<String?>>()
-      while (cursor.next())
+      while (cursor.next().value)
         data.add((0 until numberOfColumns).map(cursor::getString))
-      data
+      QueryResult.Value(data)
     }.value
     events.add(allRows)
   }

--- a/extensions/rxjava2-extensions/src/test/kotlin/app/cash/sqldelight/rx2/TestDb.kt
+++ b/extensions/rxjava2-extensions/src/test/kotlin/app/cash/sqldelight/rx2/TestDb.kt
@@ -32,7 +32,7 @@ class TestDb(
 
   fun <T : Any> createQuery(key: String, query: String, mapper: (SqlCursor) -> T): Query<T> {
     return object : Query<T>(mapper) {
-      override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> {
+      override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> {
         return db.executeQuery(null, query, mapper, 0)
       }
 
@@ -144,7 +144,7 @@ data class Employee(val username: String, val name: String) {
   }
 }
 
-private fun getLong(cursor: SqlCursor): Long {
-  check(cursor.next())
-  return cursor.getLong(0)!!
+private fun getLong(cursor: SqlCursor): QueryResult<Long> {
+  check(cursor.next().value)
+  return QueryResult.Value(cursor.getLong(0)!!)
 }

--- a/extensions/rxjava3-extensions/src/test/kotlin/app/cash/sqldelight/rx3/QueryObservableTest.kt
+++ b/extensions/rxjava3-extensions/src/test/kotlin/app/cash/sqldelight/rx3/QueryObservableTest.kt
@@ -1,6 +1,7 @@
 package app.cash.sqldelight.rx3
 
 import app.cash.sqldelight.Query
+import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlCursor
 import app.cash.sqldelight.rx3.Employee.Companion.SELECT_EMPLOYEES
 import app.cash.sqldelight.rx3.TestDb.Companion.TABLE_EMPLOYEE
@@ -13,7 +14,7 @@ class QueryObservableTest {
     val error = IllegalStateException("test exception")
 
     val query = object : Query<Any>({ throw AssertionError("Must not be called") }) {
-      override fun <R> execute(mapper: (SqlCursor) -> R) = throw error
+      override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>) = throw error
       override fun addListener(listener: Listener) = throw error
       override fun removeListener(listener: Listener) = throw error
     }
@@ -42,7 +43,7 @@ class QueryObservableTest {
     val queriesWithListeners = mutableListOf<Query.Listener>()
 
     val query = object : Query<Any>({ throw AssertionError("Must not be called") }) {
-      override fun <R> execute(mapper: (SqlCursor) -> R) = error("Must not be called")
+      override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>) = error("Must not be called")
       override fun addListener(listener: Listener) = error("Must not be called")
       override fun removeListener(listener: Listener) = error("Must not be called")
     }

--- a/extensions/rxjava3-extensions/src/test/kotlin/app/cash/sqldelight/rx3/RecordingObserver.kt
+++ b/extensions/rxjava3-extensions/src/test/kotlin/app/cash/sqldelight/rx3/RecordingObserver.kt
@@ -16,6 +16,7 @@
 package app.cash.sqldelight.rx3
 
 import app.cash.sqldelight.Query
+import app.cash.sqldelight.db.QueryResult
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import io.reactivex.rxjava3.observers.DisposableObserver
@@ -37,9 +38,9 @@ internal class RecordingObserver(val numberOfColumns: Int) : DisposableObserver<
   override fun onNext(value: Query<*>) {
     val allRows = value.execute { cursor ->
       val data = mutableListOf<List<String?>>()
-      while (cursor.next())
+      while (cursor.next().value)
         data.add((0 until numberOfColumns).map(cursor::getString))
-      data
+      QueryResult.Value(data)
     }.value
     events.add(allRows)
   }

--- a/extensions/rxjava3-extensions/src/test/kotlin/app/cash/sqldelight/rx3/TestDb.kt
+++ b/extensions/rxjava3-extensions/src/test/kotlin/app/cash/sqldelight/rx3/TestDb.kt
@@ -31,7 +31,7 @@ class TestDb(
 
   fun <T : Any> createQuery(key: String, query: String, mapper: (SqlCursor) -> T): Query<T> {
     return object : Query<T>(mapper) {
-      override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> {
+      override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> {
         return db.executeQuery(null, query, mapper, 0)
       }
 
@@ -143,7 +143,7 @@ data class Employee(val username: String, val name: String) {
   }
 }
 
-private fun getLong(cursor: SqlCursor): Long {
-  check(cursor.next())
-  return cursor.getLong(0)!!
+private fun getLong(cursor: SqlCursor): QueryResult<Long> {
+  check(cursor.next().value)
+  return QueryResult.Value(cursor.getLong(0)!!)
 }

--- a/runtime/src/commonMain/kotlin/app/cash/sqldelight/db/SqlCursor.kt
+++ b/runtime/src/commonMain/kotlin/app/cash/sqldelight/db/SqlCursor.kt
@@ -26,7 +26,7 @@ interface SqlCursor {
    * @return true if the cursor successfully moved to a new row, false if there was no row to
    *   iterate to.
    */
-  fun next(): Boolean
+  fun next(): QueryResult<Boolean>
 
   /**
    * @return The string or null value of column [index] for the current row of the result set.

--- a/runtime/src/commonMain/kotlin/app/cash/sqldelight/db/SqlDriver.kt
+++ b/runtime/src/commonMain/kotlin/app/cash/sqldelight/db/SqlDriver.kt
@@ -40,7 +40,7 @@ interface SqlDriver : Closeable {
   fun <R> executeQuery(
     identifier: Int?,
     sql: String,
-    mapper: (SqlCursor) -> R,
+    mapper: (SqlCursor) -> QueryResult<R>,
     parameters: Int,
     binders: (SqlPreparedStatement.() -> Unit)? = null,
   ): QueryResult<R>

--- a/runtime/src/commonMain/kotlin/app/cash/sqldelight/logs/LogSqliteDriver.kt
+++ b/runtime/src/commonMain/kotlin/app/cash/sqldelight/logs/LogSqliteDriver.kt
@@ -45,7 +45,7 @@ class LogSqliteDriver(
   override fun <R> executeQuery(
     identifier: Int?,
     sql: String,
-    mapper: (SqlCursor) -> R,
+    mapper: (SqlCursor) -> QueryResult<R>,
     parameters: Int,
     binders: (SqlPreparedStatement.() -> Unit)?,
   ): QueryResult<R> {

--- a/runtime/src/commonTest/kotlin/com/squareup/sqldelight/logs/LogSqliteDriverTest.kt
+++ b/runtime/src/commonTest/kotlin/com/squareup/sqldelight/logs/LogSqliteDriverTest.kt
@@ -52,7 +52,7 @@ class LogSqliteDriverTest {
   @Test
   fun queryLogsAreCorrect() {
     val query = {
-      driver.executeQuery(3, "SELECT * FROM test", {}, 0)
+      driver.executeQuery(3, "SELECT * FROM test", { QueryResult.Unit }, 0)
     }
 
     query()
@@ -90,11 +90,11 @@ class FakeSqlDriver : SqlDriver {
   override fun <R> executeQuery(
     identifier: Int?,
     sql: String,
-    mapper: (SqlCursor) -> R,
+    mapper: (SqlCursor) -> QueryResult<R>,
     parameters: Int,
     binders: (SqlPreparedStatement.() -> Unit)?,
   ): QueryResult<R> {
-    return QueryResult.Value(mapper(FakeSqlCursor()))
+    return mapper(FakeSqlCursor())
   }
 
   override fun execute(
@@ -128,8 +128,8 @@ class FakeSqlDriver : SqlDriver {
 }
 
 class FakeSqlCursor : SqlCursor {
-  override fun next(): Boolean {
-    return false
+  override fun next(): QueryResult.Value<Boolean> {
+    return QueryResult.Value(false)
   }
 
   override fun getString(index: Int): String? {

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
@@ -208,7 +208,7 @@ public class PlayerQueries(
     public val shoots: Shoots,
     mapper: (SqlCursor) -> T,
   ) : ExecutableQuery<T>(mapper) {
-    public override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> =
+    public override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> =
         transactionWithResult {
       driver.execute(-452007405, """
           |INSERT INTO player
@@ -241,7 +241,7 @@ public class PlayerQueries(
       driver.removeListener(listener, arrayOf("player"))
     }
 
-    public override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> =
+    public override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> =
         driver.executeQuery(null, """
     |SELECT *
     |FROM player
@@ -265,7 +265,7 @@ public class PlayerQueries(
       driver.removeListener(listener, arrayOf("player"))
     }
 
-    public override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> {
+    public override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> {
       val numberIndexes = createArguments(count = number.size)
       return driver.executeQuery(null, """
           |SELECT *

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TeamQueries.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TeamQueries.kt
@@ -84,7 +84,7 @@ public class TeamQueries(
       driver.removeListener(listener, arrayOf("team"))
     }
 
-    public override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> =
+    public override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> =
         driver.executeQuery(1839882838, """
     |SELECT name, captain
     |FROM team
@@ -108,7 +108,7 @@ public class TeamQueries(
       driver.removeListener(listener, arrayOf("team"))
     }
 
-    public override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> =
+    public override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> =
         driver.executeQuery(null, """
     |SELECT *
     |FROM team

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SelectQueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SelectQueryGenerator.kt
@@ -305,9 +305,11 @@ class SelectQueryGenerator(
 
     val genericResultType = TypeVariableName("R")
     val createStatementFunction = FunSpec.builder(EXECUTE_METHOD)
-      .addModifiers(OVERRIDE)
+      .addModifiers(
+        OVERRIDE,
+      )
       .addTypeVariable(genericResultType)
-      .addParameter(MAPPER_NAME, LambdaTypeName.get(parameters = arrayOf(CURSOR_TYPE), returnType = genericResultType))
+      .addParameter(MAPPER_NAME, LambdaTypeName.get(parameters = arrayOf(CURSOR_TYPE), returnType = QUERY_RESULT_TYPE.parameterizedBy(genericResultType)))
       .returns(QUERY_RESULT_TYPE.parameterizedBy(genericResultType))
       .addCode(executeBlock())
 

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueriesTypeTest.kt
@@ -198,7 +198,7 @@ class QueriesTypeTest {
       |      driver.removeListener(listener, arrayOf("data"))
       |    }
       |
-      |    public override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> =
+      |    public override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> =
       |        driver.executeQuery(${select.id}, ""${'"'}
       |    |SELECT *
       |    |FROM data
@@ -532,7 +532,7 @@ class QueriesTypeTest {
       |      driver.removeListener(listener, arrayOf("data"))
       |    }
       |
-      |    public override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> =
+      |    public override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> =
       |        driver.executeQuery(${select.id}, ""${'"'}
       |    |SELECT *
       |    |FROM data
@@ -688,7 +688,7 @@ class QueriesTypeTest {
       |      driver.removeListener(listener, arrayOf("search"))
       |    }
       |
-      |    public override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> =
+      |    public override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> =
       |        driver.executeQuery(${offsets.id}, ""${'"'}
       |    |SELECT id, offsets(search)
       |    |FROM search

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/async/AsyncQueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/async/AsyncQueriesTypeTest.kt
@@ -201,7 +201,7 @@ class AsyncQueriesTypeTest {
       |      driver.removeListener(listener, arrayOf("data"))
       |    }
       |
-      |    public override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> =
+      |    public override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> =
       |        driver.executeQuery(${select.id}, ""${'"'}
       |    |SELECT *
       |    |FROM data

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
@@ -829,7 +829,7 @@ class InterfaceGeneration {
       |      driver.removeListener(listener, arrayOf("song"))
       |    }
       |
-      |    public override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> =
+      |    public override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> =
       |        driver.executeQuery(null,
       |        ""${'"'}SELECT * FROM song WHERE album_id ${'$'}{ if (album_id == null) "IS" else "=" } ?""${'"'}, mapper,
       |        1) {
@@ -928,7 +928,7 @@ class InterfaceGeneration {
       |      driver.removeListener(listener, arrayOf("userEntity"))
       |    }
       |
-      |    public override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> =
+      |    public override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> =
       |        driver.executeQuery(${result.compiledFile.namedQueries[0].id}, ""${'"'}
       |    |WITH inserted_ids AS (
       |    |  INSERT INTO userEntity(slack_user_id)
@@ -1042,7 +1042,7 @@ class InterfaceGeneration {
       |      driver.removeListener(listener, arrayOf("item"))
       |    }
       |
-      |    public override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> =
+      |    public override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> =
       |        driver.executeQuery(${query.id}, ""${'"'}
       |    |WITH RECURSIVE
       |    |descendants AS (

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/SelectQueryFunctionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/SelectQueryFunctionTest.kt
@@ -303,7 +303,7 @@ class SelectQueryFunctionTest {
       |    driver.removeListener(listener, arrayOf("data"))
       |  }
       |
-      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> {
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> {
       |    val goodIndexes = createArguments(count = good.size)
       |    val badIndexes = createArguments(count = bad.size)
       |    return driver.executeQuery(null, ""${'"'}
@@ -392,7 +392,7 @@ class SelectQueryFunctionTest {
       |    driver.removeListener(listener, arrayOf("person"))
       |  }
       |
-      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${query.id}, ""${'"'}
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${query.id}, ""${'"'}
       |  |SELECT *
       |  |FROM person
       |  |WHERE first_name = ? AND last_name = ?

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/SelectQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/SelectQueryTypeTest.kt
@@ -144,7 +144,7 @@ class SelectQueryTypeTest {
       |    driver.removeListener(listener, arrayOf("data"))
       |  }
       |
-      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${query.id}, ""${'"'}
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${query.id}, ""${'"'}
       |  |SELECT *
       |  |FROM data
       |  |WHERE id = ?
@@ -177,7 +177,7 @@ class SelectQueryTypeTest {
       |private inner class SelectWithoutFromQuery<out T : kotlin.Any>(
       |  mapper: (app.cash.sqldelight.db.SqlCursor) -> T,
       |) : app.cash.sqldelight.ExecutableQuery<T>(mapper) {
-      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${query.id}, ""${'"'}SELECT 42""${'"'}, mapper, 0)
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${query.id}, ""${'"'}SELECT 42""${'"'}, mapper, 0)
       |
       |  public override fun toString(): kotlin.String = "Test.sq:selectWithoutFrom"
       |}
@@ -221,7 +221,7 @@ class SelectQueryTypeTest {
       |    driver.removeListener(listener, arrayOf("data"))
       |  }
       |
-      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${query.id}, ""${'"'}
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${query.id}, ""${'"'}
       |  |SELECT *
       |  |FROM data
       |  |WHERE id = ?
@@ -270,7 +270,7 @@ class SelectQueryTypeTest {
       |    driver.removeListener(listener, arrayOf("data"))
       |  }
       |
-      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> {
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> {
       |    val idIndexes = createArguments(count = id.size)
       |    return driver.executeQuery(null, ""${'"'}
       |        |SELECT *
@@ -324,7 +324,7 @@ class SelectQueryTypeTest {
       |    driver.removeListener(listener, arrayOf("data"))
       |  }
       |
-      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> {
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> {
       |    val idIndexes = createArguments(count = id.size)
       |    return driver.executeQuery(null, ""${'"'}
       |        |SELECT *
@@ -381,7 +381,7 @@ class SelectQueryTypeTest {
        |    driver.removeListener(listener, arrayOf("socialFeedItem"))
        |  }
        |
-       |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(null, ""${'"'}SELECT * FROM socialFeedItem WHERE message IS NOT NULL AND userId ${"$"}{ if (userId == null) "IS" else "=" } ? ORDER BY datetime(creation_time) DESC""${'"'}, mapper, 1) {
+       |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(null, ""${'"'}SELECT * FROM socialFeedItem WHERE message IS NOT NULL AND userId ${"$"}{ if (userId == null) "IS" else "=" } ? ORDER BY datetime(creation_time) DESC""${'"'}, mapper, 1) {
        |    bindString(0, userId)
        |  }
        |
@@ -424,7 +424,7 @@ class SelectQueryTypeTest {
        |    driver.removeListener(listener, arrayOf("socialFeedItem"))
        |  }
        |
-       |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${treatNullAsUnknownQuery.id}, ""${'"'}SELECT * FROM socialFeedItem WHERE message IS NOT NULL AND userId = ? ORDER BY datetime(creation_time) DESC""${'"'}, mapper, 1) {
+       |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${treatNullAsUnknownQuery.id}, ""${'"'}SELECT * FROM socialFeedItem WHERE message IS NOT NULL AND userId = ? ORDER BY datetime(creation_time) DESC""${'"'}, mapper, 1) {
        |    bindString(0, userId)
        |  }
        |
@@ -472,7 +472,7 @@ class SelectQueryTypeTest {
        |    driver.removeListener(listener, arrayOf("Friend"))
        |  }
        |
-       |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(null, ""${'"'}
+       |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(null, ""${'"'}
        |  |SELECT _id, username
        |  |FROM Friend
        |  |WHERE userId${'$'}{ if (userId == null) " IS " else "=" }? OR username=? LIMIT 2
@@ -523,7 +523,7 @@ class SelectQueryTypeTest {
        |    driver.removeListener(listener, arrayOf("Friend"))
        |  }
        |
-       |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${nullAsUnknownQuery.id}, ""${'"'}
+       |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${nullAsUnknownQuery.id}, ""${'"'}
        |  |SELECT _id, username
        |  |FROM Friend
        |  |WHERE userId=? OR username=? LIMIT 2
@@ -583,7 +583,7 @@ class SelectQueryTypeTest {
       |    driver.removeListener(listener, arrayOf("data"))
       |  }
       |
-      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(null, ""${'"'}
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(null, ""${'"'}
       |  |SELECT *
       |  |FROM data
       |  |WHERE val ${"$"}{ if (val_ == null) "IS" else "=" } ?
@@ -651,7 +651,7 @@ class SelectQueryTypeTest {
       |    driver.removeListener(listener, arrayOf("data"))
       |  }
       |
-      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${nullAsUnknownQuery.id}, ""${'"'}
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${nullAsUnknownQuery.id}, ""${'"'}
       |  |SELECT *
       |  |FROM data
       |  |WHERE val = ?
@@ -710,7 +710,7 @@ class SelectQueryTypeTest {
       |    driver.removeListener(listener, arrayOf("data"))
       |  }
       |
-      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${query.id}, ""${'"'}
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${query.id}, ""${'"'}
       |  |SELECT *
       |  |FROM data
       |  |WHERE data MATCH ? AND rowid = ?
@@ -761,7 +761,7 @@ class SelectQueryTypeTest {
       |    driver.removeListener(listener, arrayOf("data"))
       |  }
       |
-      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${query.id}, ""${'"'}
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${query.id}, ""${'"'}
       |  |SELECT *
       |  |FROM data
       |  |WHERE data MATCH '"one ' || ? || '" * '
@@ -816,7 +816,7 @@ class SelectQueryTypeTest {
       |    driver.removeListener(listener, arrayOf("data"))
       |  }
       |
-      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> {
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> {
       |    val idIndexes = createArguments(count = id.size)
       |    val token_Indexes = createArguments(count = token_.size)
       |    return driver.executeQuery(null, ""${'"'}
@@ -885,7 +885,7 @@ class SelectQueryTypeTest {
       |    driver.removeListener(listener, arrayOf("data"))
       |  }
       |
-      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(null, ""${'"'}
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(null, ""${'"'}
       |  |WITH child_ids AS (SELECT id FROM data WHERE id ${'$'}{ if (id == null) "IS" else "=" } ?)
       |  |SELECT *
       |  |FROM data
@@ -943,7 +943,7 @@ class SelectQueryTypeTest {
       |    driver.removeListener(listener, arrayOf("data"))
       |  }
       |
-      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${nullAsUnknownQuery.id}, ""${'"'}
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${nullAsUnknownQuery.id}, ""${'"'}
       |  |WITH child_ids AS (SELECT id FROM data WHERE id = ?)
       |  |SELECT *
       |  |FROM data
@@ -998,7 +998,7 @@ class SelectQueryTypeTest {
       |    driver.removeListener(listener, arrayOf("data"))
       |  }
       |
-      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> {
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> {
       |    val idIndexes = createArguments(count = id.size)
       |    return driver.executeQuery(null, ""${'"'}
       |        |SELECT *
@@ -1066,7 +1066,7 @@ class SelectQueryTypeTest {
       |    driver.removeListener(listener, arrayOf("data"))
       |  }
       |
-      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(null, ""${'"'}
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(null, ""${'"'}
       |  |SELECT *
       |  |FROM data
       |  |WHERE token ${"$"}{ if (token == null) "IS" else "=" } ? OR ? IS NULL
@@ -1115,7 +1115,7 @@ class SelectQueryTypeTest {
       |    driver.removeListener(listener, arrayOf("data"))
       |  }
       |
-      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${nullAsUnknownQuery.id}, ""${'"'}
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${nullAsUnknownQuery.id}, ""${'"'}
       |  |SELECT *
       |  |FROM data
       |  |WHERE token = ? OR ? IS NULL
@@ -1719,7 +1719,7 @@ class SelectQueryTypeTest {
         |    driver.removeListener(listener, arrayOf("ComboData", "ComboData2"))
         |  }
         |
-        |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> {
+        |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> {
         |    val valuesIndexes = createArguments(count = values.size)
         |    return driver.executeQuery(null, ""${'"'}
         |        |SELECT (SELECT count(*) FROM ComboData WHERE value IN ${"$"}valuesIndexes) +
@@ -1772,7 +1772,7 @@ class SelectQueryTypeTest {
       |  public val value_: kotlin.Long,
       |  mapper: (app.cash.sqldelight.db.SqlCursor) -> T,
       |) : app.cash.sqldelight.ExecutableQuery<T>(mapper) {
-      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = transactionWithResult {
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> = transactionWithResult {
       |    driver.execute(${query.idForIndex(0)}, ""${'"'}
       |        |INSERT INTO data (value)
       |        |  VALUES (?)

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/async/AsyncSelectQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/async/AsyncSelectQueryTypeTest.kt
@@ -139,7 +139,7 @@ class AsyncSelectQueryTypeTest {
       |    driver.removeListener(listener, arrayOf("data"))
       |  }
       |
-      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${query.id}, ""${'"'}
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${query.id}, ""${'"'}
       |  |SELECT *
       |  |FROM data
       |  |WHERE id = ?
@@ -238,7 +238,7 @@ class AsyncSelectQueryTypeTest {
       |  public val value_: kotlin.Long,
       |  mapper: (app.cash.sqldelight.db.SqlCursor) -> T,
       |) : app.cash.sqldelight.ExecutableQuery<T>(mapper) {
-      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = app.cash.sqldelight.db.QueryResult.AsyncValue {
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> app.cash.sqldelight.db.QueryResult<R>): app.cash.sqldelight.db.QueryResult<R> = app.cash.sqldelight.db.QueryResult.AsyncValue {
       |    transactionWithResult {
       |      driver.execute(${query.idForIndex(0)}, ""${'"'}
       |          |INSERT INTO data (value)

--- a/sqldelight-gradle-plugin/src/test/integration-multiplatform-async/src/commonMain/kotlin/app/sqltest/shared/common/data/SharedDatabase.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-multiplatform-async/src/commonMain/kotlin/app/sqltest/shared/common/data/SharedDatabase.kt
@@ -4,6 +4,7 @@ import app.cash.sqldelight.async.coroutines.await
 import app.cash.sqldelight.async.coroutines.awaitCreate
 import app.cash.sqldelight.async.coroutines.awaitMigrate
 import app.cash.sqldelight.async.coroutines.awaitQuery
+import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
 import app.sqltest.shared.SqlTestDb
 import kotlinx.coroutines.sync.Mutex
@@ -50,7 +51,7 @@ class SharedDatabase(private val driverFactory: DriverFactory) {
         identifier = null,
         sql = "PRAGMA $versionPragma",
         mapper = { cursor ->
-          if (cursor.next()) {
+          if (cursor.next().await()) {
             cursor.getLong(0)?.toInt()
           } else {
             null
@@ -78,11 +79,7 @@ class SharedDatabase(private val driverFactory: DriverFactory) {
         identifier = null,
         sql = "PRAGMA $versionPragma",
         mapper = { cursor ->
-          if (cursor.next()) {
-            cursor.getLong(0)?.toInt()
-          } else {
-            null
-          }
+          QueryResult.Value(if (cursor.next().value) cursor.getLong(0)?.toInt() else null)
         },
         parameters = 0,
       ).await() ?: 0

--- a/sqldelight-gradle-plugin/src/test/multithreaded-sqlite/src/main/kotlin/com/example/db/DbHelper.kt
+++ b/sqldelight-gradle-plugin/src/test/multithreaded-sqlite/src/main/kotlin/com/example/db/DbHelper.kt
@@ -1,5 +1,6 @@
 package com.example.db
 
+import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlCursor
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.example.db.Database.Companion.Schema
@@ -49,9 +50,9 @@ class DbHelper(
 
   private var version: Int
     get() {
-      fun mapper(cursor: SqlCursor): Int {
-        check(cursor.next())
-        return cursor.getLong(0)!!.toInt()
+      fun mapper(cursor: SqlCursor): QueryResult.Value<Int> {
+        check(cursor.next().value)
+        return QueryResult.Value(cursor.getLong(0)!!.toInt())
       }
       return driver.executeQuery(null, "PRAGMA user_version;", ::mapper, 0, null).value
     }


### PR DESCRIPTION
`SqlCursor.next()` now returns `QueryResult<Boolean>` which can be an `AsyncValue` for async drivers.

I'll follow up with changes to the R2DBC driver that uses this new API. 