### PR TITLE
Fixes 5018 PostgreSql add Primary Key not nullable types

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -314,7 +314,9 @@ alter_table_drop_column ::= DROP [ COLUMN ] {column_name} {
   pin = 1
 }
 
-alter_table_add_constraint ::= ADD table_constraint
+alter_table_add_constraint ::= ADD table_constraint {
+    mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.AlterTableAddConstraintMixin"
+}
 
 type_clause ::= 'TYPE'
 

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/AlterTableAddConstraintMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/AlterTableAddConstraintMixin.kt
@@ -1,0 +1,27 @@
+package app.cash.sqldelight.dialects.postgresql.grammar.mixins
+
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlAlterTableAddConstraint
+import com.alecstrong.sql.psi.core.psi.AlterTableApplier
+import com.alecstrong.sql.psi.core.psi.LazyQuery
+import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
+import com.alecstrong.sql.psi.core.psi.SqlTypes
+import com.intellij.lang.ASTNode
+
+abstract class AlterTableAddConstraintMixin(node: ASTNode) :
+  SqlCompositeElementImpl(node),
+  PostgreSqlAlterTableAddConstraint,
+  AlterTableApplier {
+  override fun applyTo(lazyQuery: LazyQuery): LazyQuery =
+    if (tableConstraint.node.findChildByType(SqlTypes.PRIMARY) != null &&
+      tableConstraint.node.findChildByType(SqlTypes.KEY) != null
+    ) {
+      val columns = lazyQuery.query.columns.map { queryCol ->
+        tableConstraint.indexedColumnList.find { indexedCol -> queryCol.element.textMatches(indexedCol) }.let {
+          queryCol.copy(nullable = if (it != null) false else queryCol.nullable)
+        }
+      }
+      LazyQuery(lazyQuery.tableName, query = { lazyQuery.query.copy(columns = columns) })
+    } else {
+      lazyQuery
+    }
+}

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/migrations/MigrationQueryTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/migrations/MigrationQueryTest.kt
@@ -29,6 +29,10 @@ class MigrationQueryTest {
     checkFixtureCompiles("alter-table-alter-column", PostgreSqlDialect())
   }
 
+  @Test fun `alter table add constraint`() {
+    checkFixtureCompiles("alter-table-add-constraint", PostgreSqlDialect())
+  }
+
   @Test fun `varying query migration packages`() {
     checkFixtureCompiles("varying-query-migration-packages", PostgreSqlDialect())
   }

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/com/example/1.sqm
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/com/example/1.sqm
@@ -1,0 +1,9 @@
+CREATE TABLE TestSingle(
+  first INTEGER,
+  second TEXT
+);
+
+CREATE TABLE TestCompound (
+  first INTEGER,
+  second TEXT
+);

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/com/example/2.sqm
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/com/example/2.sqm
@@ -1,0 +1,3 @@
+ALTER TABLE TestSingle ADD PRIMARY KEY (first);
+ALTER TABLE TestCompound ADD CONSTRAINT pk_first_second PRIMARY KEY (first, second);
+

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/com/example/Data.sq
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/com/example/Data.sq
@@ -1,0 +1,8 @@
+selectSingle:
+SELECT *
+FROM TestSingle;
+
+selectCompound:
+SELECT *
+FROM TestCompound;
+

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/output/com/example/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/output/com/example/DataQueries.kt
@@ -1,0 +1,51 @@
+package com.example
+
+import app.cash.sqldelight.Query
+import app.cash.sqldelight.TransacterImpl
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.jdbc.JdbcCursor
+import kotlin.Any
+import kotlin.Int
+import kotlin.String
+
+public class DataQueries(
+  driver: SqlDriver,
+) : TransacterImpl(driver) {
+  public fun <T : Any> selectSingle(mapper: (first: Int, second: String?) -> T): Query<T> =
+      Query(-79_317_191, arrayOf("TestSingle"), driver, "Data.sq", "selectSingle", """
+  |SELECT *
+  |FROM TestSingle
+  """.trimMargin()) { cursor ->
+    check(cursor is JdbcCursor)
+    mapper(
+      cursor.getInt(0)!!,
+      cursor.getString(1)
+    )
+  }
+
+  public fun selectSingle(): Query<TestSingle> = selectSingle { first, second ->
+    TestSingle(
+      first,
+      second
+    )
+  }
+
+  public fun <T : Any> selectCompound(mapper: (first: Int, second: String) -> T): Query<T> =
+      Query(-19_725_220, arrayOf("TestCompound"), driver, "Data.sq", "selectCompound", """
+  |SELECT *
+  |FROM TestCompound
+  """.trimMargin()) { cursor ->
+    check(cursor is JdbcCursor)
+    mapper(
+      cursor.getInt(0)!!,
+      cursor.getString(1)!!
+    )
+  }
+
+  public fun selectCompound(): Query<TestCompound> = selectCompound { first, second ->
+    TestCompound(
+      first,
+      second
+    )
+  }
+}

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/output/com/example/TestCompound.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/output/com/example/TestCompound.kt
@@ -1,0 +1,9 @@
+package com.example
+
+import kotlin.Int
+import kotlin.String
+
+public data class TestCompound(
+  public val first: Int,
+  public val second: String,
+)

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/output/com/example/TestSingle.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/output/com/example/TestSingle.kt
@@ -1,0 +1,9 @@
+package com.example
+
+import kotlin.Int
+import kotlin.String
+
+public data class TestSingle(
+  public val first: Int,
+  public val second: String?,
+)


### PR DESCRIPTION
Fixes #5018 

🧑‍🍳 🧇  Adds a mixin to the grammar to handle nullable types when adding a  `PRIMARY KEY` with `ALTER TABLE`.
PostgreSql Primary Key columns are NOT NULL 

AlterTableAddConstraintMixin
This takes a lazyQuery as input, checks if the table constraint is a primary key, updates matching columns to not nullable, and returns a new lazyQuery with the transformed columns. This has the effect of propagating primary key nullability constraints to the columns when altering the table.

New `MigrationQueryTest` added

tested locally with https://github.com/griffio/sqldelight-postgres-01