### PR TITLE
Fix 3916 PostgreSql rename column

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -293,6 +293,7 @@ alter_table_column_alias ::= id | string {
     "com.alecstrong.sql.psi.core.psi.AliasElement";
     "com.alecstrong.sql.psi.core.psi.NamedElement";
     "com.alecstrong.sql.psi.core.psi.SqlCompositeElement"
+    "com.alecstrong.sql.psi.core.psi.SqlColumnName"
   ]
 }
 

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/AlterTableRenameColumnMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/AlterTableRenameColumnMixin.kt
@@ -18,7 +18,7 @@ internal abstract class AlterTableRenameColumnMixin(
   PostgreSqlAlterTableRenameColumn,
   AlterTableApplier {
   private val columnName
-    get() = children.filterIsInstance<SqlColumnName>().single()
+    get() = children.filterIsInstance<SqlColumnName>().first()
 
   private val columnAlias
     get() = children.filterIsInstance<SqlColumnAlias>().single()

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/alter-table-rename-column/1.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/alter-table-rename-column/1.s
@@ -11,3 +11,6 @@ FROM test;
 
 SELECT value2
 FROM test;
+
+ALTER TABLE test
+  RENAME COLUMN value2 TO value3;

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/alter-table-rename-column/1.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/alter-table-rename-column/1.s
@@ -14,3 +14,11 @@ FROM test;
 
 ALTER TABLE test
   RENAME COLUMN value2 TO value3;
+
+-- error[col 7]: No column found with name value2
+SELECT value2
+FROM test;
+
+SELECT value3
+FROM test;
+


### PR DESCRIPTION
🌵 `SqlColumnAlias` element doesn't implement `SqlColumnName` but is added to table columns for querying later. 
After the columns were modified during a rename the element was not found on subsequent query of `SqlColumnName` types.

Now, implementing as `SqlColumnName` it takes the first child element of the pair of `SqlColumnName` types representing the `a` to `b` rename.

fixes #3916 