### PR TITLE
Gradle plugin: Don't expose linkSqlite

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/kotlin/LinkSqlite.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/kotlin/LinkSqlite.kt
@@ -4,7 +4,7 @@ import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
-fun Project.linkSqlite() {
+internal fun Project.linkSqlite() {
   val extension = project.extensions.findByType(KotlinMultiplatformExtension::class.java) ?: return
   extension.targets
     .filterIsInstance<KotlinNativeTarget>()


### PR DESCRIPTION
We should not expose this internal function to our public Gradle plugin api. Users should use the sqldelight extension.