### PR TITLE
Update Postgresql AlterTableAlterColumnMixin

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/AlterTableAlterColumnMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/AlterTableAlterColumnMixin.kt
@@ -1,8 +1,10 @@
 package app.cash.sqldelight.dialects.postgresql.grammar.mixins
 
 import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlAlterTableAlterColumn
+import com.alecstrong.sql.psi.core.SqlAnnotationHolder
 import com.alecstrong.sql.psi.core.psi.AlterTableApplier
 import com.alecstrong.sql.psi.core.psi.LazyQuery
+import com.alecstrong.sql.psi.core.psi.NamedElement
 import com.alecstrong.sql.psi.core.psi.SqlColumnConstraint
 import com.alecstrong.sql.psi.core.psi.SqlColumnDef
 import com.alecstrong.sql.psi.core.psi.SqlColumnName
@@ -36,7 +38,6 @@ internal abstract class AlterTableAlterColumnMixin(
     val sqlColumnType = children.filterIsInstance<SqlColumnType>().firstOrNull()
     if (sqlColumnType != null) return sqlColumnType
 
-    val columnName = columnName
     val element = tablesAvailable(this).first { it.tableName.textMatches(alterStmt.tableName) }
       .query.columns.first { it.element.textMatches(columnName) }.element
     return (element.parent as ColumnDefMixin).columnType
@@ -55,15 +56,33 @@ internal abstract class AlterTableAlterColumnMixin(
       }
     }
 
-    val alterColumnTable = getColumnName()
     return LazyQuery(
       tableName = lazyQuery.tableName,
       query = {
-        val columns = lazyQuery.query.columns.map { queryColumn ->
-          if (queryColumn.element.textMatches(alterColumnTable)) queryColumn.copy(element = alterColumnTable, nullable = nullableColumn ?: queryColumn.nullable) else queryColumn
+        val columns = lazyQuery.query.columns
+        val alterColumn = columns.singleOrNull {
+          (it.element as NamedElement).textMatches(columnName)
         }
-        lazyQuery.query.copy(columns = columns)
+
+        lazyQuery.query.copy(
+          columns = columns.map { if (it == alterColumn) it.copy(element = columnName, nullable = nullableColumn ?: it.nullable) else it },
+        )
       },
     )
+  }
+
+  override fun annotate(annotationHolder: SqlAnnotationHolder) {
+    super.annotate(annotationHolder)
+
+    if (tablesAvailable(this)
+        .filter { it.tableName.textMatches(alterStmt.tableName) }
+        .flatMap { it.query.columns }
+        .none { (it.element as? NamedElement)?.textMatches(columnName) == true }
+    ) {
+      annotationHolder.createErrorAnnotation(
+        element = columnName,
+        message = "No column found to alter with name ${columnName.text}",
+      )
+    }
   }
 }

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/AlterTableAlterColumnMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/AlterTableAlterColumnMixin.kt
@@ -35,7 +35,7 @@ internal abstract class AlterTableAlterColumnMixin(
   }
 
   override fun getColumnType(): SqlColumnType {
-    val sqlColumnType = children.filterIsInstance<SqlColumnType>().firstOrNull()
+    val sqlColumnType = children.filterIsInstance<SqlColumnType>().singleOrNull()
     if (sqlColumnType != null) return sqlColumnType
 
     val element = tablesAvailable(this).first { it.tableName.textMatches(alterStmt.tableName) }
@@ -64,8 +64,12 @@ internal abstract class AlterTableAlterColumnMixin(
           (it.element as NamedElement).textMatches(columnName)
         }
 
+        val sqlColumnName = children.filterIsInstance<SqlColumnType>().singleOrNull()?.run { columnName }
+
         lazyQuery.query.copy(
-          columns = columns.map { if (it == alterColumn) it.copy(element = columnName, nullable = nullableColumn ?: it.nullable) else it },
+          columns = columns.map {
+            if (it == alterColumn) it.copy(element = sqlColumnName ?: it.element, nullable = nullableColumn ?: it.nullable) else it
+          },
         )
       },
     )


### PR DESCRIPTION
🆙  More updates to improve Postgresql migration support

* Adds override to annotate the compiler message for missing column name
* Remove some redundant variables
* Issue where Queries was using `old` column name if had been previously renamed  😖 

Support several migrations - individually or as a group

Check if `nullableColumn` exists to use the `nullableColumn` value
Check if a `SqlColumnType` exists to use the alter column `SqlColumn`

```
ALTER TABLE test ALTER COLUMN x SET NOT NULL; -- change nullability, set the nullable property on the QueryColumn element
ALTER TABLE test ALTER COLUMN x TYPE BIGINT; -- change column type, set the element property to columnName
ALTER TABLE test ALTER COLUMN x DROP IDENTITY; -- no changes, keep current element and nullable properties
```

Additional local tests 🐘 🔌  https://github.com/griffio/sqldelight-postgres-01