### PR TITLE
Fix `OutOfMemory` build error

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -109,5 +109,4 @@ jobs:
           build-root-directory: sample
 
 env:
-  GRADLE_OPTS: -Dorg.gradle.caching=true -Dorg.gradle.jvmargs="-Xmx2g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
-
+  GRADLE_OPTS: -Dorg.gradle.caching=true

--- a/.github/workflows/Publish-Website.yml
+++ b/.github/workflows/Publish-Website.yml
@@ -78,4 +78,4 @@ jobs:
         run: mike deploy -u --push ${{ steps.version.outputs.VERSION_NAME }} latest
 
 env:
-  GRADLE_OPTS: -Dorg.gradle.caching=true -Dorg.gradle.jvmargs="-Xmx2g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
+  GRADLE_OPTS: -Dorg.gradle.caching=true

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -155,5 +155,5 @@ jobs:
         run: npm publish
 
 env:
-  GRADLE_OPTS: -Dorg.gradle.caching=true -Dorg.gradle.jvmargs="-Xmx2g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
+  GRADLE_OPTS: -Dorg.gradle.caching=true
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 GROUP=app.cash.sqldelight
 VERSION_NAME=2.1.0-SNAPSHOT
 


### PR DESCRIPTION
Fixes #4646 

Moves the `org.gradle.jvmargs` back to `gradle.properties`, from CI workflows