### PR TITLE
Fixes 4932 postgresql default constraint functions

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -121,6 +121,7 @@ default_constraint ::= [ NOT NULL | NULL ] DEFAULT (
   current_timestamp_with_optional_interval |
   {signed_number} |
   {literal_value} |
+  {function_expr} |
   LP <<expr '-1'>> RP
 ) {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlDefaultConstraintImpl"

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/column_types/Sample.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/column_types/Sample.s
@@ -70,7 +70,11 @@ CREATE TABLE all_types(
 
   some_interval_d TIMESTAMP NOT NULL DEFAULT NOW() - INTERVAL '5 days',
 
-  some_interval_e INTERVAL DEFAULT INTERVAL '3h' + INTERVAL '20m'
+  some_interval_e INTERVAL DEFAULT INTERVAL '3h' + INTERVAL '20m',
+
+  some_default_uuid UUID DEFAULT gen_random_uuid(),
+
+  some_default_sequence INTEGER DEFAULT nextval('some_seq')
 
 );
 


### PR DESCRIPTION
fixes #4932 - compiler error when functions are used as `DEFAULT` column values 

😑 Currently the work-around/escape-hatch is to enclose the function in parentheses as this matches the grammar rule`LP expr RP`

Add `{function_expr}` to the `default_constraint` rule

Other consideration is that ideally the function result type must be assignable to the column type 🔡 🔢 and would need to be compiler checked - currently none of the `DEFAULT` types are checked and can be any type of expression 🤭 

```
CREATE TABLE t1(
  c1 UUID DEFAULT gen_random_uuid(),
  c2 INTEGER DEFAULT nextval('some_seq')
);
```
---

💡 Ideally - SqlDelight would provide error

```
CREATE TABLE t1(
  c1 INTEGER DEFAULT gen_random_uuid()
);
```
Postgresql does provide error
`error: column "c1" is of type integer but default expression is of type uuid`
