### PR TITLE
Native-driver: add support for linuxArm64

### DIFF
--- a/drivers/native-driver/build.gradle
+++ b/drivers/native-driver/build.gradle
@@ -8,33 +8,40 @@ plugins {
 }
 
 kotlin {
+  // tier 1
+  linuxX64()
+  macosX64()
+  macosArm64()
+  iosSimulatorArm64()
   iosX64()
-  iosArm64()
-  tvosX64()
-  tvosArm64()
+
+  // tier 2
+  linuxArm64()
+  watchosSimulatorArm64()
   watchosX64()
   watchosArm32()
   watchosArm64()
-  macosX64()
-  mingwX64()
-  linuxX64()
-  macosArm64()
-  iosSimulatorArm64()
-  watchosSimulatorArm64()
   tvosSimulatorArm64()
+  tvosX64()
+  tvosArm64()
+  iosArm64()
+
+  // tier 3
+  // https://github.com/touchlab/SQLiter/issues/117
+  // androidNativeArm32()
+  // androidNativeArm64()
+  // androidNativeX86()
+  // androidNativeX64()
+  mingwX64()
+  watchosDeviceArm64()
 
   targetHierarchy.default { target ->
     target.group("native") {
       it.group("nativeLinuxLike") {
         it.withLinux()
-        // no withApple: https://github.com/cashapp/sqldelight/issues/4257
-        it.withIos()
-        it.withTvos()
-        it.withMacos()
-        it.withWatchosArm32()
-        it.withWatchosArm64()
-        it.withWatchosX64()
-        it.withWatchosSimulatorArm64()
+        it.withApple()
+        // https://github.com/touchlab/SQLiter/issues/117
+        // it.withAndroidNative()
       }
     }
   }

--- a/extensions/coroutines-extensions/build.gradle
+++ b/extensions/coroutines-extensions/build.gradle
@@ -12,17 +12,11 @@ archivesBaseName = 'sqldelight-coroutines-extensions'
 kotlin {
   targetHierarchy.default {
     it.group("testableNative") {
-      // no withApple: https://github.com/cashapp/sqldelight/issues/4257
-      it.withIos()
-      it.withTvos()
-      it.withMacos()
-      it.withWatchosArm32()
-      it.withWatchosArm64()
-      it.withWatchosX64()
-      it.withWatchosSimulatorArm64()
-
-      it.withLinuxX64()
+      it.withApple()
+      it.withLinux()
       it.withMingw()
+      // https://github.com/touchlab/SQLiter/issues/117
+      // it.withAndroidNative()
     }
   }
 

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -16,21 +16,6 @@ apiValidation {
 }
 
 kotlin {
-  targetHierarchy.default {
-    it.group("testableNative") {
-      // no withApple: https://github.com/cashapp/sqldelight/issues/4257
-      it.withIos()
-      it.withTvos()
-      it.withMacos()
-      it.withWatchosArm32()
-      it.withWatchosArm64()
-      it.withWatchosX64()
-      it.withWatchosSimulatorArm64()
-      it.withLinuxX64()
-      it.withMingw()
-    }
-  }
-
   sourceSets {
     commonMain {
     }


### PR DESCRIPTION
#4788 bumped sqliter to 1.3.0 which includes linuxArm64 support. This PR enables this target.

Also closes https://github.com/cashapp/sqldelight/issues/4257