### PR TITLE
Fixes 5040 PostgreSql json operators

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -154,7 +154,6 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
     "to_json", "to_jsonb",
     "array_to_json", "row_to_json",
     "json_build_array", "jsonb_build_array",
-    "json_build_object", "jsonb_build_object",
     "json_object", "jsonb_object",
     "json_extract_path", "jsonb_extract_path",
     "json_extract_path_text", "jsonb_extract_path_text",
@@ -164,6 +163,8 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
     "jsonb_pretty",
     "json_typeof", "jsonb_typeof",
     "json_agg", "jsonb_agg", "json_object_agg", "jsonb_object_agg",
+    -> IntermediateType(PostgreSqlType.JSON)
+    "json_build_object", "jsonb_build_object",
     -> IntermediateType(TEXT)
     "array_agg" -> {
       val typeForAgg = encapsulatingTypePreferringKotlin(exprList, SMALL_INT, PostgreSqlType.INTEGER, INTEGER, BIG_INT, REAL, TEXT, TIMESTAMP_TIMEZONE, TIMESTAMP, DATE).asNullable()

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -260,6 +260,9 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
         val windowFunctionExpr = windowFunctionExpr as WindowFunctionMixin
         functionType(windowFunctionExpr.functionExpr)!!
       }
+      jsonExpression != null -> {
+        IntermediateType(PostgreSqlType.JSON)
+      }
       else -> parentResolver.resolvedType(this)
     }
 

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -261,7 +261,11 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
         functionType(windowFunctionExpr.functionExpr)!!
       }
       jsonExpression != null -> {
-        IntermediateType(PostgreSqlType.JSON)
+        if (jsonExpression!!.jsonbBooleanOperator != null) {
+          IntermediateType(BOOLEAN)
+        } else {
+          IntermediateType(PostgreSqlType.JSON)
+        }
       }
       else -> parentResolver.resolvedType(this)
     }

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -238,6 +238,7 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
           PostgreSqlType.INTERVAL,
           PostgreSqlType.TIMESTAMP_TIMEZONE,
           PostgreSqlType.TIMESTAMP,
+          PostgreSqlType.JSON,
         )
       }
     }

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -374,7 +374,7 @@ json_expression ::= {column_name} ( jsona_binary_operator | jsonb_binary_operato
   pin = 2
 }
 jsona_binary_operator ::= '->' | '->>' | '#>' | '#>>'
-jsonb_binary_operator ::= '#-' | '||' | '-' | '#-'
+jsonb_binary_operator ::= '#-'
 jsonb_boolean_operator ::= '@@' | '@>' | '<@' | '@?' | '??|' | '??&' | '??'
 
 extension_stmt ::= create_sequence_stmt | copy_stdin | truncate_stmt | set_stmt | drop_sequence_stmt | alter_sequence_stmt | create_extension_stmt | drop_extension_stmt | alter_extension_stmt {

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -372,7 +372,7 @@ json_expression ::= {column_name} ( jsona_binary_operator | jsonb_binary_operato
   mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.JsonExpressionMixin"
   pin = 2
 }
-jsona_binary_operator ::= '->' | '->>' | '#>'
+jsona_binary_operator ::= '->' | '->>' | '#>' | '#>>'
 jsonb_binary_operator ::= '@>' | '<@' | '?|' | '?&' | '?' | '#-'
 
 extension_stmt ::= create_sequence_stmt | copy_stdin | truncate_stmt | set_stmt | drop_sequence_stmt | alter_sequence_stmt | create_extension_stmt | drop_extension_stmt | alter_extension_stmt {

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -175,6 +175,7 @@ create_index_stmt ::= CREATE [ UNIQUE ] INDEX [ 'CONCURRENTLY' ] [ IF NOT EXISTS
   pin = 6
 }
 
+
 identity_clause ::= 'IDENTITY' [ LP [ 'SEQUENCE' 'NAME' sequence_name ] [ sequence_parameters* ] RP ]
 
 generated_clause ::= GENERATED ( (ALWAYS AS LP <<expr '-1'>> RP 'STORED') | ( (ALWAYS | BY DEFAULT) AS identity_clause ) ) {
@@ -368,12 +369,13 @@ boolean_not_expression ::= NOT (boolean_literal | {column_name})
 
 boolean_literal ::= TRUE | FALSE
 
-json_expression ::= {column_name} ( jsona_binary_operator | jsonb_binary_operator ) <<expr '-1'>> {
+json_expression ::= {column_name} ( jsona_binary_operator | jsonb_binary_operator | jsonb_boolean_operator ) <<expr '-1'>> {
   mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.JsonExpressionMixin"
   pin = 2
 }
 jsona_binary_operator ::= '->' | '->>' | '#>' | '#>>'
-jsonb_binary_operator ::= '@>' | '<@' | '?|' | '?&' | '?' | '#-'
+jsonb_binary_operator ::= '#-' | '||' | '-' | '#-'
+jsonb_boolean_operator ::= '@@' | '@>' | '<@' | '@?' | '??|' | '??&' | '??'
 
 extension_stmt ::= create_sequence_stmt | copy_stdin | truncate_stmt | set_stmt | drop_sequence_stmt | alter_sequence_stmt | create_extension_stmt | drop_extension_stmt | alter_extension_stmt {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlExtensionStmtImpl"

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/JsonExpressionMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/JsonExpressionMixin.kt
@@ -15,7 +15,7 @@ internal abstract class JsonExpressionMixin(node: ASTNode) :
     if (columnType == null || columnType !in arrayOf("JSON", "JSONB")) {
       annotationHolder.createErrorAnnotation(firstChild, "Left side of json expression must be a json column.")
     }
-    if (jsonbBinaryOperator != null && columnType != "JSONB") {
+    if ((jsonbBinaryOperator != null || jsonbBooleanOperator != null) && columnType != "JSONB") {
       annotationHolder.createErrorAnnotation(firstChild, "Left side of jsonb expression must be a jsonb column.")
     }
     super.annotate(annotationHolder)

--- a/dialects/postgresql/src/test/kotlin/app/cash/sqldelight/dialects/postgres/PostgreSqlFixturesTest.kt
+++ b/dialects/postgresql/src/test/kotlin/app/cash/sqldelight/dialects/postgres/PostgreSqlFixturesTest.kt
@@ -18,7 +18,7 @@ class PostgreSqlFixturesTest(name: String, fixtureRoot: File) : FixturesTest(nam
     "BLOB" to "TEXT",
     "id TEXT GENERATED ALWAYS AS (2) UNIQUE NOT NULL" to "id TEXT GENERATED ALWAYS AS (2) STORED UNIQUE NOT NULL",
     "'(', ')', ',', '.', <binary like operator real>, BETWEEN or IN expected, got ','"
-      to "'(', ')', ',', '.', <binary like operator real>, <jsona binary operator real>, <jsonb binary operator real>, BETWEEN or IN expected, got ','",
+      to "'#-', '(', ')', ',', '.', <binary like operator real>, <jsona binary operator real>, <jsonb boolean operator real>, BETWEEN or IN expected, got ','",
   )
 
   override fun setupDialect() {

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/json_functions/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/json_functions/Test.s
@@ -22,5 +22,5 @@ SELECT
   data @@ '$.b[*] > 0'
 FROM myTable;
 
-SELECT data ->> 'a', datab -> 'b', data #> '{aa}', datab #>> '{bb}'
+SELECT data ->> 'a', datab -> 'b', data #> '{aa}', datab #>> '{bb}', datab || datab, datab - 'b', datab - 1
 FROM myTable;

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/json_functions/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/json_functions/Test.s
@@ -3,34 +3,24 @@ CREATE TABLE myTable(
     datab JSONB NOT NULL
 );
 
-SELECT *
-FROM myTable
-WHERE
-  data -> 'sup' AND
-  data ->> 'sup' AND
-  data #> 'sup' AND
+SELECT
 --error[col 2]: Left side of jsonb expression must be a jsonb column.
-  data @> 'sup' AND
+  data #- '{"a"}',
 --error[col 2]: Left side of jsonb expression must be a jsonb column.
-  data <@ 'sup' AND
+  data @> datab,
 --error[col 2]: Left side of jsonb expression must be a jsonb column.
-  data ? 'sup' AND
+  data <@ datab,
 --error[col 2]: Left side of jsonb expression must be a jsonb column.
-  data ?| 'sup' AND
+  data ?? 'b',
 --error[col 2]: Left side of jsonb expression must be a jsonb column.
-  data ?& 'sup' AND
+  data ??| '{"a","b"}',
 --error[col 2]: Left side of jsonb expression must be a jsonb column.
-  data #- 'sup' AND
-  datab -> 'sup' AND
-  datab ->> 'sup' AND
-  datab #> 'sup' AND
-  datab @> 'sup' AND
-  datab <@ 'sup' AND
-  datab ? 'sup' AND
-  datab ?| 'sup' AND
-  datab ?& 'sup' AND
-  datab #- 'sup'
-;
+  data ??& '{"a"}',
+--error[col 2]: Left side of jsonb expression must be a jsonb column.
+  data @? '$.a[*]',
+--error[col 2]: Left side of jsonb expression must be a jsonb column.
+  data @@ '$.b[*] > 0'
+FROM myTable;
 
 SELECT data ->> 'a', datab -> 'b', data #> '{aa}', datab #>> '{bb}'
 FROM myTable;

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/json_functions/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/json_functions/Test.s
@@ -31,3 +31,6 @@ WHERE
   datab ?& 'sup' AND
   datab #- 'sup'
 ;
+
+SELECT data ->> 'a', datab -> 'b', data #> '{aa}', datab #>> '{bb}'
+FROM myTable;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Json.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Json.sq
@@ -1,10 +1,10 @@
-CREATE TABLE myJson(
+CREATE TABLE TestJson(
   data JSON NOT NULL,
   datab JSONB NOT NULL
 );
 
 insert:
-INSERT INTO myJson(data, datab) VALUES(
+INSERT INTO TestJson(data, datab) VALUES(
   json_build_object(:key, :value),
   jsonb_build_object('key', 'value')
 );
@@ -13,8 +13,16 @@ buildJson:
 SELECT json_build_object('key', 'value'), jsonb_build_object('key', 'value');
 
 insertLiteral:
-INSERT INTO myJson(data, datab) VALUES (?, ?);
+INSERT INTO TestJson(data, datab) VALUES (?, ?);
 
 select:
 SELECT *
-FROM myJson;
+FROM TestJson;
+
+selectJsonObjectOperators:
+SELECT data ->> 'a', datab -> 'b', data #> '{aa}', datab #>> '{bb}'
+FROM TestJson;
+
+selectJsonArrayOperators:
+SELECT data -> 0, data ->> 1, data ->> 2
+FROM TestJson;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Json.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Json.sq
@@ -1,6 +1,8 @@
 CREATE TABLE TestJson(
   data JSON NOT NULL,
-  datab JSONB NOT NULL
+  datab JSONB NOT NULL,
+  datac JSONB,
+  datad TEXT[]
 );
 
 insert:
@@ -13,7 +15,7 @@ buildJson:
 SELECT json_build_object('key', 'value'), jsonb_build_object('key', 'value');
 
 insertLiteral:
-INSERT INTO TestJson(data, datab) VALUES (?, ?);
+INSERT INTO TestJson(data, datab, datac, datad) VALUES (?, ?, ?, ?);
 
 select:
 SELECT *
@@ -25,4 +27,8 @@ FROM TestJson;
 
 selectJsonArrayOperators:
 SELECT data -> 0, data ->> 1, data ->> 2
+FROM TestJson;
+
+selectJsonBooleanOperators:
+SELECT datab @> datac, datac <@ datab, datab ?? 'b', datab ??| datad, datab ??& datad
 FROM TestJson;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Json.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Json.sq
@@ -22,13 +22,17 @@ SELECT *
 FROM TestJson;
 
 selectJsonObjectOperators:
-SELECT data ->> 'a', datab -> 'b', data #> '{aa}', datab #>> '{bb}'
+SELECT data ->> 'a', datab -> 'b', data #> '{aa}', datab #>> '{bb}', datab - 'b'
 FROM TestJson;
 
-selectJsonArrayOperators:
-SELECT data -> 0, data ->> 1, data ->> 2
+selectJsonArrayIndexOperators:
+SELECT data -> 0, data ->> 1, data ->> 2, datab - 1
 FROM TestJson;
 
 selectJsonBooleanOperators:
-SELECT datab @> datac, datac <@ datab, datab ?? 'b', datab ??| datad, datab ??& datad
+SELECT datab @> datac, datac <@ datab, datab ?? 'b', datab ??| datad, datab ??& datad, datab @@ '$.b[*] > 0'
+FROM TestJson;
+
+selectJsonConcatOperators:
+SELECT datab || datac
 FROM TestJson;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Json.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Json.sq
@@ -11,8 +11,9 @@ INSERT INTO TestJson(data, datab) VALUES(
   jsonb_build_object('key', 'value')
 );
 
-buildJson:
-SELECT json_build_object('key', 'value'), jsonb_build_object('key', 'value');
+setJsonb:
+UPDATE TestJson
+SET datab = jsonb_set(datab, :path, :newValue) RETURNING datab;
 
 insertLiteral:
 INSERT INTO TestJson(data, datab, datac, datad) VALUES (?, ?, ?, ?);
@@ -35,4 +36,8 @@ FROM TestJson;
 
 selectJsonConcatOperators:
 SELECT datab || datac
+FROM TestJson;
+
+selectJsonPretty:
+SELECT jsonb_pretty(datab)
 FROM TestJson;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -691,4 +691,25 @@ class PostgreSqlTest {
       assertThat(first().datab).isEqualTo("""{"key b": "value b"}""")
     }
   }
+
+  @Test
+  fun testJsonObjectOperators() {
+    database.jsonQueries.insertLiteral("""{"a" : 11,"aa":[1,2,3]}""", """{"b" : 12,"bb":[1,2,3]}""")
+    with(database.jsonQueries.selectJsonObjectOperators().executeAsList()) {
+      assertThat(first().expr).isEqualTo("11")
+      assertThat(first().expr_).isEqualTo("12")
+      assertThat(first().expr__).isEqualTo("[1,2,3]")
+      assertThat(first().expr___).isEqualTo("[1, 2, 3]")
+    }
+  }
+
+  @Test
+  fun testJsonArrayOperators() {
+    database.jsonQueries.insertLiteral("""[1,2,3]""", """[1,2,3]""")
+    with(database.jsonQueries.selectJsonArrayOperators().executeAsList()) {
+      assertThat(first().expr).isEqualTo("1")
+      assertThat(first().expr_).isEqualTo("2")
+      assertThat(first().expr__).isEqualTo("3")
+    }
+  }
 }

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -675,6 +675,15 @@ class PostgreSqlTest {
   }
 
   @Test
+  fun testInsertJson() {
+    database.jsonQueries.insert("another key", "another value")
+    with(database.jsonQueries.select().executeAsList()) {
+      assertThat(first().data_).isEqualTo("""{"another key" : "another value"}""")
+      assertThat(first().datab).isEqualTo("""{"key": "value"}""")
+    }
+  }
+
+  @Test
   fun testInsertJsonLiteral() {
     database.jsonQueries.insertLiteral("""{"key a" : "value a"}""", """{"key b" : "value b"}""", """{}""", emptyArray<String>())
     with(database.jsonQueries.select().executeAsList()) {
@@ -724,6 +733,28 @@ class PostgreSqlTest {
     database.jsonQueries.insertLiteral("""{}""", """{"a":1}""", """{"b":2}""", emptyArray<String>())
     with(database.jsonQueries.selectJsonConcatOperators().executeAsList()) {
       assertThat(first().expr).isEqualTo("""{"a": 1, "b": 2}""")
+    }
+  }
+
+  @Test
+  fun testJsonbPretty() {
+    database.jsonQueries.insertLiteral("""{}""", """{"a":1,"b":2}""", """{}""", emptyArray<String>())
+    with(database.jsonQueries.selectJsonPretty().executeAsList()) {
+      assertThat(first()).isEqualTo(
+        """{
+      |    "a": 1,
+      |    "b": 2
+      |}
+        """.trimMargin(),
+      )
+    }
+  }
+
+  @Test
+  fun testJsonbSet() {
+    database.jsonQueries.insertLiteral("""{}""", """[{"a":1},{"b":2}]""", """{}""", emptyArray<String>())
+    with(database.jsonQueries.setJsonb("""{0, "a"}""", """123""").executeAsList()) {
+      assertThat(first()).isEqualTo("""[{"a": 123}, {"b": 2}]""")
     }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -691,16 +691,18 @@ class PostgreSqlTest {
       assertThat(first().expr_).isEqualTo("12")
       assertThat(first().expr__).isEqualTo("[1,2,3]")
       assertThat(first().expr___).isEqualTo("[1, 2, 3]")
+      assertThat(first().expr____).isEqualTo("""{"bb": [1, 2, 3]}""")
     }
   }
 
   @Test
-  fun testJsonArrayOperators() {
+  fun testJsonArrayIndexOperators() {
     database.jsonQueries.insertLiteral("""[1,2,3]""", """[1,2,3]""", """{}""", emptyArray<String>())
-    with(database.jsonQueries.selectJsonArrayOperators().executeAsList()) {
+    with(database.jsonQueries.selectJsonArrayIndexOperators().executeAsList()) {
       assertThat(first().expr).isEqualTo("1")
       assertThat(first().expr_).isEqualTo("2")
       assertThat(first().expr__).isEqualTo("3")
+      assertThat(first().expr___).isEqualTo("[1, 3]")
     }
   }
 
@@ -713,6 +715,15 @@ class PostgreSqlTest {
       assertThat(first().expr__).isEqualTo(true)
       assertThat(first().expr___).isEqualTo(true)
       assertThat(first().expr____).isEqualTo(true)
+      assertThat(first().expr_____).isEqualTo(true)
+    }
+  }
+
+  @Test
+  fun testJsonConcatOperators() {
+    database.jsonQueries.insertLiteral("""{}""", """{"a":1}""", """{"b":2}""", emptyArray<String>())
+    with(database.jsonQueries.selectJsonConcatOperators().executeAsList()) {
+      assertThat(first().expr).isEqualTo("""{"a": 1, "b": 2}""")
     }
   }
 }

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -675,17 +675,8 @@ class PostgreSqlTest {
   }
 
   @Test
-  fun testInsertJson() {
-    database.jsonQueries.insert("another key", "another value")
-    with(database.jsonQueries.select().executeAsList()) {
-      assertThat(first().data_).isEqualTo("""{"another key" : "another value"}""")
-      assertThat(first().datab).isEqualTo("""{"key": "value"}""")
-    }
-  }
-
-  @Test
   fun testInsertJsonLiteral() {
-    database.jsonQueries.insertLiteral("""{"key a" : "value a"}""", """{"key b" : "value b"}""")
+    database.jsonQueries.insertLiteral("""{"key a" : "value a"}""", """{"key b" : "value b"}""", """{}""", emptyArray<String>())
     with(database.jsonQueries.select().executeAsList()) {
       assertThat(first().data_).isEqualTo("""{"key a" : "value a"}""")
       assertThat(first().datab).isEqualTo("""{"key b": "value b"}""")
@@ -694,7 +685,7 @@ class PostgreSqlTest {
 
   @Test
   fun testJsonObjectOperators() {
-    database.jsonQueries.insertLiteral("""{"a" : 11,"aa":[1,2,3]}""", """{"b" : 12,"bb":[1,2,3]}""")
+    database.jsonQueries.insertLiteral("""{"a" : 11,"aa":[1,2,3]}""", """{"b" : 12,"bb":[1,2,3]}""", """{}""", emptyArray<String>())
     with(database.jsonQueries.selectJsonObjectOperators().executeAsList()) {
       assertThat(first().expr).isEqualTo("11")
       assertThat(first().expr_).isEqualTo("12")
@@ -705,11 +696,23 @@ class PostgreSqlTest {
 
   @Test
   fun testJsonArrayOperators() {
-    database.jsonQueries.insertLiteral("""[1,2,3]""", """[1,2,3]""")
+    database.jsonQueries.insertLiteral("""[1,2,3]""", """[1,2,3]""", """{}""", emptyArray<String>())
     with(database.jsonQueries.selectJsonArrayOperators().executeAsList()) {
       assertThat(first().expr).isEqualTo("1")
       assertThat(first().expr_).isEqualTo("2")
       assertThat(first().expr__).isEqualTo("3")
+    }
+  }
+
+  @Test
+  fun testJsonBooleanOperators() {
+    database.jsonQueries.insertLiteral("""{}""", """{"a":1, "b":2}""", """{"b":2}""", arrayOf("a", "b"))
+    with(database.jsonQueries.selectJsonBooleanOperators().executeAsList()) {
+      assertThat(first().expr).isEqualTo(true)
+      assertThat(first().expr_).isEqualTo(true)
+      assertThat(first().expr__).isEqualTo(true)
+      assertThat(first().expr___).isEqualTo(true)
+      assertThat(first().expr____).isEqualTo(true)
     }
   }
 }


### PR DESCRIPTION
fixes #5040 

🚧 🍔 based on branch `griffio:fix-5028-postgresql-json` as requires JSON type

Adds Json Path operator to grammar
Adds jsonExpression to return JSON type in resolver
Adds Integration Tests - json functions
Note: `?` '?|' `?&' operators require the Sql statement to use an additional ?` see https://jdbc.postgresql.org/documentation/query/#using-the-statement-or-preparedstatement-interface

`||`, `-` JSON type used with existing operators

Fix json functions to allow Json type binding with `setObjectOther`