### PR TITLE
Address aggregate functions and typing behavior when there is/isn't a group

### DIFF
--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/ExpressionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/ExpressionTest.kt
@@ -236,6 +236,142 @@ class ExpressionTest {
     assertThat(query.resultColumns.single().javaType).isEqualTo(LONG)
   }
 
+  @Test fun `aggregate function not referencing a row returns a nullable type for other columns if there's no group`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE test (
+      |  id INTEGER NOT NULL
+      |);
+      |
+      |someSelect:
+      |SELECT id,
+      |       COUNT(*)
+      |FROM test;
+      """.trimMargin(),
+      tempFolder,
+    )
+
+    val query = file.namedQueries.first()
+    assertThat(query.resultColumns.map { it.javaType }).containsExactly(
+      LONG.copy(nullable = true),
+      LONG,
+    ).inOrder()
+  }
+
+  @Test fun `aggregate function not referencing a row returns a non null type for other non null columns if there's a group`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE test (
+      |  id INTEGER NOT NULL
+      |);
+      |
+      |someSelect:
+      |SELECT id,
+      |       COUNT(*)
+      |FROM test
+      |GROUP BY id;
+      """.trimMargin(),
+      tempFolder,
+    )
+
+    val query = file.namedQueries.first()
+    assertThat(query.resultColumns.map { it.javaType }).containsExactly(
+      LONG,
+      LONG,
+    ).inOrder()
+  }
+
+  @Test fun `aggregate function not referencing a row returns a nullable type for other nullable columns if there's a group`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE test (
+      |  id INTEGER
+      |);
+      |
+      |someSelect:
+      |SELECT id,
+      |       COUNT(*)
+      |FROM test
+      |GROUP BY id;
+      """.trimMargin(),
+      tempFolder,
+    )
+
+    val query = file.namedQueries.first()
+    assertThat(query.resultColumns.map { it.javaType }).containsExactly(
+      LONG.copy(nullable = true),
+      LONG,
+    ).inOrder()
+  }
+
+  @Test fun `aggregate function referencing a row returns a nullable type for other non null columns if there's no group`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE test (
+      |  id INTEGER NOT NULL
+      |);
+      |
+      |someSelect:
+      |SELECT id,
+      |       MAX(id)
+      |FROM test;
+      """.trimMargin(),
+      tempFolder,
+    )
+
+    val query = file.namedQueries.first()
+    assertThat(query.resultColumns.map { it.javaType }).containsExactly(
+      LONG.copy(nullable = true),
+      LONG.copy(nullable = true),
+    ).inOrder()
+  }
+
+  @Test fun `aggregate function referencing a row returns a non nullable type for other non null columns if there's a group`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE test (
+      |  id INTEGER NOT NULL
+      |);
+      |
+      |someSelect:
+      |SELECT id,
+      |       MAX(id)
+      |FROM test
+      |GROUP BY id;
+      """.trimMargin(),
+      tempFolder,
+    )
+
+    val query = file.namedQueries.first()
+    assertThat(query.resultColumns.map { it.javaType }).containsExactly(
+      LONG,
+      LONG,
+    ).inOrder()
+  }
+
+  @Test fun `aggregate function referencing a row returns a nullable type for other nullable columns if there's a group`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE test (
+      |  id INTEGER
+      |);
+      |
+      |someSelect:
+      |SELECT id,
+      |       MAX(id)
+      |FROM test
+      |GROUP BY id;
+      """.trimMargin(),
+      tempFolder,
+    )
+
+    val query = file.namedQueries.first()
+    assertThat(query.resultColumns.map { it.javaType }).containsExactly(
+      LONG.copy(nullable = true),
+      LONG,
+    ).inOrder()
+  }
+
   @Test fun `instr function returns nullable int if any of the args are null`() {
     val file = FixtureCompiler.parseSql(
       """


### PR DESCRIPTION
Came across a case in one of my projects where I was using `COUNT` without a group, and had other columns in the projection. If the table is empty, the other column will be null even if it is a non nullable column:

```sql
CREATE TABLE test (
  id INTEGER NOT NULL
);

-- returns null | 0
SELECT id, COUNT(*) FROM test;
```

While testing this, I also found that functions like `MAX` will not return null for `MAX` if there is a `GROUP BY` specified even if the table is empty. Current behavior always sets `MAX` to nullable. The [Sqlite docs](https://www.sqlite.org/lang_aggfunc.html#max_agg) are a little tricky because they specify that:

> Aggregate max() returns NULL if and only if there are no non-NULL values in the group

which means that if there are no values in the group, it won't return null (instead the result set is empty). Postgres (v15) and MySQL (v8) seems to have the same behavior.

```sql
-- null
SELECT MAX(id) FROM test;

--empty
SELECT MAX(id) FROM test GROUP BY id;

--empty
SELECT id, MAX(id) FROM test GROUP BY id;

-- Error in Postgres and MySQL
-- null | null on Sqlite
SELECT id, MAX(id) FROM test;
```