### PR TITLE
Add DATE PostgreSQL type to min and max aggregate functions

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -13,6 +13,7 @@ import app.cash.sqldelight.dialect.api.TypeResolver
 import app.cash.sqldelight.dialect.api.encapsulatingType
 import app.cash.sqldelight.dialect.api.encapsulatingTypePreferringKotlin
 import app.cash.sqldelight.dialects.postgresql.PostgreSqlType.BIG_INT
+import app.cash.sqldelight.dialects.postgresql.PostgreSqlType.DATE
 import app.cash.sqldelight.dialects.postgresql.PostgreSqlType.SMALL_INT
 import app.cash.sqldelight.dialects.postgresql.PostgreSqlType.TIMESTAMP
 import app.cash.sqldelight.dialects.postgresql.PostgreSqlType.TIMESTAMP_TIMEZONE
@@ -119,8 +120,8 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
     "substring", "replace" -> IntermediateType(TEXT).nullableIf(resolvedType(exprList[0]).javaType.isNullable)
     "starts_with" -> IntermediateType(BOOLEAN)
     "coalesce", "ifnull" -> encapsulatingTypePreferringKotlin(exprList, SMALL_INT, PostgreSqlType.INTEGER, INTEGER, BIG_INT, REAL, TEXT, BLOB)
-    "max" -> encapsulatingTypePreferringKotlin(exprList, SMALL_INT, PostgreSqlType.INTEGER, INTEGER, BIG_INT, REAL, TEXT, BLOB, TIMESTAMP_TIMEZONE, TIMESTAMP).asNullable()
-    "min" -> encapsulatingTypePreferringKotlin(exprList, BLOB, TEXT, SMALL_INT, INTEGER, PostgreSqlType.INTEGER, BIG_INT, REAL, TIMESTAMP_TIMEZONE, TIMESTAMP).asNullable()
+    "max" -> encapsulatingTypePreferringKotlin(exprList, SMALL_INT, PostgreSqlType.INTEGER, INTEGER, BIG_INT, REAL, TEXT, BLOB, TIMESTAMP_TIMEZONE, TIMESTAMP, DATE).asNullable()
+    "min" -> encapsulatingTypePreferringKotlin(exprList, BLOB, TEXT, SMALL_INT, INTEGER, PostgreSqlType.INTEGER, BIG_INT, REAL, TIMESTAMP_TIMEZONE, TIMESTAMP, DATE).asNullable()
     "sum" -> {
       val type = resolvedType(exprList.single())
       if (type.dialectType == REAL) {

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Dates.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Dates.sq
@@ -27,3 +27,9 @@ SELECT max(timestamp) FROM dates;
 
 selectMin:
 SELECT min(timestamp_with_timezone) FROM dates;
+
+selectMaxDate:
+SELECT max(date) FROM dates;
+
+selectMinDate:
+SELECT min(date) FROM dates;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -228,6 +228,30 @@ class PostgreSqlTest {
     }
   }
 
+  @Test fun testMinMaxDates() {
+    database.datesQueries.insertDate(
+      date = LocalDate.of(2023, 1, 1),
+      time = LocalTime.of(11, 30, 59, 10000),
+      timestamp = LocalDateTime.of(2029, 1, 1, 21, 30, 59, 10000),
+      timestamp_with_timezone = OffsetDateTime.of(1970, 4, 9, 20, 15, 45, 0, ZoneOffset.ofHours(0)),
+    ).executeAsOne()
+
+    database.datesQueries.insertDate(
+      date = LocalDate.of(2022, 10, 17),
+      time = LocalTime.of(11, 30, 59, 10000),
+      timestamp = LocalDateTime.of(2029, 1, 1, 21, 30, 59, 10000),
+      timestamp_with_timezone = OffsetDateTime.of(1970, 4, 9, 20, 15, 45, 0, ZoneOffset.ofHours(0)),
+    ).executeAsOne()
+
+    database.datesQueries.selectMaxDate().executeAsOne().let {
+      assertThat(it.max).isEqualTo(LocalDate.of(2023, 1, 1))
+    }
+
+    database.datesQueries.selectMinDate().executeAsOne().let {
+      assertThat(it.min).isEqualTo(LocalDate.of(2022, 10, 17))
+    }
+  }
+
   @Test fun testSerial() {
     database.run {
       oneEntityQueries.transaction {


### PR DESCRIPTION
This change adds the possibility to use the `max` and `min` functions in PostgreSQL for the DATE data type.