### PR TITLE
Add postgreSql column default interval

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -19,6 +19,7 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.COMMA"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.CONFLICT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.CONSTRAINT"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.CURRENT_TIMESTAMP"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.DEFAULT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.DELETE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.DESC"
@@ -40,6 +41,7 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.KEY"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.LIMIT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.LP"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.MINUS"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.NOT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.NOTHING"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.NULL"
@@ -47,6 +49,7 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ON"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.OR"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ORDER"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.PLUS"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.PRIMARY"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.RENAME"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.REPLACE"
@@ -68,6 +71,7 @@ overrides ::= type_name
   | string_literal
   | bind_parameter
   | table_constraint
+  | default_constraint
   | with_clause_auxiliary_stmt
   | delete_stmt_limited
   | insert_stmt
@@ -84,13 +88,26 @@ column_constraint ::= [ CONSTRAINT {identifier} ] (
   UNIQUE {conflict_clause} |
   {check_constraint} |
   generated_clause |
-  {default_constraint} |
+  default_constraint |
   COLLATE {collation_name} |
   {foreign_key_clause}
 ) {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlColumnConstraintImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlColumnConstraint"
   override = true
+}
+
+current_timestamp_with_optional_interval ::= ( CURRENT_TIMESTAMP | 'NOW()' | interval_expression ) [ [ PLUS | MINUS ] interval_expression ] *
+default_constraint ::= [ NOT NULL | NULL ] DEFAULT (
+  current_timestamp_with_optional_interval |
+  {signed_number} |
+  {literal_value} |
+  LP <<expr '-1'>> RP
+) {
+  extends = "com.alecstrong.sql.psi.core.psi.impl.SqlDefaultConstraintImpl"
+  implements = "com.alecstrong.sql.psi.core.psi.SqlDefaultConstraint"
+  override = true
+  pin = 2
 }
 
 type_name ::= (
@@ -159,6 +176,8 @@ boolean_data_type ::= 'BOOLEAN' | 'BOOL'
 json_data_type ::= 'JSON' | 'JSONB'
 
 blob_data_type ::= 'BYTEA'
+
+interval_expression ::= 'INTERVAL' string_literal
 
 with_clause_auxiliary_stmt ::= {compound_select_stmt} | delete_stmt_limited | insert_stmt | update_stmt_limited {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlWithClauseAuxiliaryStmtImpl"

--- a/dialects/postgresql/src/test/fixtures_postgresql/column_types/Sample.s
+++ b/dialects/postgresql/src/test/fixtures_postgresql/column_types/Sample.s
@@ -60,7 +60,18 @@ CREATE TABLE all_types(
 
   some_bytea BYTEA,
 
-  some_int2_array INT2[]
+  some_int2_array INT2[],
+
+  some_interval_a INTERVAL DEFAULT INTERVAL '5 days',
+
+  some_interval_b INTERVAL NOT NULL DEFAULT INTERVAL '5 days',
+
+  some_interval_c TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP + INTERVAL '7 days',
+
+  some_interval_d TIMESTAMP NOT NULL DEFAULT NOW() - INTERVAL '5 days',
+
+  some_interval_e INTERVAL DEFAULT INTERVAL '3h' + INTERVAL '20m'
+
 );
 
 SELECT * FROM all_types


### PR DESCRIPTION
close #4122

* Add PostgreSql specific grammar
* Update fixture test

This brings the PostgreSql grammar to similar level of MySql support for Interval

Provides grammar for:

``` sql
  some_interval_a INTERVAL DEFAULT INTERVAL '5 days',
  some_interval_b TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP - INTERVAL '5 days',
  some_interval_c TIMESTAMP NOT NULL DEFAULT NOW() - INTERVAL '5 days',
  some_interval_d INTERVAL DEFAULT INTERVAL '3h' + INTERVAL '20m'
```

Note:- Does not support
arithmetic e.g INTERVAL ’1 day’ * 7
“::interval” short-hand
“5 days” validation of literals
Modifiers e.g INTERVAL ‘5’ DAY

Other examples of Interval expressions that could be supported
https://github.com/postgres/postgres/blob/master/src/test/regress/sql/interval.sql