### PR TITLE
Do not run assemble task et al. in jobs

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -50,8 +50,6 @@ jobs:
 
       - name: Run spotless
         run: ./gradlew spotlessCheck
-      - name: Assemble parallel
-        run: ./gradlew assemble dokkaHtml sourceJar sourceDebugJar sourceReleaseJar
 
       # Linux tests
       - name: Run gradle tests


### PR DESCRIPTION
Instead of just building every artifact, we should just let each job build the artifacts it needs as part of each step.

This may also help to cut down our cache footprint, which is way over Github's limit (we're likely dropping caches as we create new ones, which is not helping our cache hit rate!)