### PR TITLE
Allow overriding the type nullability in encapsulatingType

### DIFF
--- a/dialects/hsql/src/main/kotlin/app/cash/sqldelight/dialects/hsql/HsqlTypeResolver.kt
+++ b/dialects/hsql/src/main/kotlin/app/cash/sqldelight/dialects/hsql/HsqlTypeResolver.kt
@@ -42,7 +42,9 @@ class HsqlTypeResolver(private val parentResolver: TypeResolver) : TypeResolver 
   }
 
   private fun SqlFunctionExpr.hsqlFunctionType() = when (functionName.text.lowercase()) {
-    "coalesce", "ifnull" -> encapsulatingTypePreferringKotlin(exprList, TINY_INT, SMALL_INT, HsqlType.INTEGER, INTEGER, BIG_INT, REAL, TEXT, BLOB)
+    "coalesce", "ifnull" -> encapsulatingTypePreferringKotlin(exprList, TINY_INT, SMALL_INT, HsqlType.INTEGER, INTEGER, BIG_INT, REAL, TEXT, BLOB, nullability = { exprListNullability ->
+      exprListNullability.all { it }
+    })
     "greatest" -> encapsulatingTypePreferringKotlin(
       exprList,
       TINY_INT,

--- a/dialects/mysql/src/main/kotlin/app/cash/sqldelight/dialects/mysql/MySqlTypeResolver.kt
+++ b/dialects/mysql/src/main/kotlin/app/cash/sqldelight/dialects/mysql/MySqlTypeResolver.kt
@@ -60,7 +60,10 @@ class MySqlTypeResolver(
         } else {
           encapsulatingType(
             exprList = expr.getExprList(),
-            nullableIfAny = (expr is SqlBinaryAddExpr || expr is SqlBinaryMultExpr || expr is SqlBinaryPipeExpr),
+            nullability = { exprListNullability ->
+              (expr is SqlBinaryAddExpr || expr is SqlBinaryMultExpr || expr is SqlBinaryPipeExpr) &&
+                exprListNullability.any { it }
+            },
             TINY_INT,
             SMALL_INT,
             MySqlType.INTEGER,
@@ -131,7 +134,9 @@ class MySqlTypeResolver(
       INTEGER,
     )
     "sin", "cos", "tan" -> IntermediateType(REAL)
-    "coalesce", "ifnull" -> encapsulatingTypePreferringKotlin(exprList, TINY_INT, SMALL_INT, MySqlType.INTEGER, INTEGER, BIG_INT, REAL, TEXT, BLOB)
+    "coalesce", "ifnull" -> encapsulatingTypePreferringKotlin(exprList, TINY_INT, SMALL_INT, MySqlType.INTEGER, INTEGER, BIG_INT, REAL, TEXT, BLOB, nullability = { exprListNullability ->
+      exprListNullability.all { it }
+    })
     "max" -> encapsulatingTypePreferringKotlin(
       exprList,
       TINY_INT,

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/ExpressionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/ExpressionTest.kt
@@ -392,7 +392,8 @@ class ExpressionTest {
       |someSelect:
       |SELECT coalesce(foo, bar),
       |       coalesce(bar, bar),
-      |       coalesce(foo, bar)
+      |       coalesce(foo, bar),
+      |       coalesce(bar, foo)
       |FROM test;
       """.trimMargin(),
       tempFolder,
@@ -403,6 +404,7 @@ class ExpressionTest {
     assertThat(query.resultColumns.map { it.javaType }).containsExactly(
       ClassName("com.example", "Foo"),
       ClassName("com.example", "Foo").copy(nullable = true),
+      ClassName("com.example", "Foo"),
       ClassName("com.example", "Foo"),
     ).inOrder()
   }
@@ -430,7 +432,9 @@ class ExpressionTest {
       |       coalesce(foo, foo2),
       |       coalesce(foo, baz),
       |       coalesce(bar, baz),
-      |       coalesce(foo, bar, baz)
+      |       coalesce(bar, foo),
+      |       coalesce(foo, bar, baz),
+      |       coalesce(baz, bar, foo)
       |FROM test;
       """.trimMargin(),
       tempFolder,
@@ -448,6 +452,8 @@ class ExpressionTest {
       DOUBLE,
       STRING,
       STRING.copy(nullable = true),
+      integerKotlinType,
+      STRING,
       STRING,
     ).inOrder()
   }


### PR DESCRIPTION
  - For preferKotlinType in the homogeneous types case, the first type is selected
  - For a function like coalesce that's not correct since any non null arg makes the return not nullable
  - The previous behavior is maintained by making the nullability parameter null (which is the default)

Fixes #4870 