### PR TITLE
Introduce executeAsFlow instead of executeAsList to provide streaming

### DIFF
--- a/extensions/coroutines-extensions/src/commonMain/kotlin/app/cash/sqldelight/coroutines/FlowExtensions.kt
+++ b/extensions/coroutines-extensions/src/commonMain/kotlin/app/cash/sqldelight/coroutines/FlowExtensions.kt
@@ -92,3 +92,16 @@ fun <T : Any> Flow<Query<T>>.mapToList(
     it.awaitAsList()
   }
 }
+
+/**
+ * Returns the result rows as a flow.
+ * Note: This emits an item for every row returned.
+ * It provides a streaming API to get all rows.
+ */
+fun <T : Any> Query<T>.executeAsFlow(): Flow<T> = execute { sqlCursor ->
+    flow {
+        while (sqlCursor.next()) {
+            emit(this@executeAsFlow.mapper(sqlCursor))
+        }
+    }
+}.value


### PR DESCRIPTION
Provides a streaming api. Especially usefull for large resultsets to prevent loading the complete list in memory.

Note: This is just a suggestion, it misses tests. Curious about what the repo-owners think about it. 