### PR TITLE
Test for select with group by and coalesce

### DIFF
--- a/dialects/mysql/src/test/fixtures_mysql/select-group-by/Test.s
+++ b/dialects/mysql/src/test/fixtures_mysql/select-group-by/Test.s
@@ -1,0 +1,12 @@
+CREATE TABLE test(
+  someColumn VARCHAR(8) NOT NULL,
+  someColumn2 VARCHAR(8) NOT NULL
+);
+
+SELECT someColumn
+FROM test
+GROUP BY someColumn;
+
+SELECT someColumn
+FROM test
+GROUP BY COALESCE(someColumn, 'default');


### PR DESCRIPTION
We ran into this in our queries. I bisected and found ce827d11f551625b01b8c567a991c54e26b42157 introduced a breaking change here. This only breaks when columns are referenced inside of functions (first query works, second doesn't)

```
MySqlFixturesTest > execute[select-group-by] FAILED
    java.lang.AssertionError: Test failed because the compile output unexpectedly has the errors <[
        Test.s line 12:18 - No column found with name someColumn
    ]>. 
    Overall we expected to see no errors but got the errors <[
        Test.s line 12:18 - No column found with name someColumn
    ]>
```