### PR TITLE
Fix 4616 generate series for PostgreSql

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -163,6 +163,7 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
     -> IntermediateType(TEXT)
     "json_array_length", "jsonb_array_length" -> IntermediateType(INTEGER)
     "jsonb_path_exists", "jsonb_path_match", "jsonb_path_exists_tz", "jsonb_path_match_tz" -> IntermediateType(BOOLEAN)
+    "generate_series" -> encapsulatingType(exprList, INTEGER, BIG_INT, REAL, TIMESTAMP_TIMEZONE, TIMESTAMP)
     else -> null
   }
 

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Functions.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Functions.sq
@@ -16,3 +16,10 @@ stddev(foo),
 regr_count(foo, bar)
 FROM myTable
 GROUP BY foo, bar;
+
+selectGenerateSeries:
+SELECT generate_series(
+    CAST(:start AS TIMESTAMPTZ),
+    CAST(:finish AS TIMESTAMPTZ),
+    CAST('1 hour' AS INTERVAL)
+);

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -449,4 +449,14 @@ class PostgreSqlTest {
       assertThat(mul).isEqualTo(4.5)
     }
   }
+
+  @Test
+  fun testGenerateSeries() {
+    val start = OffsetDateTime.of(2023, 9, 1, 0, 0, 0, 0, ZoneOffset.ofHours(0))
+    val finish = OffsetDateTime.of(2023, 9, 1, 5, 0, 0, 0, ZoneOffset.ofHours(0))
+    val series = database.functionsQueries.selectGenerateSeries(start, finish).executeAsList()
+    assertThat(series.size).isEqualTo(6)
+    assertThat(series.first()).isEqualTo(start)
+    assertThat(series.last()).isEqualTo(finish)
+  }
 }


### PR DESCRIPTION
Adds `generate_series` PostgreSql function 
Adds integration test

This is simpler than adding support for generate_series as a table source.

```sql
SELECT generate_series(
    CAST('2023-09-01T00:00:00Z' AS TIMESTAMPTZ),
    CAST('2023-09-02T00:00:00Z' AS TIMESTAMPTZ),
    CAST('1 hour' AS INTERVAL)
  );
```
closes #4616 