### PR TITLE
Makes sample/common/iosTest base test setup to use in memory DB

### DIFF
--- a/sample/common/src/iosTest/kotlin/com/example/sqldelight/hockey/BaseTest.kt
+++ b/sample/common/src/iosTest/kotlin/com/example/sqldelight/hockey/BaseTest.kt
@@ -5,11 +5,13 @@ import com.example.sqldelight.hockey.data.Db
 import com.example.sqldelight.hockey.data.Schema
 
 actual suspend fun createDriver() {
-  Db.dbSetup(NativeSqliteDriver(Schema, "sampledb", onConfiguration = {
-    it.copy(
-      inMemory = true
-    )
-  }))
+  Db.dbSetup(
+    NativeSqliteDriver(Schema, "sampledb", onConfiguration = {
+      it.copy(
+        inMemory = true,
+      )
+    }),
+  )
 }
 
 actual suspend fun closeDriver() {

--- a/sample/common/src/iosTest/kotlin/com/example/sqldelight/hockey/BaseTest.kt
+++ b/sample/common/src/iosTest/kotlin/com/example/sqldelight/hockey/BaseTest.kt
@@ -5,7 +5,11 @@ import com.example.sqldelight.hockey.data.Db
 import com.example.sqldelight.hockey.data.Schema
 
 actual suspend fun createDriver() {
-  Db.dbSetup(NativeSqliteDriver(Schema, "sampledb"))
+  Db.dbSetup(NativeSqliteDriver(Schema, "sampledb", onConfiguration = {
+    it.copy(
+      inMemory = true
+    )
+  }))
 }
 
 actual suspend fun closeDriver() {


### PR DESCRIPTION
jvmCommon uses an in-memory database, but iosCommon uses an on-disk database. This PR makes iosCommon to use in-memory database.

I was creating my project based on the sample, and I faced an issue: changing schema led to failures in IosSchemaTest. This PR fixes that.