### PR TITLE
Add postgreSql interval column result

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -19,6 +19,8 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.COMMA"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.CONFLICT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.CONSTRAINT"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.CURRENT_DATE"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.CURRENT_TIME"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.CURRENT_TIMESTAMP"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.DEFAULT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.DELETE"
@@ -195,6 +197,19 @@ delete_stmt_limited ::= [ {with_clause} ] DELETE FROM {qualified_table_name} [ W
 string_literal ::= string {
   mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.StringLiteralMixin"
   implements = "com.alecstrong.sql.psi.core.psi.SqlStringLiteral"
+  override = true
+}
+
+literal_value ::= ( {numeric_literal}
+                  | string_literal
+                  | {blob_literal}
+                  | NULL
+                  | CURRENT_TIME
+                  | CURRENT_DATE
+                  | CURRENT_TIMESTAMP
+                  | interval_expression ) {
+  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.LiteralValueMixin"
+  implements = "com.alecstrong.sql.psi.core.psi.SqlLiteralValue"
   override = true
 }
 

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/LiteralValueMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/LiteralValueMixin.kt
@@ -1,0 +1,8 @@
+package app.cash.sqldelight.dialects.postgresql.grammar.mixins
+
+import com.alecstrong.sql.psi.core.psi.impl.SqlLiteralValueImpl
+import com.intellij.lang.ASTNode
+
+internal abstract class LiteralValueMixin(
+  node: ASTNode,
+) : SqlLiteralValueImpl(node)

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/BindArgsTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/BindArgsTest.kt
@@ -4,14 +4,11 @@ import app.cash.sqldelight.core.lang.types.typeResolver
 import app.cash.sqldelight.core.lang.util.argumentType
 import app.cash.sqldelight.core.lang.util.findChildrenOfType
 import app.cash.sqldelight.core.lang.util.isArrayParameter
-import app.cash.sqldelight.core.lang.util.type
 import app.cash.sqldelight.dialect.api.PrimitiveType
-import app.cash.sqldelight.dialects.postgresql.PostgreSqlDialect
 import app.cash.sqldelight.dialects.sqlite_3_24.SqliteDialect
 import app.cash.sqldelight.test.util.FixtureCompiler
 import com.alecstrong.sql.psi.core.psi.SqlBindExpr
 import com.alecstrong.sql.psi.core.psi.SqlColumnDef
-import com.alecstrong.sql.psi.core.psi.SqlResultColumn
 import com.google.common.truth.Truth.assertThat
 import com.squareup.kotlinpoet.asClassName
 import org.junit.Rule
@@ -386,21 +383,6 @@ class BindArgsTest {
       assertThat(args[2].dialectType).isEqualTo(PrimitiveType.TEXT)
       assertThat(args[2].javaType).isEqualTo(String::class.asClassName())
       assertThat(args[2].name).isEqualTo("last_name")
-    }
-  }
-
-  @Test
-  fun `Result Column is PostgreSql interval type`() {
-    val file = FixtureCompiler.parseSql(
-      """
-      SELECT INTERVAL '1 day';
-      """.trimMargin(),
-      tempFolder,
-      dialect = PostgreSqlDialect(),
-    )
-
-    file.findChildrenOfType<SqlResultColumn>().map { it.type() }.let { args ->
-      println(args)
     }
   }
 

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/BindArgsTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/BindArgsTest.kt
@@ -4,11 +4,14 @@ import app.cash.sqldelight.core.lang.types.typeResolver
 import app.cash.sqldelight.core.lang.util.argumentType
 import app.cash.sqldelight.core.lang.util.findChildrenOfType
 import app.cash.sqldelight.core.lang.util.isArrayParameter
+import app.cash.sqldelight.core.lang.util.type
 import app.cash.sqldelight.dialect.api.PrimitiveType
+import app.cash.sqldelight.dialects.postgresql.PostgreSqlDialect
 import app.cash.sqldelight.dialects.sqlite_3_24.SqliteDialect
 import app.cash.sqldelight.test.util.FixtureCompiler
 import com.alecstrong.sql.psi.core.psi.SqlBindExpr
 import com.alecstrong.sql.psi.core.psi.SqlColumnDef
+import com.alecstrong.sql.psi.core.psi.SqlResultColumn
 import com.google.common.truth.Truth.assertThat
 import com.squareup.kotlinpoet.asClassName
 import org.junit.Rule
@@ -383,6 +386,21 @@ class BindArgsTest {
       assertThat(args[2].dialectType).isEqualTo(PrimitiveType.TEXT)
       assertThat(args[2].javaType).isEqualTo(String::class.asClassName())
       assertThat(args[2].name).isEqualTo("last_name")
+    }
+  }
+
+  @Test
+  fun `Result Column is PostgreSql interval type`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      SELECT INTERVAL '1 day';
+      """.trimMargin(),
+      tempFolder,
+      dialect = PostgreSqlDialect(),
+    )
+
+    file.findChildrenOfType<SqlResultColumn>().map { it.type() }.let { args ->
+      println(args)
     }
   }
 

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Dates.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Dates.sq
@@ -15,3 +15,6 @@ SELECT date_trunc('hour', timestamp), date_trunc('hour', timestamp_with_timezone
 
 selectNow:
 SELECT NOW();
+
+selectInterval:
+SELECT INTERVAL '1 day';

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -224,6 +224,12 @@ class PostgreSqlTest {
     assertThat(now).isGreaterThan(OffsetDateTime.MIN)
   }
 
+  @Test fun interval() {
+    val interval = database.datesQueries.selectInterval().executeAsOne()
+    assertThat(interval).isNotNull()
+    assertThat(interval.getDays()).isEqualTo(1)
+  }
+
   @Test fun successfulOptimisticLock() {
     with(database.withLockQueries) {
       val row = insertText("sup").executeAsOne()


### PR DESCRIPTION
closes #4144  Look into approach for supporting INTERVAL literal column results

`SELECT INTERVAL '1 day';`

Override Literals, test returns `PGInterval` type.

TODOs

Literals for CURRENT_DATE, CURRENT_TIME, CURRENT_DATE_TIME should also be considered.

Support `SELECT NOW() + INTERVAL '1 day';`