### PR TITLE
Pass PR CI on docs change

### DIFF
--- a/.github/workflows/PR-skip.yml
+++ b/.github/workflows/PR-skip.yml
@@ -1,0 +1,17 @@
+# Matches paths that are skipped by PR.yml, to ensure that CI isn't constantly pending.
+# See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+
+name: Test
+
+on:
+  pull_request:
+    # Ensure paths match paths-ignore in PR.yml
+    paths:
+      - 'docs/**'
+      - '*.md'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -2,6 +2,7 @@ name: Test
 
 on:
   pull_request:
+    # Ensure paths-ignore match paths in PR-skip.yml
     paths-ignore:
       - 'docs/**'
       - '*.md'


### PR DESCRIPTION
Context https://github.com/cashapp/sqldelight/pull/4263#issuecomment-1587316115

It's a dumb hack, but [it's what GitHub recommends](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks#handling-skipped-but-required-checks) 🤷 