### PR TITLE
Add support for SuspendingTransacter in QueryPagingSource

### DIFF
--- a/extensions/androidx-paging3/src/commonMain/kotlin/app/cash/sqldelight/paging3/QueryPagingSource.kt
+++ b/extensions/androidx-paging3/src/commonMain/kotlin/app/cash/sqldelight/paging3/QueryPagingSource.kt
@@ -18,7 +18,7 @@ package app.cash.sqldelight.paging3
 import app.cash.paging.PagingConfig
 import app.cash.paging.PagingSource
 import app.cash.sqldelight.Query
-import app.cash.sqldelight.Transacter
+import app.cash.sqldelight.TransacterBase
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlCursor
 import kotlin.coroutines.CoroutineContext
@@ -63,7 +63,7 @@ internal abstract class QueryPagingSource<Key : Any, RowType : Any> :
 @JvmName("QueryPagingSourceInt")
 fun <RowType : Any> QueryPagingSource(
   countQuery: Query<Int>,
-  transacter: Transacter,
+  transacter: TransacterBase,
   context: CoroutineContext,
   queryProvider: (limit: Int, offset: Int) -> Query<RowType>,
 ): PagingSource<Int, RowType> = OffsetQueryPagingSource(
@@ -86,7 +86,7 @@ fun <RowType : Any> QueryPagingSource(
 @JvmName("QueryPagingSourceLong")
 fun <RowType : Any> QueryPagingSource(
   countQuery: Query<Long>,
-  transacter: Transacter,
+  transacter: TransacterBase,
   context: CoroutineContext,
   queryProvider: (limit: Long, offset: Long) -> Query<RowType>,
 ): PagingSource<Int, RowType> = OffsetQueryPagingSource(
@@ -165,7 +165,7 @@ private fun Query<Long>.toInt(): Query<Int> =
  */
 @Suppress("FunctionName")
 fun <Key : Any, RowType : Any> QueryPagingSource(
-  transacter: Transacter,
+  transacter: TransacterBase,
   context: CoroutineContext,
   pageBoundariesProvider: (anchor: Key?, limit: Long) -> Query<Key>,
   queryProvider: (beginInclusive: Key, endExclusive: Key?) -> Query<RowType>,

--- a/extensions/androidx-paging3/src/commonTest/kotlin/app/cash/sqldelight/paging3/KeyedQueryPagingSourceTest.kt
+++ b/extensions/androidx-paging3/src/commonTest/kotlin/app/cash/sqldelight/paging3/KeyedQueryPagingSourceTest.kt
@@ -20,7 +20,8 @@ import app.cash.paging.PagingSourceLoadParamsRefresh
 import app.cash.paging.PagingSourceLoadResultPage
 import app.cash.paging.PagingState
 import app.cash.sqldelight.Query
-import app.cash.sqldelight.Transacter
+import app.cash.sqldelight.SuspendingTransacterImpl
+import app.cash.sqldelight.TransacterBase
 import app.cash.sqldelight.TransacterImpl
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlCursor
@@ -32,17 +33,33 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 @ExperimentalCoroutinesApi
-class KeyedQueryPagingSourceTest : DbTest {
+class KeyedQueryPagingSourceTest : BaseKeyedQueryPagingSourceTest() {
+  override fun createTransacter(driver: SqlDriver): TransacterBase {
+    return object : TransacterImpl(driver) {}
+  }
+}
+
+@ExperimentalCoroutinesApi
+class KeyedQueryPagingSourceWithSuspendingTransacterTest : BaseKeyedQueryPagingSourceTest() {
+  override fun createTransacter(driver: SqlDriver): TransacterBase {
+    return object : SuspendingTransacterImpl(driver) {}
+  }
+}
+
+@ExperimentalCoroutinesApi
+abstract class BaseKeyedQueryPagingSourceTest : DbTest {
 
   private lateinit var driver: SqlDriver
-  private lateinit var transacter: Transacter
+  private lateinit var transacter: TransacterBase
   private lateinit var source: KeyedQueryPagingSource<Long, Long>
+
+  abstract fun createTransacter(driver: SqlDriver): TransacterBase
 
   override suspend fun setup(driver: SqlDriver) {
     this.driver = driver
     driver.execute(null, "CREATE TABLE testTable(value INTEGER PRIMARY KEY)", 0)
     (0L until 10L).forEach { this.insert(it) }
-    transacter = object : TransacterImpl(driver) {}
+    transacter = createTransacter(driver)
     source = KeyedQueryPagingSource(
       queryProvider = this::query,
       pageBoundariesProvider = this::pageBoundaries,

--- a/extensions/androidx-paging3/src/commonTest/kotlin/app/cash/sqldelight/paging3/OffsetQueryPagingSourceTest.kt
+++ b/extensions/androidx-paging3/src/commonTest/kotlin/app/cash/sqldelight/paging3/OffsetQueryPagingSourceTest.kt
@@ -29,7 +29,8 @@ import app.cash.paging.PagingSourceLoadResultInvalid
 import app.cash.paging.PagingSourceLoadResultPage
 import app.cash.paging.PagingState
 import app.cash.sqldelight.Query
-import app.cash.sqldelight.Transacter
+import app.cash.sqldelight.SuspendingTransacterImpl
+import app.cash.sqldelight.TransacterBase
 import app.cash.sqldelight.TransacterImpl
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlCursor
@@ -47,16 +48,32 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
-class OffsetQueryPagingSourceTest : DbTest {
+class OffsetQueryPagingSourceTest : BaseOffsetQueryPagingSourceTest() {
+  override fun createTransacter(driver: SqlDriver): TransacterBase {
+    return object : TransacterImpl(driver) {}
+  }
+}
+
+@ExperimentalCoroutinesApi
+class OffsetQueryPagingSourceWithSuspendingTransacterTest : BaseOffsetQueryPagingSourceTest() {
+  override fun createTransacter(driver: SqlDriver): TransacterBase {
+    return object : SuspendingTransacterImpl(driver) {}
+  }
+}
+
+@ExperimentalCoroutinesApi
+abstract class BaseOffsetQueryPagingSourceTest : DbTest {
 
   private lateinit var driver: SqlDriver
-  private lateinit var transacter: Transacter
+  private lateinit var transacter: TransacterBase
   private lateinit var pagingSource: PagingSource<Int, TestItem>
+
+  abstract fun createTransacter(driver: SqlDriver): TransacterBase
 
   override suspend fun setup(driver: SqlDriver) {
     this.driver = driver
     driver.execute(null, "CREATE TABLE TestItem(id INTEGER NOT NULL PRIMARY KEY);", 0)
-    transacter = object : TransacterImpl(driver) {}
+    transacter = createTransacter(driver)
     pagingSource = QueryPagingSource(
       countQuery(),
       transacter,


### PR DESCRIPTION
Fixes #4291

The QueryPagingSource API is extended not only to support a blocking Transacter, but a more generic TransacterBase which includes SuspendingTransacter.
The solution is rather crude, but I think it's better than copying two large blocks of code which only differ by one line.