### PR TITLE
Use gradle's new syntax for locking a dependency's version

### DIFF
--- a/docs/android_sqlite/testing.md
+++ b/docs/android_sqlite/testing.md
@@ -28,9 +28,9 @@ If you are using the SQLite that comes bundled with Android (rather than shippin
 
 ```groovy
 dependencies {
-  testImplementation('org.xerial:sqlite-jdbc:3.8.10.2') {
+  testImplementation('org.xerial:sqlite-jdbc') {
     // Override the version of sqlite used by sqlite-driver to match Android API 23
-    force = true
+    version { strictly('3.8.10.2') }
   }
 }
 ```


### PR DESCRIPTION
The old syntax produces this error:

```groovy
GroovyRuntimeException: Cannot set the value of read-only property 'force' for DefaultExternalModuleDependency{group='org.xerial', name='sqlite-jdbc', version='3.32.2', configuration='default'} of type org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency.
```