### PR TITLE
Refactor build logic to support configuration cache

### DIFF
--- a/buildLogic/toolchain-convention/src/main/kotlin/app/cash/sqldelight/toolchain/BugsnagKey.kt
+++ b/buildLogic/toolchain-convention/src/main/kotlin/app/cash/sqldelight/toolchain/BugsnagKey.kt
@@ -1,0 +1,34 @@
+package app.cash.sqldelight.toolchain
+
+import java.io.File
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+@CacheableTask
+abstract class BugsnagKey : DefaultTask() {
+  @get:Input
+  val bugsnagKey: Provider<String> = project.providers.gradleProperty("SQLDELIGHT_BUGSNAG_KEY").orElse("")
+
+  @get:OutputDirectory
+  val outputDir: Provider<Directory> = project.layout.buildDirectory.dir("gen")
+
+  @TaskAction
+  fun writeBugsnagKey() {
+    val outputDir = outputDir.get().asFile
+    val packageFile = File(outputDir, "app/cash/sqldelight/intellij")
+    packageFile.mkdirs()
+    val versionFile = File(packageFile, "Bugsnag.kt")
+    versionFile.writeText(
+      """// Generated file. Do not edit!
+package app.cash.sqldelight.intellij
+
+internal val BUGSNAG_KEY = "${bugsnagKey.get()}"
+""",
+    )
+  }
+}

--- a/buildLogic/toolchain-convention/src/main/kotlin/app/cash/sqldelight/toolchain/PluginVersion.kt
+++ b/buildLogic/toolchain-convention/src/main/kotlin/app/cash/sqldelight/toolchain/PluginVersion.kt
@@ -1,0 +1,40 @@
+package app.cash.sqldelight.toolchain
+
+import java.io.File
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+@CacheableTask
+abstract class PluginVersion : DefaultTask() {
+  @get:Input
+  val gitHash: Provider<String> = project.providers.exec {
+    it.commandLine("git", "rev-parse", "--short", "HEAD")
+  }.standardOutput.asText
+
+  @get:Input
+  val version: String = project.version.toString()
+
+  @get:OutputDirectory
+  val outputDir: Provider<Directory> = project.layout.buildDirectory.dir("gen")
+
+  @TaskAction
+  fun writeVersionFile() {
+    val outputDir = outputDir.get().asFile
+    val packageFile = File(outputDir, "app/cash/sqldelight")
+    packageFile.mkdirs()
+    val versionFile = File(packageFile, "Version.kt")
+    versionFile.writeText(
+"""// Generated file. Do not edit!
+package app.cash.sqldelight
+
+val VERSION = "$version"
+val GIT_SHA = "${gitHash.get().trim()}"
+""",
+    )
+  }
+}

--- a/sqldelight-compiler/build.gradle
+++ b/sqldelight-compiler/build.gradle
@@ -1,3 +1,5 @@
+import app.cash.sqldelight.toolchain.PluginVersion
+
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.grammarKitComposer)
@@ -14,10 +16,6 @@ tasks.named('test') {
     showStackTraces true
     showCauses true
   }
-}
-
-sourceSets {
-  main.java.srcDir "gen"
 }
 
 grammarKit {
@@ -55,39 +53,10 @@ dependencies {
   testImplementation projects.dialects.sqlite338
 }
 
-tasks.register('pluginVersion') {
-  def getGitHash = { ->
-    def stdout = new ByteArrayOutputStream()
-    exec {
-      commandLine 'git', 'rev-parse', '--short', 'HEAD'
-      standardOutput = stdout
-    }
-    return stdout.toString().trim()
-  }
+TaskProvider<PluginVersion> pluginVersion = tasks.register('pluginVersion', PluginVersion)
 
-  def outputDir = file("gen")
-
-  inputs.property 'version', version
-  outputs.dir outputDir
-
-  def versionFile = file("$outputDir/app.cash.sqldelight/Version.kt")
-
-  doLast {
-    versionFile.parentFile.mkdirs()
-    versionFile.text = """// Generated file. Do not edit!
-package app.cash.sqldelight
-
-val VERSION = "${version}"
-val GIT_SHA = "${getGitHash}"
-"""
-  }
+sourceSets.main {
+  kotlin.srcDir(pluginVersion)
 }
 
 apply from: "$rootDir/gradle/gradle-mvn-push.gradle"
-
-afterEvaluate {
-  tasks.named('compileKotlin') { dependsOn('pluginVersion') }
-  tasks.named('dokkaHtml') { dependsOn('pluginVersion') }
-  tasks.named('dokkaHtmlPartial') { dependsOn('pluginVersion') }
-  tasks.named('javaSourcesJar') { dependsOn('pluginVersion') }
-}

--- a/sqldelight-idea-plugin/build.gradle
+++ b/sqldelight-idea-plugin/build.gradle
@@ -1,4 +1,5 @@
 import org.jetbrains.intellij.tasks.RunPluginVerifierTask.FailureLevel
+import app.cash.sqldelight.toolchain.BugsnagKey
 
 plugins {
   alias(libs.plugins.intellij)
@@ -71,10 +72,6 @@ tasks.named('publishPlugin') {
   channels = [isReleaseBuild() ? 'Stable' : 'EAP']
 }
 
-sourceSets {
-  main.java.srcDir "src/generated/kotlin"
-}
-
 repositories {
   maven { url = uri("https://repo.gradle.org/gradle/libs-releases") }
 }
@@ -96,31 +93,9 @@ dependencies {
   testImplementation projects.dialects.sqlite318
 }
 
-def getBugsnagKey() {
-  return hasProperty('SQLDELIGHT_BUGSNAG_KEY') ? SQLDELIGHT_BUGSNAG_KEY : ''
+def bugsnagKey = tasks.register('bugsnagKey', BugsnagKey)
+sourceSets.main {
+  kotlin.srcDir(bugsnagKey)
 }
-
-tasks.register('bugsnagKey') {
-  def outputDir = file("src/generated/kotlin")
-  def versionFile = file("$outputDir/app.cash.sqldelight/intellij/Bugsnag.kt")
-
-  inputs.property 'bugsnagKey', getBugsnagKey()
-  outputs.file(versionFile)
-
-  doLast {
-    versionFile.parentFile.mkdirs()
-    versionFile.text = """// Generated file. Do not edit!
-package app.cash.sqldelight.intellij
-
-internal val BUGSNAG_KEY = "${getBugsnagKey()}"
-"""
-  }
-}
-
-tasks.named('compileKotlin') { dependsOn('bugsnagKey') }
 
 tasks.named('buildSearchableOptions') { enabled = false }
-
-afterEvaluate {
-  tasks.named('kspKotlin') { dependsOn('bugsnagKey') }
-}


### PR DESCRIPTION
With these changes we can run `assemble` with the config cache. We can't run `build` because Dokka does not support the CC and we run Dokka for the integration tests indirectly by calling publish local directory.

Open question: Do you want to set the Gradle property `org.gradle.configuration-cache=true` or do you prefer local opt-in without committing?