### PR TITLE
Add a windowSizeBytes parameter to AndroidSqliteDriver

### DIFF
--- a/drivers/android-driver/src/main/java/app/cash/sqldelight/driver/android/AndroidSqliteDriver.kt
+++ b/drivers/android-driver/src/main/java/app/cash/sqldelight/driver/android/AndroidSqliteDriver.kt
@@ -6,6 +6,8 @@ import android.database.Cursor
 import android.database.CursorWindow
 import android.os.Build
 import android.util.LruCache
+import androidx.annotation.DoNotInline
+import androidx.annotation.RequiresApi
 import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.sqlite.db.SupportSQLiteOpenHelper
 import androidx.sqlite.db.SupportSQLiteProgram
@@ -20,6 +22,7 @@ import app.cash.sqldelight.db.SqlCursor
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlPreparedStatement
 import app.cash.sqldelight.db.SqlSchema
+import app.cash.sqldelight.driver.android.Api28Impl.setWindowSize
 
 private const val DEFAULT_CACHE_SIZE = 20
 
@@ -325,7 +328,7 @@ private class AndroidCursor(
       windowSizeBytes != null &&
       cursor is AbstractWindowedCursor
     ) {
-      cursor.window = CursorWindow(null, windowSizeBytes)
+      cursor.setWindowSize(windowSizeBytes)
     }
   }
 
@@ -335,4 +338,13 @@ private class AndroidCursor(
   override fun getBytes(index: Int) = if (cursor.isNull(index)) null else cursor.getBlob(index)
   override fun getDouble(index: Int) = if (cursor.isNull(index)) null else cursor.getDouble(index)
   override fun getBoolean(index: Int) = if (cursor.isNull(index)) null else cursor.getLong(index) == 1L
+}
+
+@RequiresApi(Build.VERSION_CODES.P)
+private object Api28Impl {
+  @JvmStatic
+  @DoNotInline
+  fun AbstractWindowedCursor.setWindowSize(windowSizeBytes: Long) {
+    window = CursorWindow(null, windowSizeBytes)
+  }
 }


### PR DESCRIPTION
Android has the concept of a cursor window, where a query will try to preemptively load data up to a certain size (by default [2MB](https://android.googlesource.com/platform/frameworks/base/+/master/core/res/res/values/config.xml#2369)). However if individual rows are too big to fit that size, a `SQLiteBlobTooBigException` will be thrown.

A few issues where this happens:

- https://github.com/cashapp/sqldelight/issues/1584
- https://github.com/cashapp/sqldelight/issues/1627
- https://github.com/cashapp/sqldelight/issues/1862
- https://github.com/apollographql/apollo-kotlin/issues/4072

More context about CursorWindow in [this blog post](https://medium.com/androiddevelopers/large-database-queries-on-android-cb043ae626e8).

Since Android 28+ this can be mitigated by controlling the window size. This PR adds the ability to pass this value to AndroidSqliteDriver.

