### PR TITLE
Split toolchain versions and JDK target versions

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           ./gradlew build -x :sqldelight-idea-plugin:build -x :sqldelight-gradle-plugin:test --stacktrace -x linuxX64Test
       - name: Run gradle plugin tests
-        if: matrix.os == 'ubuntu-latest' && matrix.job == 'gradle-plugin-tests'
+        if: matrix.os == 'macOS-latest' && matrix.job == 'gradle-plugin-tests'
         run: ./gradlew :sqldelight-gradle-plugin:test :sqldelight-gradle-plugin:grammarkitTest
 
       - name: Run the IntelliJ plugin

--- a/buildLogic/toolchain-convention/build.gradle
+++ b/buildLogic/toolchain-convention/build.gradle
@@ -18,4 +18,5 @@ gradlePlugin {
 
 dependencies {
   compileOnly libs.kotlin.plugin
+  compileOnly libs.android.plugin
 }

--- a/buildLogic/toolchain-convention/src/main/kotlin/app/cash/sqldelight/toolchain/ToolchainConventions.kt
+++ b/buildLogic/toolchain-convention/src/main/kotlin/app/cash/sqldelight/toolchain/ToolchainConventions.kt
@@ -1,20 +1,47 @@
 package app.cash.sqldelight.toolchain
 
+import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JvmVendorSpec
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import com.android.build.gradle.BaseExtension as AndroidBaseExtension
 
-abstract class ToolchainConventions(private val jdkVersion: Int) : Plugin<Project> {
+abstract class ToolchainConventions(private val targetJdkVersion: String) : Plugin<Project> {
   override fun apply(project: Project) {
     project.kotlinExtension.jvmToolchain { spec ->
-      spec.languageVersion.set(JavaLanguageVersion.of(jdkVersion))
+      spec.languageVersion.set(JavaLanguageVersion.of(BUILD_JDK))
       spec.vendor.set(JvmVendorSpec.AZUL)
     }
+
+    project.tasks.withType(KotlinCompile::class.java).configureEach { task ->
+      task.compilerOptions {
+        jvmTarget.set(JvmTarget.fromTarget(targetJdkVersion))
+      }
+    }
+
+    project.extensions.findByType(JavaPluginExtension::class.java)?.apply {
+      sourceCompatibility = JavaVersion.toVersion(targetJdkVersion)
+      targetCompatibility = JavaVersion.toVersion(targetJdkVersion)
+    }
+
+    project.extensions.findByType(AndroidBaseExtension::class.java)?.compileOptions?.apply {
+      sourceCompatibility = JavaVersion.toVersion(targetJdkVersion)
+      targetCompatibility = JavaVersion.toVersion(targetJdkVersion)
+    }
+  }
+
+  companion object {
+    const val BUILD_JDK = 17
   }
 }
 
-class RuntimeToolchainConventions : ToolchainConventions(8)
+// Controls the minimum JDK version required to use the SQLDelight runtime
+class RuntimeToolchainConventions : ToolchainConventions("1.8")
 
-class CompilerToolchainConventions : ToolchainConventions(11)
+// Controls the minimum JDK version required to run the SQLDelight plugin and compiler
+class CompilerToolchainConventions : ToolchainConventions("11")


### PR DESCRIPTION
AGP 8 (#4059) requires JDK 17 to run, but some integration tests are running with JDK 11 from the toolchain settings.

This sets the toolchain version to 17 for all projects, and configures the source/target compatibility to be 8 or 11 instead.
