### PR TITLE
Fix `JdbcSqliteDriver` url parsing when choosing `ConnectionManager` type

### DIFF
--- a/drivers/sqlite-driver/src/main/kotlin/app/cash/sqldelight/driver/jdbc/sqlite/JdbcSqliteDriver.kt
+++ b/drivers/sqlite-driver/src/main/kotlin/app/cash/sqldelight/driver/jdbc/sqlite/JdbcSqliteDriver.kt
@@ -4,7 +4,6 @@ import app.cash.sqldelight.Query
 import app.cash.sqldelight.driver.jdbc.ConnectionManager
 import app.cash.sqldelight.driver.jdbc.ConnectionManager.Transaction
 import app.cash.sqldelight.driver.jdbc.JdbcDriver
-import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver.Companion.IN_MEMORY
 import java.sql.Connection
 import java.sql.DriverManager
 import java.sql.PreparedStatement
@@ -14,8 +13,22 @@ import kotlin.concurrent.getOrSet
 @Suppress("DELEGATED_MEMBER_HIDES_SUPERTYPE_OVERRIDE")
 class JdbcSqliteDriver constructor(
   /**
-   * Database connection URL in the form of `jdbc:sqlite:path` where `path` is either blank
-   * (creating an in-memory database) or a path to a file.
+   * Database connection URL in the form of `jdbc:sqlite:path?key1=value1&...` where:
+   * - `jdbc:sqlite:` is the prefix which instructs [DriverManager] to open a connection
+   *   using the provided [org.sqlite.JDBC] Driver.
+   * - `path` is a file path which instructs sqlite *where* it should open the database
+   *   connection.
+   * - `?key1=value1&...` is an optional query string which instruct sqlite *how* it
+   *   should open the connection.
+   *
+   * Examples:
+   * - `jdbc:sqlite:/path/to/myDatabase.db` opens a database connection, writing changes
+   *   to the filesystem at the specified `path`.
+   * - `jdbc:sqlite:` (i.e. an empty path) will create a temporary database whereby the
+   *   temp file is deleted upon connection closure.
+   * - `jdbc:sqlite::memory:` will create a purely in-memory database.
+   * - `jdbc:sqlite:memdb1?mode=memory&cache=shared` will create a named in-memory
+   *   database which can be shared across connections until all are closed.
    */
   url: String,
   properties: Properties = Properties(),
@@ -51,9 +64,17 @@ class JdbcSqliteDriver constructor(
   }
 }
 
-private fun connectionManager(url: String, properties: Properties) = when (url) {
-  IN_MEMORY -> InMemoryConnectionManager(properties)
-  else -> ThreadedConnectionManager(url, properties)
+private fun connectionManager(url: String, properties: Properties): ConnectionManager {
+  val path = url.substringBefore('?').substringAfter("jdbc:sqlite:")
+
+  return when {
+    path.isEmpty() ||
+      path == ":memory:" ||
+      path == "file::memory:" ||
+      path.startsWith(":resource:") ||
+      url.contains("mode=memory") -> InMemoryConnectionManager(url, properties)
+    else -> ThreadedConnectionManager(url, properties)
+  }
 }
 
 private abstract class JdbcSqliteDriverConnectionManager : ConnectionManager {
@@ -71,10 +92,11 @@ private abstract class JdbcSqliteDriverConnectionManager : ConnectionManager {
 }
 
 private class InMemoryConnectionManager(
+  url: String,
   properties: Properties,
 ) : JdbcSqliteDriverConnectionManager() {
   override var transaction: Transaction? = null
-  private val connection: Connection = DriverManager.getConnection(IN_MEMORY, properties)
+  private val connection: Connection = DriverManager.getConnection(url, properties)
 
   override fun getConnection() = connection
   override fun closeConnection(connection: Connection) = Unit

--- a/drivers/sqlite-driver/src/main/kotlin/app/cash/sqldelight/driver/jdbc/sqlite/JdbcSqliteDriver.kt
+++ b/drivers/sqlite-driver/src/main/kotlin/app/cash/sqldelight/driver/jdbc/sqlite/JdbcSqliteDriver.kt
@@ -72,7 +72,7 @@ private fun connectionManager(url: String, properties: Properties): ConnectionMa
       path == ":memory:" ||
       path == "file::memory:" ||
       path.startsWith(":resource:") ||
-      url.contains("mode=memory") -> InMemoryConnectionManager(url, properties)
+      url.contains("mode=memory") -> StaticConnectionManager(url, properties)
     else -> ThreadedConnectionManager(url, properties)
   }
 }
@@ -91,7 +91,7 @@ private abstract class JdbcSqliteDriverConnectionManager : ConnectionManager {
   }
 }
 
-private class InMemoryConnectionManager(
+private class StaticConnectionManager(
   url: String,
   properties: Properties,
 ) : JdbcSqliteDriverConnectionManager() {


### PR DESCRIPTION
Fixes #4018 

This PR fixes a an issue when choosing which type of `ConnectionManager` should be utilized, depending on what parameters are passed via url where a static connection is needed to be maintained.