### PR TITLE
Ensure kotlinx.coroutines are shaded in the plugin

### DIFF
--- a/sqldelight-gradle-plugin/build.gradle
+++ b/sqldelight-gradle-plugin/build.gradle
@@ -110,7 +110,7 @@ if (System.getenv("CI") == "true") {
       relocators = relocators.grep {
         !it.getPattern().startsWith("com.squareup.sqldelight") &&
                 !it.getPattern().startsWith("groovy") &&
-                !it.getPattern().startsWith("kotlin")
+                !it.getPattern().startsWith("kotlin.")
       }
     }
 


### PR DESCRIPTION
Leaving the kotlinx.coroutines classes unshaded in the plugin means they can interfere with other plugins that are relying on that code at a different version.

Fixes #4650