### PR TITLE
Fix 4448 missing import for table model

### DIFF
--- a/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/ReturningQueryable.kt
+++ b/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/ReturningQueryable.kt
@@ -29,7 +29,7 @@ class ReturningQueryable(
       ?: return@lazy null
     val requestedColumnsAreIdenticalToTable = table.query.columns.flattenCompounded() == pureColumns
     if (requestedColumnsAreIdenticalToTable) {
-      tableName
+      table.tableName
     } else {
       null
     }

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/migrations/MigrationQueryTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/migrations/MigrationQueryTest.kt
@@ -25,6 +25,10 @@ class MigrationQueryTest {
     checkFixtureCompiles("alter-table-alter-column", PostgreSqlDialect())
   }
 
+  @Test fun `varying query migration packages`() {
+    checkFixtureCompiles("varying-query-migration-packages", PostgreSqlDialect())
+  }
+
   private fun checkFixtureCompiles(fixtureRoot: String, dialect: SqlDelightDialect = SqliteDialect()) {
     val result = FixtureCompiler.compileFixture(
       overrideDialect = dialect,

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/varying-query-migration-packages/com/example/migrations/1.sqm
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/varying-query-migration-packages/com/example/migrations/1.sqm
@@ -1,0 +1,4 @@
+CREATE TABLE test (
+  first TEXT NOT NULL,
+  second INT NOT NULL
+);

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/varying-query-migration-packages/com/example/queries/Data.sq
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/varying-query-migration-packages/com/example/queries/Data.sq
@@ -1,0 +1,12 @@
+migrationSelect:
+SELECT *
+FROM test;
+
+migrationInsert:
+INSERT INTO test(first, second) VALUES (?, ?) RETURNING *;
+
+migrationDelete:
+DELETE FROM test WHERE first = ? RETURNING *;
+
+migrationUpdate:
+UPDATE test SET first = ? RETURNING *;

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/varying-query-migration-packages/output/com/example/migrations/Test.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/varying-query-migration-packages/output/com/example/migrations/Test.kt
@@ -1,0 +1,9 @@
+package com.example.migrations
+
+import kotlin.Int
+import kotlin.String
+
+public data class Test(
+  public val first: String,
+  public val second: Int,
+)

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/varying-query-migration-packages/output/com/example/queries/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/varying-query-migration-packages/output/com/example/queries/DataQueries.kt
@@ -1,0 +1,135 @@
+package com.example.queries
+
+import app.cash.sqldelight.ExecutableQuery
+import app.cash.sqldelight.Query
+import app.cash.sqldelight.TransacterImpl
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlCursor
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.jdbc.JdbcCursor
+import app.cash.sqldelight.driver.jdbc.JdbcPreparedStatement
+import com.example.migrations.Test
+import kotlin.Any
+import kotlin.Int
+import kotlin.String
+
+public class DataQueries(
+  driver: SqlDriver,
+) : TransacterImpl(driver) {
+  public fun <T : Any> migrationSelect(mapper: (first: String, second: Int) -> T): Query<T> =
+      Query(-1_568_224_787, arrayOf("test"), driver, "Data.sq", "migrationSelect", """
+  |SELECT *
+  |FROM test
+  """.trimMargin()) { cursor ->
+    check(cursor is JdbcCursor)
+    mapper(
+      cursor.getString(0)!!,
+      cursor.getInt(1)!!
+    )
+  }
+
+  public fun migrationSelect(): Query<Test> = migrationSelect { first, second ->
+    Test(
+      first,
+      second
+    )
+  }
+
+  public fun <T : Any> migrationInsert(
+    first: String,
+    second: Int,
+    mapper: (first: String, second: Int) -> T,
+  ): ExecutableQuery<T> = MigrationInsertQuery(first, second) { cursor ->
+    check(cursor is JdbcCursor)
+    mapper(
+      cursor.getString(0)!!,
+      cursor.getInt(1)!!
+    )
+  }
+
+  public fun migrationInsert(first: String, second: Int): ExecutableQuery<Test> =
+      migrationInsert(first, second) { first_, second_ ->
+    Test(
+      first_,
+      second_
+    )
+  }
+
+  public fun <T : Any> migrationDelete(first: String, mapper: (first: String, second: Int) -> T):
+      ExecutableQuery<T> = MigrationDeleteQuery(first) { cursor ->
+    check(cursor is JdbcCursor)
+    mapper(
+      cursor.getString(0)!!,
+      cursor.getInt(1)!!
+    )
+  }
+
+  public fun migrationDelete(first: String): ExecutableQuery<Test> = migrationDelete(first) {
+      first_, second ->
+    Test(
+      first_,
+      second
+    )
+  }
+
+  public fun <T : Any> migrationUpdate(first: String, mapper: (first: String, second: Int) -> T):
+      ExecutableQuery<T> = MigrationUpdateQuery(first) { cursor ->
+    check(cursor is JdbcCursor)
+    mapper(
+      cursor.getString(0)!!,
+      cursor.getInt(1)!!
+    )
+  }
+
+  public fun migrationUpdate(first: String): ExecutableQuery<Test> = migrationUpdate(first) {
+      first_, second ->
+    Test(
+      first_,
+      second
+    )
+  }
+
+  private inner class MigrationInsertQuery<out T : Any>(
+    public val first: String,
+    public val second: Int,
+    mapper: (SqlCursor) -> T,
+  ) : ExecutableQuery<T>(mapper) {
+    override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> =
+        driver.executeQuery(-1_845_995_606,
+        """INSERT INTO test(first, second) VALUES (?, ?) RETURNING *""", mapper, 2) {
+      check(this is JdbcPreparedStatement)
+      bindString(0, first)
+      bindInt(1, second)
+    }
+
+    override fun toString(): String = "Data.sq:migrationInsert"
+  }
+
+  private inner class MigrationDeleteQuery<out T : Any>(
+    public val first: String,
+    mapper: (SqlCursor) -> T,
+  ) : ExecutableQuery<T>(mapper) {
+    override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> =
+        driver.executeQuery(-1_997_661_540, """DELETE FROM test WHERE first = ? RETURNING *""",
+        mapper, 1) {
+      check(this is JdbcPreparedStatement)
+      bindString(0, first)
+    }
+
+    override fun toString(): String = "Data.sq:migrationDelete"
+  }
+
+  private inner class MigrationUpdateQuery<out T : Any>(
+    public val first: String,
+    mapper: (SqlCursor) -> T,
+  ) : ExecutableQuery<T>(mapper) {
+    override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> =
+        driver.executeQuery(-1_501_049_414, """UPDATE test SET first = ? RETURNING *""", mapper, 1)
+        {
+      check(this is JdbcPreparedStatement)
+      bindString(0, first)
+    }
+
+    override fun toString(): String = "Data.sq:migrationUpdate"
+  }
+}


### PR DESCRIPTION
fixes #4448 

🦑 This is for both Sqlite and Postgresql dialects that support `RETURNING *`

`app.cash.sqldelight.dialect.api.ReturningQueryable` now returns the parent table reference instead of the statement table reference to use the correct package name that is taken from the source file

`SelectQueryable` works already

e.g the `CREATE TABLE Test ... ` is contained in `com\example\migration\1.sqm`
`INSERT INTO Test()...RETURNING*` is contained in `com\example\queries\Data.sq`

The generated `DataQueries` must contain `import com.example.migration.Test`

The other migration fixtures assume that `sqm` and `sq` are co-located in same directory and thus work.
