### PR TITLE
Updating mysql grammar to support additional expressions for 'on duplicate update'.

### DIFF
--- a/dialects/mysql/src/main/kotlin/app/cash/sqldelight/dialects/mysql/grammar/MySql.bnf
+++ b/dialects/mysql/src/main/kotlin/app/cash/sqldelight/dialects/mysql/grammar/MySql.bnf
@@ -305,7 +305,7 @@ insert_stmt ::= [ {with_clause} ] ( INSERT | REPLACE ) [ 'LOW_PRIORITY' | 'DELAY
   pin = 7
 }
 
-assignment_value ::= VALUES LP {column_name} RP | { <<expr '-1'>> | DEFAULT}
+assignment_value ::= VALUES LP {column_name} RP | <<expr '-1'>> | DEFAULT
 
 assignment ::= {column_name} EQ assignment_value
 

--- a/dialects/mysql/src/test/fixtures_mysql/insert-on-duplicate-key/Test.s
+++ b/dialects/mysql/src/test/fixtures_mysql/insert-on-duplicate-key/Test.s
@@ -1,8 +1,12 @@
 CREATE TABLE test (
   id INTEGER PRIMARY KEY,
-  value INTEGER
+  value INTEGER,
+  value2 INTEGER
 );
 
 INSERT INTO test
-VALUES (1,2)
-ON DUPLICATE KEY UPDATE value = VALUES(value);
+(id, value, value2)
+VALUES (1, 2, 3)
+ON DUPLICATE KEY UPDATE
+value = VALUES(value),
+value2 = value2 + 1;


### PR DESCRIPTION
There appears to be a grammar error with mysql dialect. This PR fixes it.

e.g. It is not possible to have query expression like below. 
```
...
ON DUPLICATE KEY UPDATE
col = col + 1;
```