### PR TITLE
PostgreSQL: Add date_part

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -80,13 +80,14 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
   }
 
   private fun SqlFunctionExpr.postgreSqlFunctionType() = when (functionName.text.lowercase()) {
-    "greatest" -> encapsulatingType(exprList, PrimitiveType.INTEGER, REAL, TEXT, BLOB)
+    "greatest" -> encapsulatingType(exprList, INTEGER, REAL, TEXT, BLOB)
     "concat" -> encapsulatingType(exprList, TEXT)
     "substring" -> IntermediateType(TEXT).nullableIf(resolvedType(exprList[0]).javaType.isNullable)
     "coalesce", "ifnull" -> encapsulatingType(exprList, SMALL_INT, PostgreSqlType.INTEGER, INTEGER, BIG_INT, REAL, TEXT, BLOB)
     "max" -> encapsulatingType(exprList, SMALL_INT, PostgreSqlType.INTEGER, INTEGER, BIG_INT, REAL, TEXT, BLOB).asNullable()
     "min" -> encapsulatingType(exprList, BLOB, TEXT, SMALL_INT, INTEGER, PostgreSqlType.INTEGER, BIG_INT, REAL).asNullable()
     "date_trunc" -> encapsulatingType(exprList, TIMESTAMP_TIMEZONE, TIMESTAMP)
+    "date_part" -> IntermediateType(REAL)
     "now" -> IntermediateType(TIMESTAMP_TIMEZONE)
     "gen_random_uuid" -> IntermediateType(PostgreSqlType.UUID)
     "length", "character_length", "char_length" -> IntermediateType(PostgreSqlType.INTEGER).nullableIf(resolvedType(exprList[0]).javaType.isNullable)

--- a/dialects/postgresql/src/test/fixtures_postgresql/custom-functions/Test.s
+++ b/dialects/postgresql/src/test/fixtures_postgresql/custom-functions/Test.s
@@ -2,4 +2,4 @@ CREATE TABLE foo (
 bar TIMESTAMPTZ NOT NULL
 );
 
-SELECT NOW() AS now, date_trunc('hour', bar) AS d FROM foo;
+SELECT NOW() AS now, date_trunc('hour', bar) AS d, date_part('hour', bar) FROM foo;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Dates.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Dates.sq
@@ -13,5 +13,8 @@ RETURNING *;
 selectDateTrunc:
 SELECT date_trunc('hour', timestamp), date_trunc('hour', timestamp_with_timezone) FROM dates;
 
+selectDatePart:
+SELECT date_part('hour', timestamp), date_part('hour', timestamp_with_timezone) FROM dates;
+
 selectNow:
 SELECT NOW();

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -181,7 +181,7 @@ class PostgreSqlTest {
       )
   }
 
-  @Test fun testDateTrunc() {
+  @Test fun testDateFunctions() {
     database.datesQueries.insertDate(
       date = LocalDate.of(2020, 1, 1),
       time = LocalTime.of(21, 30, 59, 10000),
@@ -196,6 +196,16 @@ class PostgreSqlTest {
         SelectDateTrunc(
           date_trunc = LocalDateTime.of(2020, 1, 1, 21, 0, 0, 0),
           date_trunc_ = OffsetDateTime.of(1980, 4, 9, 20, 0, 0, 0, ZoneOffset.ofHours(0)),
+        ),
+      )
+
+    assertThat(
+      database.datesQueries.selectDatePart().executeAsOne(),
+    )
+      .isEqualTo(
+        SelectDatePart(
+          date_part = 21.0,
+          date_part_ = 20.0,
         ),
       )
   }


### PR DESCRIPTION
Fixes https://github.com/AlecStrong/sql-psi/issues/427

I didn't implement `EXTRACT` because its syntax is somehow complex and `date_part` is also available.