### PR TITLE
Use process isolation for gradle workers

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightWorkerTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightWorkerTask.kt
@@ -22,7 +22,7 @@ abstract class SqlDelightWorkerTask : SourceTask() {
   abstract val classpath: ConfigurableFileCollection
 
   internal fun workQueue(): WorkQueue =
-    workerExecutor.classLoaderIsolation {
+    workerExecutor.processIsolation {
       it.classpath.from(classpath)
     }
 }


### PR DESCRIPTION
Closes https://github.com/cashapp/sqldelight/issues/4414

We found that the intermittent errors reported in the issue linked above happen when multiple `generateDatabaseInterface` tasks are run in parallel. Specifically, when reading intellij registry properties from a file, the input stream could be closed by another gradle worker running at the same time. This seems like a good use case for process isolation (https://docs.gradle.org/current/userguide/worker_api.html#creating_a_worker_daemon). Changing to process isolation solves the intermittent failures for our builds.