### PR TITLE
Adjust CI heap settings

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -98,4 +98,4 @@ jobs:
           build-root-directory: sample
 
 env:
-  GRADLE_OPTS: -Dorg.gradle.parallel=false -Dorg.gradle.caching=true
+  GRADLE_OPTS: -Dorg.gradle.parallel=true -Dorg.gradle.caching=true

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -98,4 +98,4 @@ jobs:
           build-root-directory: sample
 
 env:
-  GRADLE_OPTS: -Dorg.gradle.parallel=true -Dorg.gradle.caching=true
+  GRADLE_OPTS: -Dorg.gradle.parallel=false -Dorg.gradle.caching=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,4 +22,4 @@ kotlin.js.compiler=ir
 
 kotlin.mpp.stability.nowarn=true
 kotlin.native.ignoreDisabledTargets=true
-org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options="-Xmx2g"

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,4 +22,4 @@ kotlin.js.compiler=ir
 
 kotlin.mpp.stability.nowarn=true
 kotlin.native.ignoreDisabledTargets=true
-org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options="-Xmx2g"
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options="-Xmx2g"


### PR DESCRIPTION
Doubles the size of the Gradle daemon's heap, but keeps the Kotlin daemon's heap size the same.

Also, should we really set these in the project's gradle.properties file? I think this overrides any local settings for anyone working on it.