### PR TITLE
Update MigrationQueryTest.kt to show compiler error

### DIFF
--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/migrations/MigrationQueryTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/migrations/MigrationQueryTest.kt
@@ -36,6 +36,9 @@ class MigrationQueryTest {
       generateDb = false,
       deriveSchemaFromMigrations = true,
     )
+
+    if (result.errors.isNotEmpty()) assertWithMessage(result.errors.joinToString("\n")).fail()
+    
     for ((expectedFile, actualOutput) in result.compilerOutput) {
       assertWithMessage("No file with name $expectedFile").that(expectedFile.exists()).isTrue()
       assertWithMessage(expectedFile.name).that(actualOutput.toString())

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/migrations/MigrationQueryTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/migrations/MigrationQueryTest.kt
@@ -38,7 +38,7 @@ class MigrationQueryTest {
     )
 
     if (result.errors.isNotEmpty()) assertWithMessage(result.errors.joinToString("\n")).fail()
-    
+
     for ((expectedFile, actualOutput) in result.compilerOutput) {
       assertWithMessage("No file with name $expectedFile").that(expectedFile.exists()).isTrue()
       assertWithMessage(expectedFile.name).that(actualOutput.toString())


### PR DESCRIPTION
Have seen an improvement to be made in MigrationQueryTest, where a test passed but was a "false positive" 🔋 

⚠️ A test can succeed even if there is a compiler error.

👮 Ensure test fails when there is a compiler error and show errors.

For example -
* an invalid column in Data.sq must show the error "Data.sq: (6, 58): No column found with name x"
* an insert query missing a non default value "Data.sq: (5, 0): Cannot populate default value for column x, it must be specified in insert statement."
