### PR TITLE
Fixes 5028 PostgreSql json

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlType.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlType.kt
@@ -6,6 +6,7 @@ import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.INT
 import com.squareup.kotlinpoet.LONG
 import com.squareup.kotlinpoet.SHORT
+import com.squareup.kotlinpoet.STRING
 import com.squareup.kotlinpoet.TypeName
 
 internal enum class PostgreSqlType(override val javaType: TypeName) : DialectType {
@@ -19,6 +20,7 @@ internal enum class PostgreSqlType(override val javaType: TypeName) : DialectTyp
   INTERVAL(ClassName("org.postgresql.util", "PGInterval")),
   UUID(ClassName("java.util", "UUID")),
   NUMERIC(ClassName("java.math", "BigDecimal")),
+  JSON(STRING),
   ;
 
   override fun prepareStatementBinder(columnIndex: CodeBlock, value: CodeBlock): CodeBlock {
@@ -30,6 +32,7 @@ internal enum class PostgreSqlType(override val javaType: TypeName) : DialectTyp
           BIG_INT -> "bindLong"
           DATE, TIME, TIMESTAMP, TIMESTAMP_TIMEZONE, INTERVAL, UUID -> "bindObject"
           NUMERIC -> "bindBigDecimal"
+          JSON -> "bindObjectOther"
         },
       )
       .add("(%L, %L)\n", columnIndex, value)
@@ -44,6 +47,7 @@ internal enum class PostgreSqlType(override val javaType: TypeName) : DialectTyp
         BIG_INT -> "$cursorName.getLong($columnIndex)"
         DATE, TIME, TIMESTAMP, TIMESTAMP_TIMEZONE, INTERVAL, UUID -> "$cursorName.getObject<%T>($columnIndex)"
         NUMERIC -> "$cursorName.getBigDecimal($columnIndex)"
+        JSON -> "$cursorName.getString($columnIndex)"
       },
       javaType,
     )

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -65,7 +65,7 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
             else -> throw IllegalArgumentException("Unknown date type ${dateDataType!!.text}")
           }
         }
-        jsonDataType != null -> TEXT
+        jsonDataType != null -> PostgreSqlType.JSON
         booleanDataType != null -> BOOLEAN
         blobDataType != null -> BLOB
         else -> throw IllegalArgumentException("Unknown kotlin type for sql type ${this.text}")

--- a/drivers/jdbc-driver/src/main/kotlin/app/cash/sqldelight/driver/jdbc/JdbcDriver.kt
+++ b/drivers/jdbc-driver/src/main/kotlin/app/cash/sqldelight/driver/jdbc/JdbcDriver.kt
@@ -261,6 +261,14 @@ class JdbcPreparedStatement(
     }
   }
 
+  fun bindObjectOther(index: Int, obj: Any?) {
+    if (obj == null) {
+      preparedStatement.setNull(index + 1, Types.OTHER)
+    } else {
+      preparedStatement.setObject(index + 1, obj, Types.OTHER)
+    }
+  }
+
   override fun bindString(index: Int, string: String?) {
     if (string == null) {
       preparedStatement.setNull(index + 1, Types.VARCHAR)

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Json.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Json.sq
@@ -11,3 +11,10 @@ INSERT INTO myJson(data, datab) VALUES(
 
 buildJson:
 SELECT json_build_object('key', 'value'), jsonb_build_object('key', 'value');
+
+insertLiteral:
+INSERT INTO myJson(data, datab) VALUES (?, ?);
+
+select:
+SELECT *
+FROM myJson;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -596,4 +596,22 @@ class PostgreSqlTest {
     val result = database.binaryArgumentsQueries.selectDataBinaryIntervalComparison2(created).executeAsList()
     assertThat(result.first().datum).isEqualTo(10)
   }
+
+  @Test
+  fun testInsertJson() {
+    database.jsonQueries.insert("another key", "another value")
+    with(database.jsonQueries.select().executeAsList()) {
+      assertThat(first().data_).isEqualTo("""{"another key" : "another value"}""")
+      assertThat(first().datab).isEqualTo("""{"key": "value"}""")
+    }
+  }
+
+  @Test
+  fun testInsertJsonLiteral() {
+    database.jsonQueries.insertLiteral("""{"key a" : "value a"}""", """{"key b" : "value b"}""")
+    with(database.jsonQueries.select().executeAsList()) {
+      assertThat(first().data_).isEqualTo("""{"key a" : "value a"}""")
+      assertThat(first().datab).isEqualTo("""{"key b": "value b"}""")
+    }
+  }
 }


### PR DESCRIPTION
fixes #5028

🚧 🍔 👷 

With JDBC, setObject...Types.OTHER can be used to bind a String to a JSON type
Add new binding method* in JdbcDriver

Keep the `jsonDataType` as a String for reading and writing

Add JSON type for setObject...Types.OTHER binding to write as a String. Read a result String as normal

Add Docker Integration tests (none were being run for json with PostgresDialect)

*This may come in useful for other types like TSVector 