### PR TITLE
Drop Flamingo tests and reduce number of tested IDEA versions

### DIFF
--- a/sqldelight-idea-plugin/build.gradle
+++ b/sqldelight-idea-plugin/build.gradle
@@ -39,9 +39,9 @@ tasks.named('runIde') {
 }
 
 tasks.named('runPluginVerifier') {
+  // https://plugins.jetbrains.com/docs/intellij/android-studio-releases-list.html
   ideVersions = [
-      "IC-2022.2.4", // AS: Flamingo | 2022.2.1
-      "IC-2022.3.1", // IC
+      "IC-2022.3.3", // AS: Giraffe | 2022.3.1
       "IC-2023.1",   // IC
       "IC-2023.2",   // IC
   ]


### PR DESCRIPTION
Our PR builds are failing due to the instrumentation runners running out of disk space. I think downloading four IDEA versions could be a contributor?

We could consider splitting these tests into a test matrix that runs the tests against one (or two) intelliJ version(s) per runner so that we don't use up a ton of disk space just to run these tests.