### PR TITLE
Fix 4686 Use IDEA Project JDK first

### DIFF
--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/gradle/FileIndexMap.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/gradle/FileIndexMap.kt
@@ -104,8 +104,8 @@ internal class FileIndexMap {
 
             Timber.i("Fetching SQLDelight models")
             val javaHome = (
-              ExternalSystemJdkUtil.getJavaHome()
-                ?: ExternalSystemJdkUtil.getAvailableJdk(project).second.homePath
+              ExternalSystemJdkUtil.getAvailableJdk(project).second.homePath
+                ?: ExternalSystemJdkUtil.getJavaHome()
               )?.let { File(it) }
 
             val properties =


### PR DESCRIPTION
fixes #4686 

🧪 Have tested locally with snapshot IDEA plugin against reproducibles (Spring Boot Plugin + JAVA_HOME JDK 11) 

getAvailableJdk() checks for project JDK first, then for the most recent JDK version and finally the internal JDK that could be JAVA_HOME

Explicit fallback to JAVA_HOME may not be needed as getAvailableJdk() appears to do this anyway 