### PR TITLE
When doing a value type insert always include the column names

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/TreeUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/TreeUtil.kt
@@ -173,12 +173,26 @@ private fun PsiElement.rangesToReplace(): List<Pair<IntRange, String>> {
       ),
     )
   } else if (this is InsertStmtValuesMixin && parent?.acceptsTableInterface() == true) {
-    listOf(
-      Pair(
-        first = childOfType(SqlTypes.BIND_EXPR)!!.range,
-        second = parent!!.columns.joinToString(separator = ", ", prefix = "(", postfix = ")") { "?" },
-      ),
-    )
+    buildList {
+      if (parent!!.columnNameList.isEmpty()) {
+        add(
+          Pair(
+            first = parent!!.tableName.range,
+            second = parent!!.columns.joinToString(
+              separator = ", ",
+              prefix = "${parent!!.tableName.text} (",
+              postfix = ")",
+            ) { it.name },
+          ),
+        )
+      }
+      add(
+        Pair(
+          first = childOfType(SqlTypes.BIND_EXPR)!!.range,
+          second = parent!!.columns.joinToString(separator = ", ", prefix = "(", postfix = ")") { "?" },
+        ),
+      )
+    }
   } else {
     children.flatMap { it.rangesToReplace() }
   }

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueriesTypeTest.kt
@@ -308,7 +308,7 @@ class QueriesTypeTest {
       |) : TransacterImpl(driver) {
       |  public fun insertData(data_: Data_) {
       |    driver.execute(${insert.id.withUnderscores}, ""${'"'}
-      |        |INSERT INTO data
+      |        |INSERT INTO data (id, value)
       |        |VALUES (?, ?)
       |        ""${'"'}.trimMargin(), 2) {
       |          bindLong(0, data_.id)

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/MutatorQueryFunctionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/MutatorQueryFunctionTest.kt
@@ -145,7 +145,7 @@ class MutatorQueryFunctionTest {
       """
       |public fun insertData(data_: com.example.Data_) {
       |  driver.execute(${mutator.id.withUnderscores}, ""${'"'}
-      |      |INSERT INTO data
+      |      |INSERT INTO data (id, value)
       |      |VALUES (?, ?)
       |      ""${'"'}.trimMargin(), 2) {
       |        bindLong(0, data_.id)
@@ -259,7 +259,7 @@ class MutatorQueryFunctionTest {
       """
       |public fun insertData(data_: com.example.Data_) {
       |  driver.execute(${mutator.id.withUnderscores}, ""${'"'}
-      |      |INSERT INTO data
+      |      |INSERT INTO data (id, value)
       |      |VALUES (?, ?)
       |      ""${'"'}.trimMargin(), 2) {
       |        bindLong(0, data_.id)
@@ -554,7 +554,7 @@ class MutatorQueryFunctionTest {
       """
       |public fun insertNullableType(nullableTypes: com.example.NullableTypes) {
       |  driver.execute(${insert.id.withUnderscores}, ""${'"'}
-      |      |INSERT INTO nullableTypes
+      |      |INSERT INTO nullableTypes (val1, val2)
       |      |VALUES (?, ?)
       |      ""${'"'}.trimMargin(), 2) {
       |        bindString(0, nullableTypes.val1?.let { nullableTypesAdapter.val1Adapter.encode(it) })
@@ -677,7 +677,7 @@ class MutatorQueryFunctionTest {
       """
       |public fun insertAnnotation(annotation_: com.example.Annotation_) {
       |  driver.execute(${mutator.id.withUnderscores}, ""${'"'}
-      |      |INSERT INTO annotation
+      |      |INSERT INTO annotation (id, name)
       |      |VALUES (?, ?)
       |      ""${'"'}.trimMargin(), 2) {
       |        bindLong(0, annotation_.id)

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/MutatorQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/MutatorQueryTypeTest.kt
@@ -79,7 +79,7 @@ class MutatorQueryTypeTest {
       """
     |public fun insertData(data_: com.example.Data_) {
     |  driver.execute(${mutator.id.withUnderscores}, ""${'"'}
-    |      |INSERT INTO data
+    |      |INSERT INTO data (id, value)
     |      |VALUES (?, ?)
     |      ""${'"'}.trimMargin(), 2) {
     |        bindLong(0, data_Adapter.idAdapter.encode(data_.id))

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/util/TreeUtilTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/util/TreeUtilTest.kt
@@ -66,7 +66,7 @@ class TreeUtilTest {
 
     assertThat(insert2.rawSqlText()).isEqualTo(
       """
-      |INSERT INTO test
+      |INSERT INTO test (value, other_value, a_third_value)
       |VALUES (?, ?, ?)
       """.trimMargin(),
     )

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-rename-column/output/com/example/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-rename-column/output/com/example/DataQueries.kt
@@ -10,7 +10,7 @@ public class DataQueries(
 ) : TransacterImpl(driver) {
   public fun insertWhole(test: Test) {
     driver.execute(-2_118_611_703, """
-        |INSERT INTO test
+        |INSERT INTO test (third, second)
         |VALUES (?, ?)
         """.trimMargin(), 2) {
           check(this is JdbcPreparedStatement)


### PR DESCRIPTION
This enables using these shorthand statements during migrations where the order of columns may change