### PR TITLE
Mention binary incompatibities with previous IntelliJ plugin version

### DIFF
--- a/docs/upgrading-2.0.md
+++ b/docs/upgrading-2.0.md
@@ -5,7 +5,7 @@ SQLDelight 2.0 makes some breaking changes to the gradle plugin and runtime APIs
 This page lists those breaking changes and their new 2.0 equivalents. 
 For a full list of new features and other changes, see the [changelog](../changelog).
 
-The Gradle plugin (`app.cash.sqldelight`) version `2.0` isn't compatible with older versions `1.x` of the IntelliJ plugin.
+SQLDelight 2.0 is not compatible with older (1.x) versions of the IntelliJ plugin. Make sure to also update the IntelliJ plugin. 
 You have to update the IntelliJ plugin by adding an IntelliJ repository in the IntelliJ plugins settings, either use [alpha versions](https://plugins.jetbrains.com/plugins/alpha/com.squareup.sqldelight) or [snapshots of the master branch](https://plugins.jetbrains.com/plugins/eap/com.squareup.sqldelight).
 
 

--- a/docs/upgrading-2.0.md
+++ b/docs/upgrading-2.0.md
@@ -5,6 +5,10 @@ SQLDelight 2.0 makes some breaking changes to the gradle plugin and runtime APIs
 This page lists those breaking changes and their new 2.0 equivalents. 
 For a full list of new features and other changes, see the [changelog](../changelog).
 
+The Gradle plugin (`app.cash.sqldelight`) version `2.0` isn't compatible with older versions `1.x` of the IntelliJ plugin.
+You have to update the IntelliJ plugin by adding an IntelliJ repository in the IntelliJ plugins settings, either use [alpha versions](https://plugins.jetbrains.com/plugins/alpha/com.squareup.sqldelight) or [snapshots of the master branch](https://plugins.jetbrains.com/plugins/eap/com.squareup.sqldelight).
+
+
 ## New Package Name and Artifact Group
 
 All instances of `com.squareup.sqldelight` need to be replaced with `app.cash.sqldelight`.


### PR DESCRIPTION
Fixes #4179

    Many thanks. It seems to work now. But shouldn't it be mentioned on the website that the currently promoted latest version of SQLDelight is not compatible with the latest plugin version that you can install normally?

_Originally posted by @mipastgt in https://github.com/cashapp/sqldelight/issues/4179#issuecomment-1559139124_
