### PR TITLE
Bind arguments with SqlBinaryExpr

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/Arguments.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/Arguments.kt
@@ -25,16 +25,12 @@ import app.cash.sqldelight.dialect.api.PrimitiveType.NULL
 import app.cash.sqldelight.dialect.api.PrimitiveType.TEXT
 import app.cash.sqldelight.dialect.api.SelectQueryable
 import com.alecstrong.sql.psi.core.psi.SqlBetweenExpr
-import com.alecstrong.sql.psi.core.psi.SqlBinaryBooleanExpr
-import com.alecstrong.sql.psi.core.psi.SqlBinaryEqualityExpr
 import com.alecstrong.sql.psi.core.psi.SqlBinaryExpr
 import com.alecstrong.sql.psi.core.psi.SqlBinaryLikeExpr
-import com.alecstrong.sql.psi.core.psi.SqlBinaryPipeExpr
 import com.alecstrong.sql.psi.core.psi.SqlBindExpr
 import com.alecstrong.sql.psi.core.psi.SqlCaseExpr
 import com.alecstrong.sql.psi.core.psi.SqlCastExpr
 import com.alecstrong.sql.psi.core.psi.SqlCollateExpr
-import com.alecstrong.sql.psi.core.psi.SqlColumnExpr
 import com.alecstrong.sql.psi.core.psi.SqlCompoundSelectStmt
 import com.alecstrong.sql.psi.core.psi.SqlExpr
 import com.alecstrong.sql.psi.core.psi.SqlFunctionExpr
@@ -118,18 +114,8 @@ internal fun SqlExpr.argumentType(argument: SqlExpr): IntermediateType {
         IntermediateType(PrimitiveType.BOOLEAN)
       }
     }
-
-    is SqlBinaryPipeExpr, is SqlBinaryEqualityExpr, is SqlIsExpr, is SqlBinaryBooleanExpr -> {
+    is SqlBetweenExpr, is SqlIsExpr, is SqlBinaryExpr -> {
       val validArg = children.lastOrNull { it is SqlExpr && it !== argument && it !is SqlBindExpr }
-      validArg?.type() ?: children.last { it is SqlExpr && it !== argument }.type()
-    }
-
-    is SqlBetweenExpr, is SqlBinaryExpr -> {
-      val validArg = if (children.none() { it is SqlColumnExpr }) {
-        parent.children.lastOrNull { it is SqlExpr && it !== argument && it !is SqlBinaryExpr }
-      } else {
-        children.lastOrNull { it is SqlExpr && it !== argument && it !is SqlBindExpr }
-      }
       validArg?.type() ?: children.last { it is SqlExpr && it !== argument }.type()
     }
 

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/Arguments.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/Arguments.kt
@@ -125,11 +125,14 @@ internal fun SqlExpr.argumentType(argument: SqlExpr): IntermediateType {
     }
 
     is SqlBinaryExpr -> {
-      val validArg = children.lastOrNull { it is SqlCastExpr && it == argument } ?: if (children.none() { it is SqlColumnExpr }) {
-        parent.children.lastOrNull { it is SqlExpr && it !== argument && it !is SqlBinaryExpr }
-      } else {
-        children.lastOrNull { it is SqlExpr && it !== argument && it !is SqlBindExpr }
+      val validArg = children.lastOrNull {
+        it is SqlCastExpr && it == argument
+      } ?: children.lastOrNull {
+        it is SqlColumnExpr
+      } ?: parent.children.lastOrNull {
+        it is SqlExpr && it !== argument && it !is SqlBinaryExpr
       }
+
       validArg?.type() ?: children.last { it is SqlExpr && it !== argument }.type()
     }
 

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/Arguments.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/Arguments.kt
@@ -25,12 +25,16 @@ import app.cash.sqldelight.dialect.api.PrimitiveType.NULL
 import app.cash.sqldelight.dialect.api.PrimitiveType.TEXT
 import app.cash.sqldelight.dialect.api.SelectQueryable
 import com.alecstrong.sql.psi.core.psi.SqlBetweenExpr
+import com.alecstrong.sql.psi.core.psi.SqlBinaryBooleanExpr
+import com.alecstrong.sql.psi.core.psi.SqlBinaryEqualityExpr
 import com.alecstrong.sql.psi.core.psi.SqlBinaryExpr
 import com.alecstrong.sql.psi.core.psi.SqlBinaryLikeExpr
+import com.alecstrong.sql.psi.core.psi.SqlBinaryPipeExpr
 import com.alecstrong.sql.psi.core.psi.SqlBindExpr
 import com.alecstrong.sql.psi.core.psi.SqlCaseExpr
 import com.alecstrong.sql.psi.core.psi.SqlCastExpr
 import com.alecstrong.sql.psi.core.psi.SqlCollateExpr
+import com.alecstrong.sql.psi.core.psi.SqlColumnExpr
 import com.alecstrong.sql.psi.core.psi.SqlCompoundSelectStmt
 import com.alecstrong.sql.psi.core.psi.SqlExpr
 import com.alecstrong.sql.psi.core.psi.SqlFunctionExpr
@@ -114,8 +118,18 @@ internal fun SqlExpr.argumentType(argument: SqlExpr): IntermediateType {
         IntermediateType(PrimitiveType.BOOLEAN)
       }
     }
-    is SqlBetweenExpr, is SqlIsExpr, is SqlBinaryExpr -> {
+
+    is SqlBinaryPipeExpr, is SqlBinaryEqualityExpr, is SqlIsExpr, is SqlBinaryBooleanExpr -> {
       val validArg = children.lastOrNull { it is SqlExpr && it !== argument && it !is SqlBindExpr }
+      validArg?.type() ?: children.last { it is SqlExpr && it !== argument }.type()
+    }
+
+    is SqlBetweenExpr, is SqlBinaryExpr -> {
+      val validArg = if (children.none() { it is SqlColumnExpr }) {
+        parent.children.lastOrNull { it is SqlExpr && it !== argument && it !is SqlBinaryExpr }
+      } else {
+        children.lastOrNull { it is SqlExpr && it !== argument && it !is SqlBindExpr }
+      }
       validArg?.type() ?: children.last { it is SqlExpr && it !== argument }.type()
     }
 

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/BindArgsTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/BindArgsTest.kt
@@ -413,6 +413,29 @@ class BindArgsTest {
     }
   }
 
+  @Test fun `bind arg in arithmetic binary expression can be cast as type`() {
+    val file = FixtureCompiler.parseSql(
+      """
+        |CREATE TABLE data (
+        | datum INTEGER NOT NULL,
+        | point INTEGER NOT NULL
+        |);
+        |
+        |selectData:
+        |SELECT *, (datum + CAST(:datum1 AS REAL) * point) AS expected_datum
+        |FROM data;
+      """.trimMargin(),
+      tempFolder,
+    )
+
+    val column = file.namedQueries.first()
+    column.parameters.let { args ->
+      assertThat(args[0].dialectType).isEqualTo(PrimitiveType.REAL)
+      assertThat(args[0].javaType).isEqualTo(Double::class.asClassName().copy(nullable = true))
+      assertThat(args[0].name).isEqualTo("datum1")
+    }
+  }
+
   @Test fun `bind arg in binary expression can be cast as type`() {
     val file = FixtureCompiler.parseSql(
       """

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/BinaryArguments.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/BinaryArguments.sq
@@ -1,0 +1,35 @@
+import java.time.Instant;
+
+CREATE TABLE data (
+  datum INTEGER NOT NULL,
+  point INTEGER NOT NULL,
+  created_at TIMESTAMP AS Instant NOT NULL,
+  updated_at TIMESTAMP AS Instant NOT NULL
+);
+
+insertData:
+INSERT INTO data(datum, point, created_at, updated_at)
+VALUES(?, ?, ?, ?);
+
+selectDataBinaryComparison:
+SELECT *
+FROM data
+WHERE datum > :datum1 - 2.5 AND datum < :datum2 + 2.5;
+
+selectDataBinaryCast1:
+SELECT *, (datum + CAST(:datum1 AS REAL) * point) AS expected_datum
+FROM data;
+
+selectDataBinaryCast2:
+SELECT CAST(:datum1 AS REAL) + CAST(:datum2 AS INTEGER) - 10.5 AS expected_datum
+FROM data;
+
+selectDataBinaryIntervalComparison1:
+SELECT *
+FROM data
+WHERE created_at = :createdAt - INTERVAL '2 days' OR updated_at = :updatedAt + INTERVAL '2 days';
+
+selectDataBinaryIntervalComparison2:
+SELECT *
+FROM data
+WHERE created_at BETWEEN :createdAt - INTERVAL '2 days' AND :createdAt + INTERVAL '2 days';


### PR DESCRIPTION
fixes #4504

🤾  This PR is just to try out and see if any quick fixes 

Try and lookup the parent `SqlColumnExpr` to get the type of the column

Only the parent column can tell us what the type actually is declared as e.g Instant

Currently the tests pass and local snapshot works with cases

```
import java.time.Instant;

CREATE TABLE session (
  id UUID PRIMARY KEY,
  created_at TIMESTAMP AS Instant NOT NULL,
  updated_at TIMESTAMP AS Instant NOT NULL
);

selectSession1:
SELECT *
FROM session
WHERE created_at = :createdAt - INTERVAL '2 days' OR updated_at = :updatedAt + INTERVAL '2 days';

selectSession2:
SELECT *
FROM session
WHERE created_at BETWEEN :createdAt - INTERVAL '2 days' AND :createdAt + INTERVAL '2 days';

```

📓 The user will be required to implement and provide a ColumnAdapter for Instant to LocalDateTime, so the generated code would look like this e.g

```
 override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> =
        driver.executeQuery(681_848_824, """
    |SELECT *
    |FROM session
    |WHERE created_at BETWEEN ? - INTERVAL '2 days' AND ? + INTERVAL '2 days'
    """.trimMargin(), mapper, 2) {
      check(this is JdbcPreparedStatement)
      val createdAt_ = sessionAdapter.created_atAdapter.encode(createdAt)
      bindObject(0, createdAt_)
      bindObject(1, createdAt_)
    }

```

CAST doesn't work with SqlBinaryExpr

In this contrived example, CAST doesn't force `factor` to be an INTEGER - the inferred type is REAL as the literal expression is chosen for the bind parameter type. Of course, the column result type is REAL

```
selectData:
    SELECT CAST(:factor AS INTEGER) - 10.5
    FROM data;
```

Should generate `bindLong` not `bindDouble`

```
override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> =
        driver.executeQuery(-1_455_721_480, """
    |SELECT CAST(? AS INTEGER) - 10.5
    |FROM session
    """.trimMargin(), mapper, 1) {
      check(this is JdbcPreparedStatement)
      bindDouble(0, factor)
    }
```

Also cases of multiple CAST with bindArgs of different types

```
SELECT CAST(:factor1 AS NUMERIC(10, 2)) * CAST(:factor2 AS INTEGER) - 10.5
```
