### PR TITLE
MySQL: support unsigned ints without display width

### DIFF
--- a/dialects/mysql/src/main/kotlin/app/cash/sqldelight/dialects/mysql/grammar/MySql.bnf
+++ b/dialects/mysql/src/main/kotlin/app/cash/sqldelight/dialects/mysql/grammar/MySql.bnf
@@ -85,7 +85,7 @@ type_name ::= (
   date_data_type |
   binary_data_type |
   json_data_type
-) [ LP {signed_number} RP [ 'unsigned' ] | LP {signed_number} COMMA {signed_number} RP ] |
+) [ LP {signed_number} RP | LP {signed_number} COMMA {signed_number} RP ] [ 'unsigned' ] |
 character_type |
 enum_set_type
 {

--- a/dialects/mysql/src/test/fixtures_mysql/number-types/Number.s
+++ b/dialects/mysql/src/test/fixtures_mysql/number-types/Number.s
@@ -1,4 +1,5 @@
 CREATE TABLE numbers (
   is_nullable bit(1) NOT NULL,
-  row_number int(10) unsigned DEFAULT NULL
+  row_number int(10) unsigned DEFAULT NULL,
+  no_width int unsigned DEFAULT NULL
 );


### PR DESCRIPTION
MySQL 8 deprecates int display width