### PR TITLE
Make gradle `test` run verifyMigrationTask instead of `check`

### DIFF
--- a/docs/common/migrations.md
+++ b/docs/common/migrations.md
@@ -29,7 +29,7 @@ These SQL statements are run by the `Database.Schema.migrate()` method. Migratio
 
 ## Verifying Migrations
 
-You can also place a `.db` file in the `src/main/sqldelight` folder of the same `<version number>.db` format. If there is a `.db` file present, a new `verifySqlDelightMigration` task will be added to the gradle project, and it will run as part of the `test` task, meaning your migrations will be verified against that `.db` file. It confirms that the migrations yield a database with the latest schema.
+You can also place a `.db` file in the `src/main/sqldelight` folder of the same `<version number>.db` format. If there is a `.db` file present, a new `verifySqlDelightMigration` task will be added to the gradle project, and it will run as part of the `check` task, meaning your migrations will be verified against that `.db` file. It confirms that the migrations yield a database with the latest schema.
 
 To generate a `.db` file from your latest schema, run the `generateSqlDelightSchema` task, which is available once you specify a `schemaOutputDirectory`, as described in the [gradle.md](gradle.md). You should probably do this before you create your first migration.
 


### PR DESCRIPTION
This matches what the docs say and wires things up automatically for anyone who doesn't use the check task directly.

> ... a new `verifySqlDelightMigration` task will be added to the gradle project, and it will run as part of the `test` task ...

https://cashapp.github.io/sqldelight/2.0.0/multiplatform_sqlite/migrations/#verifying-migrations