### PR TITLE
R2DBC: Await closing the driver

### DIFF
--- a/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
+++ b/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
@@ -130,7 +130,7 @@ class R2dbcDriver(
 
 /**
  * Creates and returns a [R2dbcDriver] with the given [connection].
- * 
+ *
  * The scope waits until the driver is closed [R2dbcDriver.close].
  */
 fun CoroutineScope.R2dbcDriver(

--- a/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
+++ b/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
@@ -128,6 +128,11 @@ class R2dbcDriver(
   }
 }
 
+/**
+ * Creates and returns a [R2dbcDriver] with the given [connection].
+ * 
+ * The scope waits until the driver is closed [R2dbcDriver.close].
+ */
 fun CoroutineScope.R2dbcDriver(
   connection: Connection,
 ): R2dbcDriver {

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql-async/src/test/kotlin/app/cash/sqldelight/postgresql/integration/async/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql-async/src/test/kotlin/app/cash/sqldelight/postgresql/integration/async/PostgreSqlTest.kt
@@ -7,6 +7,7 @@ import app.cash.sqldelight.db.OptimisticLockException
 import app.cash.sqldelight.driver.r2dbc.R2dbcDriver
 import com.google.common.truth.Truth.assertThat
 import io.r2dbc.spi.ConnectionFactories
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.reactive.awaitSingle
 import kotlinx.coroutines.test.TestResult
 import org.junit.Assert
@@ -31,11 +32,18 @@ class PostgreSqlTest {
       val connectionFactory = ConnectionFactories.get(PostgreSQLR2DBCDatabaseContainer.getOptions(it))
       kotlinx.coroutines.test.runTest {
         val connection = connectionFactory.create().awaitSingle()
-        val driver = R2dbcDriver(connection)
+        val driver = R2dbcDriver(connection) {
+          if (it == null) {
+            awaitClose.complete(Unit)
+          } else {
+            awaitClose.completeExceptionally(it)
+          }
+        }
         val db = MyDatabase(driver)
         MyDatabase.Schema.awaitCreate(driver)
         block(db)
         driver.close()
+        awaitClose.join()
       }
     }
   }
@@ -63,9 +71,16 @@ class PostgreSqlTest {
       val connectionFactory = ConnectionFactories.get(PostgreSQLR2DBCDatabaseContainer.getOptions(it))
       kotlinx.coroutines.test.runTest {
         val connection = connectionFactory.create().awaitSingle()
-        val driver = R2dbcDriver(connection)
+        val driver = R2dbcDriver(connection) {
+          if (it == null) {
+            awaitClose.complete(Unit)
+          } else {
+            awaitClose.completeExceptionally(it)
+          }
+        }
         assertThat(driver.connection).isEqualTo(connection)
         driver.close()
+        awaitClose.join()
       }
     }
   }

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql-async/src/test/kotlin/app/cash/sqldelight/postgresql/integration/async/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql-async/src/test/kotlin/app/cash/sqldelight/postgresql/integration/async/PostgreSqlTest.kt
@@ -32,6 +32,7 @@ class PostgreSqlTest {
       val connectionFactory = ConnectionFactories.get(PostgreSQLR2DBCDatabaseContainer.getOptions(it))
       kotlinx.coroutines.test.runTest {
         val connection = connectionFactory.create().awaitSingle()
+        val awaitClose = CompletableDeferred<Unit>()
         val driver = R2dbcDriver(connection) {
           if (it == null) {
             awaitClose.complete(Unit)
@@ -71,6 +72,7 @@ class PostgreSqlTest {
       val connectionFactory = ConnectionFactories.get(PostgreSQLR2DBCDatabaseContainer.getOptions(it))
       kotlinx.coroutines.test.runTest {
         val connection = connectionFactory.create().awaitSingle()
+        val awaitClose = CompletableDeferred<Unit>()
         val driver = R2dbcDriver(connection) {
           if (it == null) {
             awaitClose.complete(Unit)

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql-async/src/test/kotlin/app/cash/sqldelight/postgresql/integration/async/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql-async/src/test/kotlin/app/cash/sqldelight/postgresql/integration/async/PostgreSqlTest.kt
@@ -72,9 +72,9 @@ class PostgreSqlTest {
       val connectionFactory = ConnectionFactories.get(PostgreSQLR2DBCDatabaseContainer.getOptions(it))
       kotlinx.coroutines.test.runTest {
         val connection = connectionFactory.create().awaitSingle()
-        val driver = R2dbcDriver(connection)
-        assertThat(driver.connection).isEqualTo(connection)
-        driver.close()
+        R2dbcDriver(connection).use { driver ->
+          assertThat(driver.connection).isEqualTo(connection)
+        }
       }
     }
   }

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql-async/src/test/kotlin/app/cash/sqldelight/postgresql/integration/async/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql-async/src/test/kotlin/app/cash/sqldelight/postgresql/integration/async/PostgreSqlTest.kt
@@ -63,7 +63,7 @@ class PostgreSqlTest {
       )
   }
 
-  @Test fun getConnection(): TestResult {
+  @Test fun getConnectionUsingCoroutineOverload(): TestResult {
     val container = PostgreSQLContainer("postgres:9.6.8").apply {
       withDatabaseName("myDb")
     }
@@ -72,17 +72,9 @@ class PostgreSqlTest {
       val connectionFactory = ConnectionFactories.get(PostgreSQLR2DBCDatabaseContainer.getOptions(it))
       kotlinx.coroutines.test.runTest {
         val connection = connectionFactory.create().awaitSingle()
-        val awaitClose = CompletableDeferred<Unit>()
-        val driver = R2dbcDriver(connection) {
-          if (it == null) {
-            awaitClose.complete(Unit)
-          } else {
-            awaitClose.completeExceptionally(it)
-          }
-        }
+        val driver = R2dbcDriver(connection)
         assertThat(driver.connection).isEqualTo(connection)
         driver.close()
-        awaitClose.join()
       }
     }
   }


### PR DESCRIPTION
The current `close` api of the R2DBC driver does not await the result or failure of the close request. Because we can't use a suspend call, I added a normal plain old callback.