### PR TITLE
Fix `JdbcSqliteDriver` url parsing when choosing `ConnectionManager` type

### DIFF
--- a/drivers/sqlite-driver/src/main/kotlin/com/squareup/sqldelight/sqlite/driver/JdbcSqliteDriver.kt
+++ b/drivers/sqlite-driver/src/main/kotlin/com/squareup/sqldelight/sqlite/driver/JdbcSqliteDriver.kt
@@ -41,7 +41,7 @@ private fun connectionManager(url: String, properties: Properties): ConnectionMa
       path == ":memory:" ||
       path == "file::memory:" ||
       path.startsWith(":resource:") ||
-      url.contains("mode=memory") -> InMemoryConnectionManager(url, properties)
+      url.contains("mode=memory") -> StaticConnectionManager(url, properties)
     else -> ThreadedConnectionManager(url, properties)
   }
 }
@@ -60,7 +60,7 @@ private abstract class JdbcSqliteDriverConnectionManager : ConnectionManager {
   }
 }
 
-private class InMemoryConnectionManager(
+private class StaticConnectionManager(
   url: String,
   properties: Properties
 ) : JdbcSqliteDriverConnectionManager() {


### PR DESCRIPTION
Fixes #4018 

This PR fixes a an issue when choosing which type of `ConnectionManager` should be utilized, depending on what parameters are passed via url where a static connection is needed to be maintained.

NOTE: Base branch is set to `1.5.3`