### PR TITLE
Gradle tweaks

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/GenerateMigrationOutputTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/GenerateMigrationOutputTask.kt
@@ -1,6 +1,5 @@
 package app.cash.sqldelight.gradle
 
-import app.cash.sqldelight.VERSION
 import app.cash.sqldelight.core.SqlDelightCompilationUnit
 import app.cash.sqldelight.core.SqlDelightDatabaseProperties
 import app.cash.sqldelight.core.SqlDelightEnvironment
@@ -26,11 +25,6 @@ import java.util.ServiceLoader
 
 @CacheableTask
 abstract class GenerateMigrationOutputTask : SqlDelightWorkerTask() {
-  @Suppress("unused")
-  // Required to invalidate the task on version updates.
-  @Input
-  val pluginVersion = VERSION
-
   @get:OutputDirectory
   var outputDirectory: File? = null
 

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/GenerateMigrationOutputTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/GenerateMigrationOutputTask.kt
@@ -26,7 +26,7 @@ import java.util.ServiceLoader
 @CacheableTask
 abstract class GenerateMigrationOutputTask : SqlDelightWorkerTask() {
   @get:OutputDirectory
-  var outputDirectory: File? = null
+  abstract val outputDirectory: DirectoryProperty
 
   @get:Input abstract val projectName: Property<String>
 
@@ -34,7 +34,7 @@ abstract class GenerateMigrationOutputTask : SqlDelightWorkerTask() {
 
   @get:Nested abstract var compilationUnit: SqlDelightCompilationUnitImpl
 
-  @get:Input abstract var migrationOutputExtension: String
+  @get:Input abstract val migrationOutputExtension: Property<String>
 
   @TaskAction
   fun generateSchemaFile() {

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/GenerateSchemaTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/GenerateSchemaTask.kt
@@ -30,7 +30,7 @@ import java.util.ServiceLoader
 @CacheableTask
 abstract class GenerateSchemaTask : SqlDelightWorkerTask() {
   @get:OutputDirectory
-  var outputDirectory: File? = null
+  abstract val outputDirectory: DirectoryProperty
 
   @get:Input abstract val projectName: Property<String>
 
@@ -38,7 +38,7 @@ abstract class GenerateSchemaTask : SqlDelightWorkerTask() {
 
   @get:Nested abstract var compilationUnit: SqlDelightCompilationUnitImpl
 
-  @Input var verifyMigrations: Boolean = false
+  @get:Input abstract val verifyMigrations: Property<Boolean>
 
   @TaskAction
   fun generateSchemaFile() {

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/GenerateSchemaTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/GenerateSchemaTask.kt
@@ -1,6 +1,5 @@
 package app.cash.sqldelight.gradle
 
-import app.cash.sqldelight.VERSION
 import app.cash.sqldelight.core.SqlDelightCompilationUnit
 import app.cash.sqldelight.core.SqlDelightDatabaseProperties
 import app.cash.sqldelight.core.SqlDelightEnvironment
@@ -30,11 +29,6 @@ import java.util.ServiceLoader
 
 @CacheableTask
 abstract class GenerateSchemaTask : SqlDelightWorkerTask() {
-  @Suppress("unused")
-  // Required to invalidate the task on version updates.
-  @Input
-  val pluginVersion = VERSION
-
   @get:OutputDirectory
   var outputDirectory: File? = null
 

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
@@ -30,6 +30,7 @@ abstract class SqlDelightDatabase @Inject constructor(
   abstract val srcDirs: ConfigurableFileCollection
   val deriveSchemaFromMigrations: Property<Boolean> = project.objects.property(Boolean::class.java).convention(false)
   val verifyMigrations: Property<Boolean> = project.objects.property(Boolean::class.java).convention(false)
+  val verifyDefinitions: Property<Boolean> = project.objects.property(Boolean::class.java).convention(true)
   abstract val migrationOutputDirectory: DirectoryProperty
   val migrationOutputFileFormat: Property<String> = project.objects.property(String::class.java).convention(".sql")
   val generateAsync: Property<Boolean> = project.objects.property(Boolean::class.java).convention(false)
@@ -219,17 +220,17 @@ abstract class SqlDelightDatabase @Inject constructor(
         it.projectName.set(project.name)
         it.properties = getProperties()
         it.compilationUnit = getProperties().compilationUnits.single { it.name == source.name }
-        it.outputDirectory = source.outputDir
+        it.outputDirectory.set(source.outputDir)
         it.source(sourceFiles)
         it.include("**${File.separatorChar}*.$SQLDELIGHT_EXTENSION")
         it.include("**${File.separatorChar}*.$MIGRATION_EXTENSION")
         it.group = SqlDelightPlugin.GROUP
         it.description = "Generate ${source.name} Kotlin interface for $name"
-        it.verifyMigrations = verifyMigrations.get()
+        it.verifyMigrations.set(verifyMigrations)
         it.classpath.setFrom(intellijEnv, migrationEnv, configuration)
       }
 
-      val outputDirectoryProvider: Provider<File> = task.map { it.outputDirectory!! }
+      val outputDirectoryProvider: Provider<File> = task.flatMap { it.outputDirectory.asFile }
 
       // Add the source dependency on the generated code.
       // Use a Provider generated from the task to carry task dependencies
@@ -267,11 +268,12 @@ abstract class SqlDelightDatabase @Inject constructor(
         it.source(sourceSet)
         it.include("**${File.separatorChar}*.$SQLDELIGHT_EXTENSION")
         it.include("**${File.separatorChar}*.$MIGRATION_EXTENSION")
-        it.workingDirectory = File(project.buildDir, "sqldelight/migration_verification/${source.name.capitalize()}$name")
+        it.workingDirectory.set(File(project.buildDir, "sqldelight/migration_verification/${source.name.capitalize()}$name"))
         it.group = SqlDelightPlugin.GROUP
         it.description = "Verify ${source.name} $name migrations and CREATE statements match."
         it.properties = getProperties()
-        it.verifyMigrations = verifyMigrations.get()
+        it.verifyMigrations.set(verifyMigrations)
+        it.verifyDefinitions.set(verifyDefinitions)
         it.classpath.setFrom(intellijEnv, migrationEnv, configuration)
       }
 
@@ -279,14 +281,14 @@ abstract class SqlDelightDatabase @Inject constructor(
       project.tasks.register("generate${source.name.capitalize()}${name}Schema", GenerateSchemaTask::class.java) {
         it.projectName.set(project.name)
         it.compilationUnit = getProperties().compilationUnits.single { it.name == source.name }
-        it.outputDirectory = schemaOutputDirectory.get().asFile
+        it.outputDirectory.set(schemaOutputDirectory)
         it.source(sourceSet)
         it.include("**${File.separatorChar}*.$SQLDELIGHT_EXTENSION")
         it.include("**${File.separatorChar}*.$MIGRATION_EXTENSION")
         it.group = SqlDelightPlugin.GROUP
         it.description = "Generate a .db file containing the current $name schema for ${source.name}."
         it.properties = getProperties()
-        it.verifyMigrations = verifyMigrations.get()
+        it.verifyMigrations.set(verifyMigrations)
         it.classpath.setFrom(intellijEnv, migrationEnv, configuration)
       }
     }
@@ -307,8 +309,8 @@ abstract class SqlDelightDatabase @Inject constructor(
       it.compilationUnit = getProperties().compilationUnits.single { it.name == source.name }
       it.source(sourceSet)
       it.include("**${File.separatorChar}*.$MIGRATION_EXTENSION")
-      it.migrationOutputExtension = migrationOutputFileFormat.get()
-      it.outputDirectory = migrationOutputDirectory.get().asFile
+      it.migrationOutputExtension.set(migrationOutputFileFormat)
+      it.outputDirectory.set(migrationOutputDirectory)
       it.group = SqlDelightPlugin.GROUP
       it.description = "Generate valid sql migration files for ${source.name} $name."
       it.properties = getProperties()

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
@@ -135,7 +135,7 @@ abstract class SqlDelightDatabase @Inject constructor(
   }
 
   internal fun getProperties(): SqlDelightDatabasePropertiesImpl {
-    val packageName = requireNotNull(packageName.getOrNull()) { "property packageName for $name database must be provided" }
+    require(packageName.isPresent) { "property packageName for $name database must be provided" }
 
     check(!recursionGuard) { "Found a circular dependency in $project with database $name" }
     recursionGuard = true
@@ -156,7 +156,7 @@ abstract class SqlDelightDatabase @Inject constructor(
 
     try {
       return SqlDelightDatabasePropertiesImpl(
-        packageName = packageName,
+        packageName = packageName.get(),
         compilationUnits = sources.map { source ->
           SqlDelightCompilationUnitImpl(
             name = source.name,
@@ -250,7 +250,7 @@ abstract class SqlDelightDatabase @Inject constructor(
         addSquashTask(sourceFiles, source)
       }
 
-      if (migrationOutputDirectory.getOrNull() != null) {
+      if (migrationOutputDirectory.isPresent) {
         addMigrationOutputTasks(sourceFiles, source)
       }
     }
@@ -275,7 +275,7 @@ abstract class SqlDelightDatabase @Inject constructor(
         it.classpath.setFrom(intellijEnv, migrationEnv, configuration)
       }
 
-    if (schemaOutputDirectory.getOrNull() != null) {
+    if (schemaOutputDirectory.isPresent) {
       project.tasks.register("generate${source.name.capitalize()}${name}Schema", GenerateSchemaTask::class.java) {
         it.projectName.set(project.name)
         it.compilationUnit = getProperties().compilationUnits.single { it.name == source.name }

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
@@ -131,7 +131,7 @@ abstract class SqlDelightPlugin : Plugin<Project> {
       }
 
       databases.forEach { database ->
-        if (database.packageName.getOrNull() == null && android.get() && !isMultiplatform) {
+        if (!database.packageName.isPresent && android.get() && !isMultiplatform) {
           database.packageName.set(project.packageName())
         }
         if (!database.addedDialect && android.get() && !isMultiplatform) {

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
@@ -40,19 +40,17 @@ abstract class SqlDelightPlugin : Plugin<Project> {
   @get:Inject
   abstract val registry: ToolingModelBuilderRegistry
 
-  private lateinit var extension: SqlDelightExtension
-
   override fun apply(project: Project) {
     require(GradleVersion.current() >= GradleVersion.version(MIN_GRADLE_VERSION)) {
       "SQLDelight requires Gradle version $MIN_GRADLE_VERSION or greater."
     }
 
-    extension = project.extensions.create("sqldelight", SqlDelightExtension::class.java)
+    val extension = project.extensions.create("sqldelight", SqlDelightExtension::class.java)
 
     project.plugins.withId("com.android.base") {
       android.set(true)
       project.afterEvaluate {
-        project.setupSqlDelightTasks(afterAndroid = true)
+        project.setupSqlDelightTasks(afterAndroid = true, extension)
       }
     }
 
@@ -71,11 +69,11 @@ abstract class SqlDelightPlugin : Plugin<Project> {
     }
 
     project.afterEvaluate {
-      project.setupSqlDelightTasks(afterAndroid = false)
+      project.setupSqlDelightTasks(afterAndroid = false, extension)
     }
   }
 
-  private fun Project.setupSqlDelightTasks(afterAndroid: Boolean) {
+  private fun Project.setupSqlDelightTasks(afterAndroid: Boolean, extension: SqlDelightExtension) {
     if (android.get() && !afterAndroid) return
 
     check(kotlin.get()) {

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
@@ -63,6 +63,16 @@ abstract class SqlDelightPlugin : Plugin<Project> {
       kotlin.set(true)
     }
 
+    project.tasks.register("generateSqlDelightInterface") {
+      it.group = GROUP
+      it.description = "Aggregation task which runs every interface generation task for every given source"
+    }
+
+    project.tasks.register("verifySqlDelightMigration") {
+      it.group = GROUP
+      it.description = "Aggregation task which runs every migration task for every given source"
+    }
+
     project.afterEvaluate {
       project.setupSqlDelightTasks(afterAndroid = false)
     }
@@ -121,16 +131,6 @@ abstract class SqlDelightPlugin : Plugin<Project> {
         )
       } else if (databases.isEmpty()) {
         logger.warn("SQLDelight Gradle plugin was applied but there are no databases set up.")
-      }
-
-      project.tasks.register("generateSqlDelightInterface") {
-        it.group = GROUP
-        it.description = "Aggregation task which runs every interface generation task for every given source"
-      }
-
-      project.tasks.register("verifySqlDelightMigration") {
-        it.group = GROUP
-        it.description = "Aggregation task which runs every migration task for every given source"
       }
 
       databases.forEach { database ->

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
@@ -27,9 +27,7 @@ import org.gradle.tooling.provider.model.ToolingModelBuilder
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.plugin.KotlinBasePlugin
-import org.jetbrains.kotlin.gradle.dsl.KotlinJsProjectExtension
-import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import org.jetbrains.kotlin.gradle.plugin.sources.DefaultKotlinSourceSet
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetContainer
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 
@@ -86,7 +84,6 @@ abstract class SqlDelightPlugin : Plugin<Project> {
     }
 
     val isMultiplatform = project.plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")
-    val isJsOnly = if (isMultiplatform) false else project.plugins.hasPlugin("org.jetbrains.kotlin.js")
 
     val needsAsyncRuntime = extension.databases.any { it.generateAsync.get() }
     val runtimeDependencies = buildList {
@@ -95,25 +92,10 @@ abstract class SqlDelightPlugin : Plugin<Project> {
     }
 
     // Add the runtime dependency.
-    when {
-      isMultiplatform -> {
-        val sourceSets =
-          project.extensions.getByType(KotlinMultiplatformExtension::class.java).sourceSets
-        val sourceSet = (sourceSets.getByName("commonMain") as DefaultKotlinSourceSet)
-        project.configurations.getByName(sourceSet.apiConfigurationName)
-          .dependencies.addAll(runtimeDependencies)
-      }
-      isJsOnly -> {
-        val sourceSets =
-          project.extensions.getByType(KotlinJsProjectExtension::class.java).sourceSets
-        val sourceSet = (sourceSets.getByName("main") as DefaultKotlinSourceSet)
-        project.configurations.getByName(sourceSet.apiConfigurationName)
-          .dependencies.addAll(runtimeDependencies)
-      }
-      else -> {
-        project.configurations.getByName("api").dependencies.addAll(runtimeDependencies)
-      }
-    }
+    val sourceSetName = if (isMultiplatform) "commonMain" else "main"
+    val sourceSetApiConfigName =
+      project.extensions.getByType(KotlinSourceSetContainer::class.java).sourceSets.getByName(sourceSetName).apiConfigurationName
+    project.configurations.getByName(sourceSetApiConfigName).dependencies.addAll(runtimeDependencies)
 
     if (extension.linkSqlite.getOrElse(true)) {
       project.linkSqlite()

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
@@ -23,7 +23,6 @@ import app.cash.sqldelight.gradle.android.sqliteVersion
 import app.cash.sqldelight.gradle.kotlin.linkSqlite
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.Dependency
 import org.gradle.tooling.provider.model.ToolingModelBuilder
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import org.gradle.util.GradleVersion
@@ -90,7 +89,7 @@ abstract class SqlDelightPlugin : Plugin<Project> {
     val isJsOnly = if (isMultiplatform) false else project.plugins.hasPlugin("org.jetbrains.kotlin.js")
 
     val needsAsyncRuntime = extension.databases.any { it.generateAsync.get() }
-    val runtimeDependencies = mutableListOf<Dependency>().apply {
+    val runtimeDependencies = buildList {
       add(project.dependencies.create("app.cash.sqldelight:runtime:$VERSION"))
       if (needsAsyncRuntime) add(project.dependencies.create("app.cash.sqldelight:async-extensions:$VERSION"))
     }

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
@@ -27,6 +27,7 @@ import org.gradle.api.artifacts.Dependency
 import org.gradle.tooling.provider.model.ToolingModelBuilder
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import org.gradle.util.GradleVersion
+import org.jetbrains.kotlin.gradle.plugin.KotlinBasePlugin
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.sources.DefaultKotlinSourceSet
@@ -58,12 +59,9 @@ abstract class SqlDelightPlugin : Plugin<Project> {
       }
     }
 
-    val kotlinPluginHandler = { _: Plugin<*> -> kotlin.set(true) }
-    project.plugins.withId("org.jetbrains.kotlin.multiplatform", kotlinPluginHandler)
-    project.plugins.withId("org.jetbrains.kotlin.android", kotlinPluginHandler)
-    project.plugins.withId("org.jetbrains.kotlin.jvm", kotlinPluginHandler)
-    project.plugins.withId("org.jetbrains.kotlin.js", kotlinPluginHandler)
-    project.plugins.withId("kotlin2js", kotlinPluginHandler)
+    project.plugins.withType(KotlinBasePlugin::class.java) {
+      kotlin.set(true)
+    }
 
     project.afterEvaluate {
       project.setupSqlDelightTasks(afterAndroid = false)

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
@@ -51,17 +51,12 @@ abstract class SqlDelightPlugin : Plugin<Project> {
 
     extension = project.extensions.create("sqldelight", SqlDelightExtension::class.java)
 
-    val androidPluginHandler = { _: Plugin<*> ->
+    project.plugins.withId("com.android.base") {
       android.set(true)
       project.afterEvaluate {
         project.setupSqlDelightTasks(afterAndroid = true)
       }
     }
-    project.plugins.withId("com.android.application", androidPluginHandler)
-    project.plugins.withId("com.android.library", androidPluginHandler)
-    project.plugins.withId("com.android.instantapp", androidPluginHandler)
-    project.plugins.withId("com.android.feature", androidPluginHandler)
-    project.plugins.withId("com.android.dynamic-feature", androidPluginHandler)
 
     val kotlinPluginHandler = { _: Plugin<*> -> kotlin.set(true) }
     project.plugins.withId("org.jetbrains.kotlin.multiplatform", kotlinPluginHandler)

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
@@ -45,7 +45,9 @@ abstract class SqlDelightPlugin : Plugin<Project> {
       "SQLDelight requires Gradle version $MIN_GRADLE_VERSION or greater."
     }
 
-    val extension = project.extensions.create("sqldelight", SqlDelightExtension::class.java)
+    val extension = project.extensions.create("sqldelight", SqlDelightExtension::class.java).apply {
+      linkSqlite.convention(true)
+    }
 
     project.plugins.withId("com.android.base") {
       android.set(true)
@@ -95,7 +97,7 @@ abstract class SqlDelightPlugin : Plugin<Project> {
       project.extensions.getByType(KotlinSourceSetContainer::class.java).sourceSets.getByName(sourceSetName).apiConfigurationName
     project.configurations.getByName(sourceSetApiConfigName).dependencies.addAll(runtimeDependencies)
 
-    if (extension.linkSqlite.getOrElse(true)) {
+    if (extension.linkSqlite.get()) {
       project.linkSqlite()
     }
 

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
@@ -122,12 +122,10 @@ abstract class SqlDelightPlugin : Plugin<Project> {
     extension.run {
       if (databases.isEmpty() && android.get() && !isMultiplatform) {
         // Default to a database for android named "Database" to keep things simple.
-        databases.add(
-          objects.newInstance(SqlDelightDatabase::class.java, project, "Database").apply {
-            packageName.set(project.packageName())
-            project.sqliteVersion()?.let(::dialect)
-          },
-        )
+        databases.create("Database") { database ->
+          database.packageName.set(project.packageName())
+          project.sqliteVersion()?.let(database::dialect)
+        }
       } else if (databases.isEmpty()) {
         logger.warn("SQLDelight Gradle plugin was applied but there are no databases set up.")
       }

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightTask.kt
@@ -15,7 +15,6 @@
  */
 package app.cash.sqldelight.gradle
 
-import app.cash.sqldelight.VERSION
 import app.cash.sqldelight.core.SqlDelightCompilationUnit
 import app.cash.sqldelight.core.SqlDelightDatabaseProperties
 import app.cash.sqldelight.core.SqlDelightEnvironment
@@ -46,11 +45,6 @@ import java.util.ServiceLoader
 
 @CacheableTask
 abstract class SqlDelightTask : SqlDelightWorkerTask() {
-  @Suppress("unused")
-  // Required to invalidate the task on version updates.
-  @Input
-  val pluginVersion = VERSION
-
   @get:OutputDirectory
   var outputDirectory: File? = null
 

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightTask.kt
@@ -40,13 +40,12 @@ import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
-import java.io.File
 import java.util.ServiceLoader
 
 @CacheableTask
 abstract class SqlDelightTask : SqlDelightWorkerTask() {
   @get:OutputDirectory
-  var outputDirectory: File? = null
+  abstract val outputDirectory: DirectoryProperty
 
   @get:Input abstract val projectName: Property<String>
 
@@ -54,7 +53,7 @@ abstract class SqlDelightTask : SqlDelightWorkerTask() {
 
   @get:Nested abstract var compilationUnit: SqlDelightCompilationUnitImpl
 
-  @Input var verifyMigrations: Boolean = false
+  @get:Input abstract val verifyMigrations: Property<Boolean>
 
   @TaskAction
   fun generateSqlDelightFiles() {

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/VerifyMigrationTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/VerifyMigrationTask.kt
@@ -40,15 +40,15 @@ abstract class VerifyMigrationTask : SqlDelightWorkerTask() {
   @get:Input abstract val projectName: Property<String>
 
   /** Directory where the database files are copied for the migration scripts to run against. */
-  @get:Internal abstract var workingDirectory: File
+  @get:Internal abstract val workingDirectory: DirectoryProperty
 
   @get:Nested abstract var properties: SqlDelightDatabasePropertiesImpl
 
   @get:Nested abstract var compilationUnit: SqlDelightCompilationUnitImpl
 
-  @Input var verifyMigrations: Boolean = false
+  @get:Input abstract val verifyMigrations: Property<Boolean>
 
-  @Input var verifyDefinitions: Boolean = true
+  @get:Input abstract val verifyDefinitions: Property<Boolean>
 
   @get:Input abstract val driverProperties: MapProperty<String, String>
 
@@ -68,7 +68,7 @@ abstract class VerifyMigrationTask : SqlDelightWorkerTask() {
       it.verifyMigrations.set(verifyMigrations)
       it.compilationUnit.set(compilationUnit)
       it.verifyDefinitions.set(verifyDefinitions)
-      it.driverProperties.set(driverProperties.get())
+      it.driverProperties.set(driverProperties)
       it.outputFile.set(getDummyOutputFile())
     }
   }

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/VerifyMigrationTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/VerifyMigrationTask.kt
@@ -1,6 +1,5 @@
 package app.cash.sqldelight.gradle
 
-import app.cash.sqldelight.VERSION
 import app.cash.sqldelight.core.SqlDelightCompilationUnit
 import app.cash.sqldelight.core.SqlDelightDatabaseProperties
 import app.cash.sqldelight.core.SqlDelightEnvironment
@@ -38,11 +37,6 @@ import kotlin.collections.ArrayList
 
 @CacheableTask
 abstract class VerifyMigrationTask : SqlDelightWorkerTask() {
-  @Suppress("unused")
-  // Required to invalidate the task on version updates.
-  @Input
-  val pluginVersion = VERSION
-
   @get:Input abstract val projectName: Property<String>
 
   /** Directory where the database files are copied for the migration scripts to run against. */

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/kotlin/SourceRoots.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/kotlin/SourceRoots.kt
@@ -7,11 +7,8 @@ import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.api.BaseVariant
 import org.gradle.api.DomainObjectSet
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.TaskContainer
-import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.kotlin.gradle.dsl.KotlinJsProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
@@ -111,16 +108,6 @@ private fun BaseExtension.sources(project: Project): List<Source> {
         variant.addJavaSourceFoldersToModel(outputDirectoryProvider.get())
       },
     )
-  }
-}
-
-private fun TaskContainer.namedOrNull(
-  taskName: String,
-): TaskProvider<Task>? {
-  return try {
-    named(taskName)
-  } catch (_: Exception) {
-    null
   }
 }
 

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/squash/MigrationSquashTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/squash/MigrationSquashTask.kt
@@ -28,7 +28,7 @@ import java.util.ServiceLoader
 
 @CacheableTask
 abstract class MigrationSquashTask : SqlDelightWorkerTask() {
-  @Input val projectName: Property<String> = project.objects.property(String::class.java)
+  @get:Input abstract val projectName: Property<String>
 
   @get:Nested abstract var properties: SqlDelightDatabasePropertiesImpl
 

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/squash/MigrationSquashTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/squash/MigrationSquashTask.kt
@@ -1,6 +1,5 @@
 package app.cash.sqldelight.gradle.squash
 
-import app.cash.sqldelight.VERSION
 import app.cash.sqldelight.core.SqlDelightCompilationUnit
 import app.cash.sqldelight.core.SqlDelightDatabaseProperties
 import app.cash.sqldelight.core.SqlDelightEnvironment
@@ -29,11 +28,6 @@ import java.util.ServiceLoader
 
 @CacheableTask
 abstract class MigrationSquashTask : SqlDelightWorkerTask() {
-  @Suppress("unused")
-  // Required to invalidate the task on version updates.
-  @Input
-  val pluginVersion = VERSION
-
   @Input val projectName: Property<String> = project.objects.property(String::class.java)
 
   @Nested lateinit var properties: SqlDelightDatabasePropertiesImpl

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/squash/MigrationSquashTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/squash/MigrationSquashTask.kt
@@ -30,9 +30,9 @@ import java.util.ServiceLoader
 abstract class MigrationSquashTask : SqlDelightWorkerTask() {
   @Input val projectName: Property<String> = project.objects.property(String::class.java)
 
-  @Nested lateinit var properties: SqlDelightDatabasePropertiesImpl
+  @get:Nested abstract var properties: SqlDelightDatabasePropertiesImpl
 
-  @Nested lateinit var compilationUnit: SqlDelightCompilationUnitImpl
+  @get:Nested abstract var compilationUnit: SqlDelightCompilationUnitImpl
 
   @TaskAction
   fun generateSquashedMigrationFile() {


### PR DESCRIPTION
#4222 with a fix for:

```
java.lang.NoClassDefFoundError: com/android/build/gradle/api/AndroidBasePlugin
```

The plugin now checks for `plugins.withId("com.android.base")` instead of `plugins.withType(AndroidBasePlugin::class.java)` which should resolve that problem.

I can rebase once #4284 is merged if preferred, just let me know.