### PR TITLE
Disable publication of the sqljs driver

### DIFF
--- a/drivers/sqljs-driver/build.gradle
+++ b/drivers/sqljs-driver/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   alias(libs.plugins.kotlin.multiplatform)
-  alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
 }
 
@@ -35,5 +34,3 @@ kotlin {
     }
   }
 }
-
-apply from: "$rootDir/gradle/gradle-mvn-push.gradle"


### PR DESCRIPTION
Deleting the driver altogether will take some more work since it's really baked into the coroutines and paging tests, but this will unblock a release candidate.

See #4094 