### PR TITLE
Fix 4580 Add PostgreSql Select Distinct On

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -10,6 +10,7 @@
   parserImports=[
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ADD"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ABORT"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.ALL"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ALTER"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ALWAYS"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.AS"
@@ -27,6 +28,7 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.DEFAULT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.DELETE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.DESC"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.DISTINCT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.DO"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.DOT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.DROP"
@@ -40,6 +42,7 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.FROM"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.GENERATED"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.GROUP"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.HAVING"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ID"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.IF"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.IGNORE"
@@ -63,6 +66,7 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.REPLACE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ROLLBACK"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.RP"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.SELECT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.SET"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.STRING"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.TO"
@@ -70,6 +74,7 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.UNIQUE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.UPDATE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.USING"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.VALUES"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.WHERE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.WITH"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.WITHOUT"
@@ -91,6 +96,7 @@ overrides ::= type_name
   | extension_expr
   | extension_stmt
   | create_index_stmt
+  | select_stmt
 
 column_constraint ::= [ CONSTRAINT {identifier} ] (
   PRIMARY KEY [ ASC | DESC ] {conflict_clause} |
@@ -316,6 +322,13 @@ alter_table_alter_column ::= ALTER [COLUMN] {column_name}
 | SET GENERATED (ALWAYS | BY DEFAULT )
 ) {
   mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.AlterTableAlterColumnMixin"
+  pin = 1
+}
+
+select_stmt ::= SELECT ( [ DISTINCT ON LP {result_column} ( COMMA {result_column} ) * RP ] | [ DISTINCT | ALL ] ) {result_column} ( COMMA {result_column} ) * [ FROM {join_clause} ] [ WHERE <<expr '-1'>> ] [{group_by}] [HAVING <<expr '-1'>>] | VALUES {values_expression} ( COMMA {values_expression} ) * {
+  extends = "com.alecstrong.sql.psi.core.psi.impl.SqlSelectStmtImpl"
+  implements = "com.alecstrong.sql.psi.core.psi.SqlSelectStmt"
+  override = true
   pin = 1
 }
 

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -325,7 +325,12 @@ alter_table_alter_column ::= ALTER [COLUMN] {column_name}
   pin = 1
 }
 
-select_stmt ::= SELECT ( [ DISTINCT ON LP {result_column} ( COMMA {result_column} ) * RP ] | [ DISTINCT | ALL ] ) {result_column} ( COMMA {result_column} ) * [ FROM {join_clause} ] [ WHERE <<expr '-1'>> ] [{group_by}] [HAVING <<expr '-1'>>] | VALUES {values_expression} ( COMMA {values_expression} ) * {
+distinct_on_expr ::= DISTINCT ON LP {result_column} ( COMMA {result_column} ) * RP {
+  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.DistinctOnExpressionMixin"
+  implements = "com.alecstrong.sql.psi.core.psi.SqlCompositeElement"
+}
+
+select_stmt ::= SELECT ( [ distinct_on_expr ] | [ DISTINCT | ALL ] ) {result_column} ( COMMA {result_column} ) * [ FROM {join_clause} ] [ WHERE <<expr '-1'>> ] [{group_by}] [HAVING <<expr '-1'>>] | VALUES {values_expression} ( COMMA {values_expression} ) * {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlSelectStmtImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlSelectStmt"
   override = true

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/DistinctOnExpressionMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/DistinctOnExpressionMixin.kt
@@ -1,0 +1,35 @@
+package app.cash.sqldelight.dialects.postgresql.grammar.mixins
+
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlDistinctOnExpr
+import com.alecstrong.sql.psi.core.SqlAnnotationHolder
+import com.alecstrong.sql.psi.core.psi.QueryElement
+import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
+import com.alecstrong.sql.psi.core.psi.SqlResultColumn
+import com.alecstrong.sql.psi.core.psi.SqlSelectStmt
+import com.alecstrong.sql.psi.core.psi.impl.SqlCompoundSelectStmtImpl
+import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
+
+internal abstract class DistinctOnExpressionMixin(node: ASTNode) :
+  SqlCompositeElementImpl(node), PostgreSqlDistinctOnExpr {
+
+  private val distinctOnColumns get() = children.filterIsInstance<SqlResultColumn>()
+
+  override fun queryAvailable(child: PsiElement): Collection<QueryElement.QueryResult> {
+    return (parent as SqlSelectStmt).queryExposed()
+  }
+
+  override fun annotate(annotationHolder: SqlAnnotationHolder) {
+    super.annotate(annotationHolder)
+    val orderByList = (parent.parent as SqlCompoundSelectStmtImpl).orderingTermList
+    // todo leftmost only
+    distinctOnColumns.forEachIndexed { idx, col ->
+      if (!col.textMatches(orderByList[idx])) {
+        annotationHolder.createErrorAnnotation(
+          element = col,
+          message = "DISTINCT ON expression(s) must match the leftmost ORDER BY expression(s)",
+        )
+      }
+    }
+  }
+}

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/DistinctOnExpressionMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/DistinctOnExpressionMixin.kt
@@ -3,12 +3,14 @@ package app.cash.sqldelight.dialects.postgresql.grammar.mixins
 import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlDistinctOnExpr
 import com.alecstrong.sql.psi.core.SqlAnnotationHolder
 import com.alecstrong.sql.psi.core.psi.QueryElement
+import com.alecstrong.sql.psi.core.psi.SqlColumnName
 import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
 import com.alecstrong.sql.psi.core.psi.SqlResultColumn
 import com.alecstrong.sql.psi.core.psi.SqlSelectStmt
 import com.alecstrong.sql.psi.core.psi.impl.SqlCompoundSelectStmtImpl
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
 
 internal abstract class DistinctOnExpressionMixin(node: ASTNode) :
   SqlCompositeElementImpl(node), PostgreSqlDistinctOnExpr {
@@ -19,15 +21,24 @@ internal abstract class DistinctOnExpressionMixin(node: ASTNode) :
     return (parent as SqlSelectStmt).queryExposed()
   }
 
+  // Some idea of the basic validation finds the ORDER BY columns in the DISTINCT ON
+  // https://github.com/cockroachdb/cockroach/blob/b994d025c678f495cb8b93044e35a8c59595bd78/pkg/sql/opt/optbuilder/distinct.go#L87
   override fun annotate(annotationHolder: SqlAnnotationHolder) {
     super.annotate(annotationHolder)
-    val orderByList = (parent.parent as SqlCompoundSelectStmtImpl).orderingTermList
-    // todo leftmost only
-    distinctOnColumns.forEachIndexed { idx, col ->
-      if (!col.textMatches(orderByList[idx])) {
+
+    val orderByTerms = (parent.parent as SqlCompoundSelectStmtImpl).orderingTermList
+
+    val orderByColumnNames =
+      orderByTerms.mapNotNull { PsiTreeUtil.findChildOfType(it, SqlColumnName::class.java) }
+
+    val distinctOnColumnNames =
+      distinctOnColumns.mapNotNull { PsiTreeUtil.findChildOfType(it, SqlColumnName::class.java) }
+
+    orderByColumnNames.zip(distinctOnColumnNames) { orderByCol, _ ->
+      if (!distinctOnColumnNames.any { distinctOnCol -> distinctOnCol.textMatches(orderByCol) }) {
         annotationHolder.createErrorAnnotation(
-          element = col,
-          message = "DISTINCT ON expression(s) must match the leftmost ORDER BY expression(s)",
+          element = orderByCol,
+          message = "SELECT DISTINCT ON expressions must match initial ORDER BY expressions",
         )
       }
     }

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/DistinctOnExpressionMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/DistinctOnExpressionMixin.kt
@@ -35,7 +35,7 @@ internal abstract class DistinctOnExpressionMixin(node: ASTNode) :
       distinctOnColumns.mapNotNull { PsiTreeUtil.findChildOfType(it, SqlColumnName::class.java) }
 
     orderByColumnNames.zip(distinctOnColumnNames) { orderByCol, _ ->
-      if (!distinctOnColumnNames.any { distinctOnCol -> distinctOnCol.textMatches(orderByCol) }) {
+      if (distinctOnColumnNames.none { distinctOnCol -> distinctOnCol.textMatches(orderByCol) }) {
         annotationHolder.createErrorAnnotation(
           element = orderByCol,
           message = "SELECT DISTINCT ON expressions must match initial ORDER BY expressions",

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/select-distinct-on/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/select-distinct-on/Test.s
@@ -7,3 +7,7 @@ CREATE TABLE person (
 SELECT DISTINCT ON (name) *
 FROM person
 ORDER BY name, created_at DESC;
+
+SELECT DISTINCT ON (name) *
+FROM person
+ORDER BY created_at DESC;

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/select-distinct-on/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/select-distinct-on/Test.s
@@ -5,9 +5,39 @@ CREATE TABLE person (
 );
 
 SELECT DISTINCT ON (name) *
-FROM person
-ORDER BY name, created_at DESC;
+FROM person;
 
 SELECT DISTINCT ON (name) *
 FROM person
+ORDER BY name, created_at DESC;
+
+SELECT DISTINCT ON (id, name) id, name
+FROM person
+ORDER BY name DESC;
+
+SELECT DISTINCT ON (name, id) id, name, created_at
+FROM person
+ORDER BY id DESC;
+
+SELECT DISTINCT ON (name, id) id, name
+FROM person
+ORDER BY id, name ASC;
+
+SELECT DISTINCT ON (name, id) id, name
+FROM person
+ORDER BY id, name, created_at ASC;
+
+-- fail
+SELECT DISTINCT ON (name) *
+FROM person
 ORDER BY created_at DESC;
+
+-- fail
+SELECT DISTINCT ON (name, created_at) id, name, created_at
+FROM person
+ORDER BY id, name, created_at DESC;
+
+-- fail
+SELECT DISTINCT ON (name, id) id, name, created_at
+FROM person
+ORDER BY name, created_at, id DESC;

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/select-distinct-on/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/select-distinct-on/Test.s
@@ -1,0 +1,9 @@
+CREATE TABLE person (
+    id INTEGER PRIMARY KEY,
+    name TEXT,
+    created_at TIMESTAMPTZ
+);
+
+SELECT DISTINCT ON (name) *
+FROM person
+ORDER BY name, created_at DESC;

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/select-distinct-on/failure.txt
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/select-distinct-on/failure.txt
@@ -1,1 +1,3 @@
-Test.s line 11:20 - DISTINCT ON expression(s) must match the leftmost ORDER BY expression(s)
+Test.s line 33:9 - SELECT DISTINCT ON expressions must match initial ORDER BY expressions
+Test.s line 38:9 - SELECT DISTINCT ON expressions must match initial ORDER BY expressions
+Test.s line 43:15 - SELECT DISTINCT ON expressions must match initial ORDER BY expressions

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/select-distinct-on/failure.txt
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/select-distinct-on/failure.txt
@@ -1,0 +1,1 @@
+Test.s line 11:20 - DISTINCT ON expression(s) must match the leftmost ORDER BY expression(s)


### PR DESCRIPTION
Initial grammar and fixture test
Mixin for Distinct On columns
Annotate Distinct On using the basic rule "The DISTINCT ON column(s) must match the leftmost ORDER BY column(s)" see https://github.com/cockroachdb/cockroach/blob/b994d025c678f495cb8b93044e35a8c59595bd78/pkg/sql/opt/optbuilder/distinct.go#L91. This should catch at compile time, instead of runtime where columns are not matching.
 
fixes #4580