### PR TITLE
Postgres Dialect: Support proper types for binary expr and sum

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -165,7 +165,7 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
 
   private fun SqlExpr.postgreSqlType(): IntermediateType = when (this) {
     is SqlBinaryExpr -> {
-      if (node.findChildByType(binaryExpressionChildOfTypeSet) != null) {
+      if (node.findChildByType(binaryExprChildTypesResolvingToBool) != null) {
         IntermediateType(PrimitiveType.BOOLEAN)
       } else {
         encapsulatingType(
@@ -200,7 +200,7 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
   }
 
   companion object {
-    private val binaryExpressionChildOfTypeSet = TokenSet.create(
+    private val binaryExprChildTypesResolvingToBool = TokenSet.create(
       SqlTypes.EQ,
       SqlTypes.EQ2,
       SqlTypes.NEQ,

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -21,6 +21,10 @@ import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlExtensionEx
 import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlInsertStmt
 import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlTypeName
 import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlUpdateStmtLimited
+import com.alecstrong.sql.psi.core.psi.SqlBinaryAddExpr
+import com.alecstrong.sql.psi.core.psi.SqlBinaryExpr
+import com.alecstrong.sql.psi.core.psi.SqlBinaryMultExpr
+import com.alecstrong.sql.psi.core.psi.SqlBinaryPipeExpr
 import com.alecstrong.sql.psi.core.psi.SqlColumnExpr
 import com.alecstrong.sql.psi.core.psi.SqlCreateTableStmt
 import com.alecstrong.sql.psi.core.psi.SqlExpr
@@ -28,6 +32,8 @@ import com.alecstrong.sql.psi.core.psi.SqlFunctionExpr
 import com.alecstrong.sql.psi.core.psi.SqlLiteralExpr
 import com.alecstrong.sql.psi.core.psi.SqlStmt
 import com.alecstrong.sql.psi.core.psi.SqlTypeName
+import com.alecstrong.sql.psi.core.psi.SqlTypes
+import com.intellij.psi.tree.TokenSet
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.asTypeName
@@ -90,6 +96,14 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
     "coalesce", "ifnull" -> encapsulatingType(exprList, SMALL_INT, PostgreSqlType.INTEGER, INTEGER, BIG_INT, REAL, TEXT, BLOB)
     "max" -> encapsulatingType(exprList, SMALL_INT, PostgreSqlType.INTEGER, INTEGER, BIG_INT, REAL, TEXT, BLOB, TIMESTAMP_TIMEZONE, TIMESTAMP).asNullable()
     "min" -> encapsulatingType(exprList, BLOB, TEXT, SMALL_INT, INTEGER, PostgreSqlType.INTEGER, BIG_INT, REAL, TIMESTAMP_TIMEZONE, TIMESTAMP).asNullable()
+    "sum" -> {
+      val type = resolvedType(exprList.single())
+      if (type.dialectType == REAL) {
+        IntermediateType(REAL).asNullable()
+      } else {
+        IntermediateType(INTEGER).asNullable()
+      }
+    }
     "date_trunc" -> encapsulatingType(exprList, TIMESTAMP_TIMEZONE, TIMESTAMP)
     "date_part" -> IntermediateType(REAL)
     "percentile_disc" -> IntermediateType(REAL).asNullable()
@@ -150,6 +164,23 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
   }
 
   private fun SqlExpr.postgreSqlType(): IntermediateType = when (this) {
+    is SqlBinaryExpr -> {
+      if (node.findChildByType(binaryExpressionChildOfTypeSet) != null) {
+        IntermediateType(PrimitiveType.BOOLEAN)
+      } else {
+        encapsulatingType(
+          exprList = getExprList(),
+          nullableIfAny = this is SqlBinaryAddExpr || this is SqlBinaryMultExpr || this is SqlBinaryPipeExpr,
+          SMALL_INT,
+          PostgreSqlType.INTEGER,
+          INTEGER,
+          BIG_INT,
+          REAL,
+          TEXT,
+          BLOB,
+        )
+      }
+    }
     is SqlLiteralExpr -> when {
       literalValue.text == "CURRENT_DATE" -> IntermediateType(PostgreSqlType.DATE)
       literalValue.text == "CURRENT_TIME" -> IntermediateType(PostgreSqlType.TIME)
@@ -166,5 +197,20 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
     }
 
     else -> parentResolver.resolvedType(this)
+  }
+
+  companion object {
+    private val binaryExpressionChildOfTypeSet = TokenSet.create(
+      SqlTypes.EQ,
+      SqlTypes.EQ2,
+      SqlTypes.NEQ,
+      SqlTypes.NEQ2,
+      SqlTypes.AND,
+      SqlTypes.OR,
+      SqlTypes.GT,
+      SqlTypes.GTE,
+      SqlTypes.LT,
+      SqlTypes.LTE,
+    )
   }
 }

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Numbers.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Numbers.sq
@@ -1,0 +1,38 @@
+CREATE TABLE ints (
+  small SMALLINT,
+  reg INTEGER,
+  big BIGINT
+);
+
+insertInts:
+INSERT INTO ints
+VALUES (?, ?, ?);
+
+multiplyInts:
+SELECT small * small, reg * reg, big * big FROM ints;
+
+multiplyWithBigInts:
+SELECT small * big AS small, reg * big AS reg FROM ints;
+
+sumInts:
+SELECT sum(small) AS sumSmall, sum(reg) AS sumInt, sum(big) AS sumBig FROM ints;
+
+minInts:
+SELECT  min(small) AS minSmall, min(reg) AS minInt, min(big) AS minBig FROM ints;
+
+maxInts:
+SELECT  max(small) AS maxSmall, max(reg) AS maxInt, max(big) AS maxBig FROM ints;
+
+CREATE TABLE floats (
+  flo FLOAT
+);
+
+insertFloats:
+INSERT INTO floats
+VALUES (?);
+
+sumMinMaxFloat:
+SELECT sum(flo) AS sumFloat, min(flo) AS minFloat, max(flo) AS maxFloat FROM floats;
+
+multiplyFloatInt:
+SELECT flo * big AS mul FROM floats, ints;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -327,4 +327,126 @@ class PostgreSqlTest {
       ),
     )
   }
+
+  @Test fun testIntsMinMaxSum() {
+    with(
+      database.numbersQueries.sumInts().executeAsOne(),
+    ) {
+      assertThat(sumSmall).isNull()
+      assertThat(sumInt).isNull()
+      assertThat(sumBig).isNull()
+    }
+
+    with(
+      database.numbersQueries.minInts().executeAsOne(),
+    ) {
+      assertThat(minSmall).isNull()
+      assertThat(minInt).isNull()
+      assertThat(minBig).isNull()
+    }
+
+    with(
+      database.numbersQueries.maxInts().executeAsOne(),
+    ) {
+      assertThat(maxSmall).isNull()
+      assertThat(maxInt).isNull()
+      assertThat(maxBig).isNull()
+    }
+
+    database.numbersQueries.insertInts(
+      small = 1,
+      reg = 1,
+      big = 1,
+    )
+    database.numbersQueries.insertInts(
+      small = 2,
+      big = 2,
+      reg = 2,
+    )
+
+    with(
+      database.numbersQueries.sumInts().executeAsOne(),
+    ) {
+      assertThat(sumSmall).isInstanceOf(Long::class.javaObjectType)
+      assertThat(sumInt).isInstanceOf(Long::class.javaObjectType)
+      assertThat(sumBig).isInstanceOf(Long::class.javaObjectType)
+      assertThat(sumSmall).isEqualTo(3)
+      assertThat(sumInt).isEqualTo(3)
+      assertThat(sumBig).isEqualTo(3)
+    }
+
+    with(
+      database.numbersQueries.minInts().executeAsOne(),
+    ) {
+      assertThat(minSmall).isEqualTo(1)
+      assertThat(minInt).isEqualTo(1)
+      assertThat(minBig).isEqualTo(1)
+    }
+
+    with(
+      database.numbersQueries.maxInts().executeAsOne(),
+    ) {
+      assertThat(maxSmall).isEqualTo(2)
+      assertThat(maxInt).isEqualTo(2)
+      assertThat(maxBig).isEqualTo(2)
+    }
+  }
+
+  @Test
+  fun testMultiplySmallerIntsBecomeLongs() {
+    database.numbersQueries.insertInts(
+      small = 1,
+      reg = 1,
+      big = Long.MAX_VALUE,
+    )
+
+    with(
+      database.numbersQueries.multiplyWithBigInts().executeAsOne(),
+    ) {
+      assertThat(small).isEqualTo(Long.MAX_VALUE)
+      assertThat(reg).isEqualTo(Long.MAX_VALUE)
+    }
+  }
+
+  @Test
+  fun testFloat() {
+    with(
+      database.numbersQueries.sumMinMaxFloat().executeAsOne(),
+    ) {
+      assertThat(sumFloat).isNull()
+      assertThat(minFloat).isNull()
+      assertThat(maxFloat).isNull()
+    }
+
+    database.numbersQueries.insertFloats(
+      flo = 1.5,
+    )
+
+    with(
+      database.numbersQueries.sumMinMaxFloat().executeAsOne(),
+    ) {
+      assertThat(sumFloat).isEqualTo(1.5)
+      assertThat(minFloat).isEqualTo(1.5)
+      assertThat(maxFloat).isEqualTo(1.5)
+    }
+  }
+
+  @Test
+  fun testMultiplyFloatInt() {
+    database.numbersQueries.insertInts(
+      small = 3,
+      reg = 3,
+      big = 3,
+    )
+
+    database.numbersQueries.insertFloats(
+      flo = 1.5,
+    )
+
+    with(
+      database.numbersQueries.multiplyFloatInt().executeAsOne(),
+    ) {
+      assertThat(mul).isEqualTo(4.5)
+    }
+  }
 }


### PR DESCRIPTION
Based off this PR https://github.com/cashapp/sqldelight/pull/4254 but in Postgres