### PR TITLE
Move sample build to 'test' job

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -102,7 +102,7 @@ jobs:
 
       # Build the sample
       - name: Build the sample
-        if: matrix.os == 'macOS-latest' && matrix.job == 'gradle-plugin-tests'
+        if: matrix.os == 'macOS-latest' && matrix.job == 'test'
         uses: gradle/gradle-build-action@v2
         with:
           arguments: kotlinUpgradeYarnLock build --stacktrace --parallel


### PR DESCRIPTION
The 'test' job is really short, while the 'gradle-plugin-test' job is really long (the longest). This should help balance things out a little more.