### PR TITLE
Use stable output path for generated source

### DIFF
--- a/sqldelight-gradle-plugin/src/instrumentationTest/kotlin/app/cash/sqldelight/integrations/IntegrationTest.kt
+++ b/sqldelight-gradle-plugin/src/instrumentationTest/kotlin/app/cash/sqldelight/integrations/IntegrationTest.kt
@@ -78,6 +78,22 @@ class IntegrationTest {
   }
 
   @Test
+  fun integrationTestsAndroidSingleVariant() {
+    val projectLocation = File("src/test/integration-android-variants")
+    val outputDir = File(projectLocation, "build/generated/sqldelight/code/QueryWrapper")
+    val runner = GradleRunner.create()
+      .withCommonConfiguration(projectLocation)
+      .forwardOutput()
+
+    val generateDebugResult = runner
+      .withArguments("clean", "generateDebugQueryWrapperInterface", "-PdebugOnly=true")
+      .build()
+    assertThat(generateDebugResult.output).contains("BUILD SUCCESSFUL")
+
+    assertThat(File(outputDir, "debug").exists()).isTrue()
+  }
+
+  @Test
   fun integrationTestsAndroidLibrary() {
     val integrationRoot = File("src/test/integration-android-library")
 

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
@@ -332,10 +332,5 @@ abstract class SqlDelightDatabase @Inject constructor(
     }
   }
 
-  private val Source.outputDir get() =
-    if (sources.size > 1) {
-      File(generatedSourcesDirectory, name)
-    } else {
-      generatedSourcesDirectory
-    }
+  private val Source.outputDir get() = File(generatedSourcesDirectory, name)
 }

--- a/sqldelight-gradle-plugin/src/test/integration-android-variants/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-android-variants/build.gradle
@@ -41,6 +41,12 @@ android {
   }
 }
 
+androidComponents {
+  beforeVariants(selector().withBuildType("release")) {
+    enable = project.properties["debugOnly"] != "true"
+  }
+}
+
 tasks.withType(KotlinCompilationTask.class).configureEach {
   compilerOptions.jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
 }

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/properties/MultiModuleTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/properties/MultiModuleTests.kt
@@ -28,7 +28,7 @@ class MultiModuleTests {
     assertThat(properties.compilationUnits).hasSize(1)
 
     with(properties.compilationUnits[0]) {
-      assertThat(outputDirectoryFile).isEqualTo(File(fixtureRoot, "build/generated/sqldelight/code/Database"))
+      assertThat(outputDirectoryFile).isEqualTo(File(fixtureRoot, "build/generated/sqldelight/code/Database/main"))
       assertThat(sourceFolders).containsExactly(
         SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false),
         SqlDelightSourceFolderImpl(File(fixtureRoot, "../ProjectB/src/main/sqldelight"), true),
@@ -165,7 +165,7 @@ class MultiModuleTests {
           SqlDelightSourceFolderImpl(File(fixtureRoot, "../middleB/src/main/sqldelight"), true),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false),
         ),
-        outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/Database"),
+        outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/Database/main"),
       ),
     )
   }

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/properties/PropertiesFileTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/properties/PropertiesFileTest.kt
@@ -26,7 +26,7 @@ class PropertiesFileTest {
     assertThat(properties.compilationUnits).hasSize(1)
 
     with(properties.compilationUnits[0]) {
-      assertThat(outputDirectoryFile).isEqualTo(File(fixtureRoot, "build/generated/sqldelight/code/Database"))
+      assertThat(outputDirectoryFile).isEqualTo(File(fixtureRoot, "build/generated/sqldelight/code/Database/main"))
       assertThat(sourceFolders).containsExactly(
         SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false),
       )
@@ -95,7 +95,7 @@ class PropertiesFileTest {
           sourceFolders = listOf(
             SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), dependency = false),
           ),
-          outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CashDatabase"),
+          outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CashDatabase/commonMain"),
         ),
       )
     }

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/CompilationUnitTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/CompilationUnitTests.kt
@@ -41,7 +41,7 @@ class CompilationUnitTests {
           SqlDelightCompilationUnitImpl(
             name = "main",
             sourceFolders = listOf(SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false)),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/main"),
           ),
         )
       }
@@ -85,7 +85,7 @@ class CompilationUnitTests {
               SqlDelightCompilationUnitImpl(
                 name = "main",
                 sourceFolders = listOf(SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false)),
-                outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
+                outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/main"),
               ),
             ),
             dependencies = emptyList(),
@@ -101,7 +101,7 @@ class CompilationUnitTests {
                   SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/otherdb"), false),
                   SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false),
                 ),
-                outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/OtherDb"),
+                outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/OtherDb/main"),
               ),
             ),
             dependencies = emptyList(),
@@ -153,7 +153,7 @@ class CompilationUnitTests {
           SqlDelightCompilationUnitImpl(
             name = "commonMain",
             sourceFolders = listOf(SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/commonMain"),
           ),
         )
       }
@@ -227,7 +227,7 @@ class CompilationUnitTests {
           SqlDelightCompilationUnitImpl(
             name = "commonMain",
             sourceFolders = listOf(SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/commonMain"),
           ),
         )
       }

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/MigrationTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/MigrationTest.kt
@@ -253,7 +253,7 @@ class MigrationTest {
 
     assertThat(output.output).contains("BUILD SUCCESSFUL")
 
-    val generatedDatabase = File(fixtureRoot, "build/generated/sqldelight/code/Database/com/example/sqldelightmigrations/DatabaseImpl.kt")
+    val generatedDatabase = File(fixtureRoot, "build/generated/sqldelight/code/Database/main/com/example/sqldelightmigrations/DatabaseImpl.kt")
     assertThat(generatedDatabase.exists()).isTrue()
     assertThat(generatedDatabase.readText()).contains(
       """


### PR DESCRIPTION
Always include the variant name as part of output path

Closes #4267