### PR TITLE
Removes redundant qualifier names in GetInstance.kt

### DIFF
--- a/sample/android/src/main/java/com/example/sqldelight/hockey/data/GetInstance.kt
+++ b/sample/android/src/main/java/com/example/sqldelight/hockey/data/GetInstance.kt
@@ -5,8 +5,8 @@ import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import com.example.sqldelight.hockey.HockeyDb
 
 fun Db.getInstance(context: Context): HockeyDb {
-  if (!Db.ready) {
-    Db.dbSetup(AndroidSqliteDriver(Schema, context))
+  if (!ready) {
+    dbSetup(AndroidSqliteDriver(Schema, context))
   }
-  return Db.instance
+  return instance
 }


### PR DESCRIPTION
The receiver parameter is never used, removes unnecessary qualifier names in `Db.getInstance()`