### PR TITLE
Enable wasm target where applicable

### DIFF
--- a/adapters/primitive-adapters/build.gradle
+++ b/adapters/primitive-adapters/build.gradle
@@ -8,6 +8,10 @@ plugins {
 archivesBaseName = 'sqldelight-primitive-adapters'
 
 kotlin {
+  wasm {
+    nodejs()
+  }
+
   sourceSets {
     commonMain {
       dependencies {

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -16,6 +16,10 @@ apiValidation {
 }
 
 kotlin {
+  wasm {
+    nodejs()
+  }
+
   targetHierarchy.default {
     it.group("testableNative") {
       // no withApple: https://github.com/cashapp/sqldelight/issues/4257

--- a/runtime/src/wasmMain/kotlin/app/cash/sqldelight/db/Closeable.kt
+++ b/runtime/src/wasmMain/kotlin/app/cash/sqldelight/db/Closeable.kt
@@ -1,0 +1,26 @@
+package app.cash.sqldelight.db
+
+actual interface Closeable {
+  actual fun close()
+}
+
+actual inline fun <T : Closeable?, R> T.use(body: (T) -> R): R {
+  var exception: Throwable? = null
+  try {
+    return body(this)
+  } catch (e: Throwable) {
+    exception = e
+    throw e
+  } finally {
+    when {
+      this == null -> {}
+      exception == null -> close()
+      else ->
+        try {
+          close()
+        } catch (closeException: Throwable) {
+          // Nothing to do...
+        }
+    }
+  }
+}

--- a/runtime/src/wasmMain/kotlin/app/cash/sqldelight/internal/CurrentThreadId.kt
+++ b/runtime/src/wasmMain/kotlin/app/cash/sqldelight/internal/CurrentThreadId.kt
@@ -1,0 +1,3 @@
+package app.cash.sqldelight.internal
+
+internal actual fun currentThreadId(): Long = 0

--- a/runtime/src/wasmTest/kotlin/com/squareup/sqldelight/internal/CopyOnWriteList.kt
+++ b/runtime/src/wasmTest/kotlin/com/squareup/sqldelight/internal/CopyOnWriteList.kt
@@ -1,0 +1,5 @@
+package com.squareup.sqldelight.internal
+
+actual fun <T> copyOnWriteList(): MutableList<T> {
+  return mutableListOf()
+}

--- a/runtime/src/wasmTest/kotlin/com/squareup/sqldelight/logs/LinkedList.kt
+++ b/runtime/src/wasmTest/kotlin/com/squareup/sqldelight/logs/LinkedList.kt
@@ -1,0 +1,8 @@
+package com.squareup.sqldelight.logs
+
+actual class LinkedList<T> actual constructor(objectPoolSize: Int) {
+  private val list = mutableListOf<T>()
+  actual fun add(element: T): Boolean = list.add(element)
+  actual fun clear() = list.clear()
+  actual operator fun get(index: Int): T = list[index]
+}


### PR DESCRIPTION
To enable experiments in supporting some kind of wasi-based driver.

`coroutines-extensions` and `async-extensions` should also be enabled in the future once a stable release of coroutines supports wasm.