### PR TITLE
Add check for temporary database path

### DIFF
--- a/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/EphemeralTest.kt
+++ b/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/EphemeralTest.kt
@@ -21,6 +21,8 @@ abstract class EphemeralTest {
     TEMPORARY,
   }
 
+  protected open val skipNamed: Boolean = false
+
   protected val schema = object : SqlSchema<QueryResult.Value<Unit>> {
     override val version: Long = 1
 
@@ -86,6 +88,8 @@ abstract class EphemeralTest {
 
   @Test
   fun namedCreatesSharedDatabase() {
+    if (skipNamed) return
+
     val data1 = TestData(1, "val1")
     val driver1 = setupDatabase(Type.NAMED)
     driver1.insertTestData(data1)

--- a/drivers/native-driver/src/nativeMain/kotlin/app/cash/sqldelight/driver/native/NativeSqlDatabase.kt
+++ b/drivers/native-driver/src/nativeMain/kotlin/app/cash/sqldelight/driver/native/NativeSqlDatabase.kt
@@ -141,7 +141,7 @@ class NativeSqliteDriver(
   private val lock = PoolLock(reentrant = true)
 
   init {
-    if (databaseManager.configuration.inMemory) {
+    if (databaseManager.configuration.isEphemeral) {
       // Single connection for transactions
       transactionPool = Pool(1) {
         ThreadConnection(databaseManager.createMultiThreadedConnection()) { _ ->
@@ -412,4 +412,8 @@ internal class ThreadConnection(
       return QueryResult.Unit
     }
   }
+}
+
+private inline val DatabaseConfiguration.isEphemeral: Boolean get() {
+  return inMemory || (name?.isEmpty() == true && extendedConfig.basePath?.isEmpty() == true)
 }

--- a/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/NativeEphemeralTest.kt
+++ b/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/NativeEphemeralTest.kt
@@ -1,0 +1,40 @@
+package com.squareup.sqldelight.drivers.native
+
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.native.NativeSqliteDriver
+import co.touchlab.sqliter.DatabaseConfiguration
+import com.squareup.sqldelight.driver.test.EphemeralTest
+
+class NativeEphemeralTest : EphemeralTest() {
+
+  // TODO: Issue #3241
+  override val skipNamed: Boolean = true
+
+  override fun setupDatabase(type: Type): SqlDriver {
+    return NativeSqliteDriver(
+      schema = schema,
+      name = "replaceme",
+      onConfiguration = { configuration ->
+        configuration.copy(
+          name = when (type) {
+            Type.IN_MEMORY -> null
+            Type.NAMED -> "memdb1"
+            Type.TEMPORARY -> ""
+          },
+          inMemory = when (type) {
+            Type.IN_MEMORY -> true
+            Type.NAMED -> true
+            Type.TEMPORARY -> false
+          },
+          extendedConfig = DatabaseConfiguration.Extended(
+            basePath = when (type) {
+              Type.IN_MEMORY -> null
+              Type.NAMED -> null
+              Type.TEMPORARY -> ""
+            },
+          ),
+        )
+      },
+    )
+  }
+}


### PR DESCRIPTION
This PR adds to the `NativeSqliteDriver` a check for use of a "temporary" database (i.e. an empty path).

NOTE: I added to the `EphemeralTest` an override to skip the `Type.NAMED` test for the time being (and commented on it) because of https://github.com/cashapp/sqldelight/issues/3241#issuecomment-1734141566