### PR TITLE
Fix docs

### DIFF
--- a/sqldelight-compiler/environment/build.gradle
+++ b/sqldelight-compiler/environment/build.gradle
@@ -2,7 +2,6 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.shadow)
   alias(libs.plugins.publish)
-  alias(libs.plugins.dokka)
   id("app.cash.sqldelight.toolchain.compiler")
 }
 

--- a/sqlite-migrations/build.gradle
+++ b/sqlite-migrations/build.gradle
@@ -15,3 +15,7 @@ dependencies {
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"
+
+tasks.named('dokkaHtmlMultiModule') {
+  it.enabled = false
+}

--- a/sqlite-migrations/environment/build.gradle
+++ b/sqlite-migrations/environment/build.gradle
@@ -2,7 +2,6 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.shadow)
   alias(libs.plugins.publish)
-  alias(libs.plugins.dokka)
   id("app.cash.sqldelight.toolchain.compiler")
 }
 


### PR DESCRIPTION
The old `sqlite-migration` module contains the new `environment` module so it tries to call `htmlMultiModule` too, but the environment does not need dokka, because there are no sources. Thus, this task is disabled and the website should finally work again. At least locally I can run `clean dokkaHtmlMultiModule` and `clean dokkaHtml` without problems.