### PR TITLE
Alter table add constraint postgres

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -8,6 +8,7 @@
   psiClassPrefix = "PostgreSql"
 
   parserImports=[
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.ADD"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ABORT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ALWAYS"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.AS"
@@ -29,6 +30,7 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.FAIL"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.FALSE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.FOR"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.FOREIGN"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.FROM"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.GENERATED"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ID"
@@ -65,6 +67,7 @@ overrides ::= type_name
   | column_constraint
   | string_literal
   | bind_parameter
+  | table_constraint
   | with_clause_auxiliary_stmt
   | delete_stmt_limited
   | insert_stmt
@@ -114,6 +117,14 @@ bind_parameter ::= DEFAULT | ( '?' | ':' {identifier} ) {
   mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.BindParameterMixin"
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlBindParameterImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlBindParameter"
+  override = true
+}
+table_constraint ::= [ CONSTRAINT {identifier} ] (
+  ( PRIMARY KEY | UNIQUE ) [{index_name}] LP {indexed_column} [ LP {signed_number} RP ] ( COMMA {indexed_column} [ LP {signed_number} RP ] ) * RP {conflict_clause} [comment_type] |
+  FOREIGN KEY LP {column_name} ( COMMA {column_name} ) * RP {foreign_key_clause}
+) {
+  extends = "com.alecstrong.sql.psi.core.psi.impl.SqlTableConstraintImpl"
+  implements = "com.alecstrong.sql.psi.core.psi.SqlTableConstraint"
   override = true
 }
 
@@ -213,6 +224,7 @@ alter_table_rules ::= (
   | {alter_table_rename_table}
   | alter_table_rename_column
   | alter_table_drop_column
+  | alter_table_add_constraint
 ) {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlAlterTableRulesImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlAlterTableRules"
@@ -237,6 +249,8 @@ alter_table_drop_column ::= DROP [ COLUMN ] {column_name} {
   mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.AlterTableDropColumnMixin"
   pin = 1
 }
+
+alter_table_add_constraint ::= ADD table_constraint
 
 compound_select_stmt ::= [ {with_clause} ] {select_stmt}  ( {compound_operator} {select_stmt} ) * [ ORDER BY {ordering_term} ( COMMA {ordering_term} ) * ] [ LIMIT {limiting_term} ] [ ( OFFSET | COMMA ) {limiting_term} ] [ FOR UPDATE [ 'SKIP' 'LOCKED' ] ] {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlCompoundSelectStmtImpl"

--- a/dialects/postgresql/src/test/fixtures_postgresql/alter-table-add-constraint/1.s
+++ b/dialects/postgresql/src/test/fixtures_postgresql/alter-table-add-constraint/1.s
@@ -1,0 +1,7 @@
+CREATE TABLE test (
+  external_event_id TEXT
+);
+
+ALTER TABLE test
+  ADD CONSTRAINT idx_external_event_id
+  UNIQUE (external_event_id);


### PR DESCRIPTION
Minimal support for Postgres alter table add constraint as learning how all this works.

``` sql 
  ALTER TABLE test
  ADD CONSTRAINT idx_external_event_id
  UNIQUE (external_event_id);
```

The changes are made here on sqldelight as the postgressql grammer was moved from sql-psi

Noticed that issue was raised in https://github.com/AlecStrong/sql-psi/issues/286

*Have signed contributors agreement.*

---

TODOs

Check constraints - there needs to be support for type `expr` functions like `char_length`

e.g

``` sql
ALTER TABLE distributors ADD CONSTRAINT zipchk CHECK (char_length(zipcode) = 5);
```
