### PR TITLE
Fixes 4703 aggregate expressions

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -17,8 +17,8 @@ import app.cash.sqldelight.dialects.postgresql.PostgreSqlType.DATE
 import app.cash.sqldelight.dialects.postgresql.PostgreSqlType.SMALL_INT
 import app.cash.sqldelight.dialects.postgresql.PostgreSqlType.TIMESTAMP
 import app.cash.sqldelight.dialects.postgresql.PostgreSqlType.TIMESTAMP_TIMEZONE
+import app.cash.sqldelight.dialects.postgresql.grammar.mixins.AggregateExpressionMixin
 import app.cash.sqldelight.dialects.postgresql.grammar.mixins.WindowFunctionMixin
-import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlArrayAggStmt
 import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlDeleteStmtLimited
 import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlExtensionExpr
 import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlInsertStmt
@@ -243,8 +243,8 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
     }
     is PostgreSqlExtensionExpr -> when {
       arrayAggStmt != null -> {
-        val typeForAgg = ((arrayAggStmt as PostgreSqlArrayAggStmt).children.first() as SqlExpr).postgreSqlType()
-        arrayIntermediateType(typeForAgg)
+        val typeForArray = (arrayAggStmt as AggregateExpressionMixin).expr.postgreSqlType()
+        arrayIntermediateType(typeForArray)
       }
       stringAggStmt != null -> {
         IntermediateType(TEXT)

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -167,6 +167,7 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
     "json_typeof", "jsonb_typeof",
     "json_agg", "jsonb_agg", "json_object_agg", "jsonb_object_agg",
     -> IntermediateType(TEXT)
+    "string_agg" -> IntermediateType(TEXT)
     "json_array_length", "jsonb_array_length" -> IntermediateType(INTEGER)
     "jsonb_path_exists", "jsonb_path_match", "jsonb_path_exists_tz", "jsonb_path_match_tz" -> IntermediateType(BOOLEAN)
     "currval", "lastval", "nextval", "setval" -> IntermediateType(BIG_INT)
@@ -246,6 +247,9 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
       else -> parentResolver.resolvedType(this)
     }
     is PostgreSqlExtensionExpr -> when {
+      stringAggStmt != null -> {
+        IntermediateType(TEXT)
+      }
       windowFunctionExpr != null -> {
         val windowFunctionExpr = windowFunctionExpr as WindowFunctionMixin
         functionType(windowFunctionExpr.functionExpr)!!

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -167,7 +167,6 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
     "json_typeof", "jsonb_typeof",
     "json_agg", "jsonb_agg", "json_object_agg", "jsonb_object_agg",
     -> IntermediateType(TEXT)
-    "string_agg" -> IntermediateType(TEXT)
     "json_array_length", "jsonb_array_length" -> IntermediateType(INTEGER)
     "jsonb_path_exists", "jsonb_path_match", "jsonb_path_exists_tz", "jsonb_path_match_tz" -> IntermediateType(BOOLEAN)
     "currval", "lastval", "nextval", "setval" -> IntermediateType(BIG_INT)

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -46,6 +46,7 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.HAVING"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ID"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.IF"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.IS"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.IGNORE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.INDEX"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.INSERT"
@@ -353,7 +354,7 @@ compound_select_stmt ::= [ {with_clause} ] {select_stmt}  ( {compound_operator} 
   override = true
 }
 
-extension_expr ::= json_expression | boolean_literal | boolean_not_expression | window_function_expr {
+extension_expr ::= json_expression | boolean_literal | boolean_not_expression | window_function_expr | string_agg_stmt {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlExtensionExprImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlExtensionExpr"
   override = true
@@ -441,6 +442,10 @@ truncate_descendant ::= {table_name} ['*'] ( COMMA {table_name} ['*'] ) *
 truncate_option ::= truncate_option_identity | truncate_option_cascade
 truncate_option_identity ::= ( 'RESTART' | 'CONTINUE' ) 'IDENTITY'
 truncate_option_cascade ::=  'CASCADE' | 'RESTRICT'
+
+string_agg_stmt ::= 'string_agg' LP ( ALL | DISTINCT ) <<expr '-1'>> COMMA string_literal [ ORDER BY <<expr '-1'>> ] RP
+[ 'FILTER' LP WHERE <<expr '-1'>> RP ] {
+}
 
 set_stmt ::= 'SET' [ ('SESSION' | 'LOCAL') ] ( set_config | set_timezone | set_schema | set_names | set_seed )
 set_value ::= literal_value | {identifier} | DEFAULT

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -449,7 +449,7 @@ string_agg_stmt ::= 'string_agg' LP [ ALL | DISTINCT ] <<expr '-1'>> COMMA strin
 
 array_agg_stmt ::= 'array_agg' LP [ ALL | DISTINCT ] <<expr '-1'>> ( [ ORDER BY  <<expr '-1'>> ] [ ASC | DESC ] ) RP
 [ 'FILTER' LP WHERE <<expr '-1'>> RP ] {
-implements = "com.alecstrong.sql.psi.core.psi.SqlCompositeElement"
+ mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.AggregateExpressionMixin"
 }
 
 set_stmt ::= 'SET' [ ('SESSION' | 'LOCAL') ] ( set_config | set_timezone | set_schema | set_names | set_seed )

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -354,7 +354,7 @@ compound_select_stmt ::= [ {with_clause} ] {select_stmt}  ( {compound_operator} 
   override = true
 }
 
-extension_expr ::= string_agg_stmt | json_expression | boolean_literal | boolean_not_expression | window_function_expr {
+extension_expr ::= array_agg_stmt| string_agg_stmt | json_expression | boolean_literal | boolean_not_expression | window_function_expr {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlExtensionExprImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlExtensionExpr"
   override = true
@@ -443,8 +443,13 @@ truncate_option ::= truncate_option_identity | truncate_option_cascade
 truncate_option_identity ::= ( 'RESTART' | 'CONTINUE' ) 'IDENTITY'
 truncate_option_cascade ::=  'CASCADE' | 'RESTRICT'
 
-string_agg_stmt ::= 'string_agg' LP ( ALL | DISTINCT ) <<expr '-1'>> COMMA string_literal [ ORDER BY <<expr '-1'>> ] RP
+string_agg_stmt ::= 'string_agg' LP [ ALL | DISTINCT ] <<expr '-1'>> COMMA string_literal ( [ ORDER BY <<expr '-1'>> ] [ ASC | DESC ] ) RP
 [ 'FILTER' LP WHERE <<expr '-1'>> RP ] {
+}
+
+array_agg_stmt ::= 'array_agg' LP [ ALL | DISTINCT ] <<expr '-1'>> ( [ ORDER BY  <<expr '-1'>> ] [ ASC | DESC ] ) RP
+[ 'FILTER' LP WHERE <<expr '-1'>> RP ] {
+implements = "com.alecstrong.sql.psi.core.psi.SqlCompositeElement"
 }
 
 set_stmt ::= 'SET' [ ('SESSION' | 'LOCAL') ] ( set_config | set_timezone | set_schema | set_names | set_seed )

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -354,7 +354,7 @@ compound_select_stmt ::= [ {with_clause} ] {select_stmt}  ( {compound_operator} 
   override = true
 }
 
-extension_expr ::= json_expression | boolean_literal | boolean_not_expression | window_function_expr | string_agg_stmt {
+extension_expr ::= string_agg_stmt | json_expression | boolean_literal | boolean_not_expression | window_function_expr {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlExtensionExprImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlExtensionExpr"
   override = true

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -443,11 +443,11 @@ truncate_option ::= truncate_option_identity | truncate_option_cascade
 truncate_option_identity ::= ( 'RESTART' | 'CONTINUE' ) 'IDENTITY'
 truncate_option_cascade ::=  'CASCADE' | 'RESTRICT'
 
-string_agg_stmt ::= 'string_agg' LP [ ALL | DISTINCT ] <<expr '-1'>> COMMA string_literal ( [ ORDER BY <<expr '-1'>> ] [ ASC | DESC ] ) RP
+string_agg_stmt ::= 'string_agg' LP [ ALL | DISTINCT ] <<expr '-1'>> COMMA string_literal [ ORDER BY {ordering_term} ( COMMA {ordering_term} ) * ] RP
 [ 'FILTER' LP WHERE <<expr '-1'>> RP ] {
 }
 
-array_agg_stmt ::= 'array_agg' LP [ ALL | DISTINCT ] <<expr '-1'>> ( [ ORDER BY  <<expr '-1'>> ] [ ASC | DESC ] ) RP
+array_agg_stmt ::= 'array_agg' LP [ ALL | DISTINCT ] <<expr '-1'>> [ ORDER BY {ordering_term} ( COMMA {ordering_term} ) * ] RP
 [ 'FILTER' LP WHERE <<expr '-1'>> RP ] {
  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.AggregateExpressionMixin"
 }

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/AggregateExpressionMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/AggregateExpressionMixin.kt
@@ -1,0 +1,13 @@
+package app.cash.sqldelight.dialects.postgresql.grammar.mixins
+
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlArrayAggStmt
+import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
+import com.alecstrong.sql.psi.core.psi.SqlExpr
+import com.intellij.lang.ASTNode
+
+internal abstract class AggregateExpressionMixin(
+  node: ASTNode,
+) : SqlCompositeElementImpl(node),
+  PostgreSqlArrayAggStmt {
+  val expr get() = children.filterIsInstance<SqlExpr>().first()
+}

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/aggregate-expressions/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/aggregate-expressions/Test.s
@@ -40,3 +40,9 @@ FROM articles
 LEFT JOIN tags ON articles.id = tags.article_id
 JOIN users ON articles.author_id = users.id
 GROUP BY articles.id, users.id;
+
+SELECT username, string_agg (tag, ',')
+FROM articles
+LEFT JOIN tags ON articles.id = tags.article_id
+JOIN users ON articles.author_id = users.id
+GROUP BY articles.id, users.id;

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/aggregate-expressions/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/aggregate-expressions/Test.s
@@ -1,0 +1,42 @@
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  username TEXT,
+  bio TEXT,
+  image TEXT
+);
+
+CREATE TABLE articles (
+  id INTEGER PRIMARY KEY,
+  slug TEXT,
+  title TEXT,
+  description TEXT,
+  body TEXT,
+  author_id INTEGER REFERENCES users(id),
+  createdAt TIMESTAMP,
+  updatedAt TIMESTAMP
+);
+
+CREATE TABLE tags (
+  id INTEGER PRIMARY KEY,
+  article_id INTEGER REFERENCES articles(id),
+  tag TEXT
+);
+
+SELECT articles.id, slug, title, description, body, users.username, users.bio, users.image, createdAt, updatedAt,
+COALESCE (string_agg (DISTINCT tag, ',' ORDER BY tag) FILTER (WHERE tag IS NOT NULL)) AS articleTags
+FROM articles
+LEFT JOIN tags ON articles.id = tags.article_id
+JOIN users ON articles.author_id = users.id
+GROUP BY articles.id, users.id;
+
+SELECT string_agg (DISTINCT tag, ',') AS articleTags
+FROM articles
+LEFT JOIN tags ON articles.id = tags.article_id
+JOIN users ON articles.author_id = users.id
+GROUP BY articles.id, users.id;
+
+SELECT string_agg (DISTINCT title || ' ' || tag, ',' ) AS articleTags
+FROM articles
+LEFT JOIN tags ON articles.id = tags.article_id
+JOIN users ON articles.author_id = users.id
+GROUP BY articles.id, users.id;

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/aggregate-expressions/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/aggregate-expressions/Test.s
@@ -23,7 +23,7 @@ CREATE TABLE tags (
 );
 
 SELECT articles.id, slug, title, description, body, users.username, users.bio, users.image, createdAt, updatedAt,
-COALESCE (string_agg (DISTINCT tag, ',' ORDER BY tag) FILTER (WHERE tag IS NOT NULL)) AS articleTags
+COALESCE (string_agg (DISTINCT tag, ',' ORDER BY tag DESC) FILTER (WHERE tag IS NOT NULL)) AS articleTags
 FROM articles
 LEFT JOIN tags ON articles.id = tags.article_id
 JOIN users ON articles.author_id = users.id
@@ -42,6 +42,19 @@ JOIN users ON articles.author_id = users.id
 GROUP BY articles.id, users.id;
 
 SELECT username, string_agg (tag, ',')
+FROM articles
+LEFT JOIN tags ON articles.id = tags.article_id
+JOIN users ON articles.author_id = users.id
+GROUP BY articles.id, users.id;
+
+SELECT articles.id, slug, title, description, body, users.username, users.bio, users.image, createdAt, updatedAt,
+COALESCE (array_agg (DISTINCT tag ORDER BY tag) FILTER (WHERE tag IS NOT NULL), '{}') AS articleTags
+FROM articles
+LEFT JOIN tags ON articles.id = tags.article_id
+JOIN users ON articles.author_id = users.id
+GROUP BY articles.id, users.id;
+
+SELECT array_agg (tag ORDER BY tag)
 FROM articles
 LEFT JOIN tags ON articles.id = tags.article_id
 JOIN users ON articles.author_id = users.id

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Dog.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Dog.sq
@@ -86,6 +86,13 @@ FROM dog
 GROUP BY breed
 ORDER BY breed;
 
+selectDogsCoalesceArrayAggName:
+SELECT breed,
+       coalesce(array_agg(name))
+FROM dog
+GROUP BY breed
+ORDER BY breed;
+
 selectDogsArrayAggNameOrderBy:
 SELECT breed,
        array_agg(DISTINCT name ORDER BY name ASC)

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Dog.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Dog.sq
@@ -71,3 +71,10 @@ SELECT breed,
 FROM dog
 GROUP BY breed
 ORDER BY breed;
+
+selectDogsStringAggNameOrderBy:
+SELECT breed,
+       string_agg(DISTINCT name, ',' ORDER BY name)
+FROM dog
+GROUP BY breed
+ORDER BY breed;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Dog.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Dog.sq
@@ -79,6 +79,13 @@ FROM dog
 GROUP BY breed
 ORDER BY breed;
 
+selectDogsArrayAggName:
+SELECT breed,
+       array_agg(name)
+FROM dog
+GROUP BY breed
+ORDER BY breed;
+
 selectDogsArrayAggNameOrderBy:
 SELECT breed,
        array_agg(DISTINCT name ORDER BY name ASC)

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Dog.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Dog.sq
@@ -78,3 +78,17 @@ SELECT breed,
 FROM dog
 GROUP BY breed
 ORDER BY breed;
+
+selectDogsArrayAggNameOrderBy:
+SELECT breed,
+       array_agg(DISTINCT name ORDER BY name ASC)
+FROM dog
+GROUP BY breed
+ORDER BY breed;
+
+selectDogsArrayAggNameOrderByWhereFilter:
+SELECT breed,
+       array_agg(DISTINCT name ORDER BY name DESC) FILTER (WHERE is_good = 1)
+FROM dog
+GROUP BY breed
+ORDER BY breed;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -286,6 +286,19 @@ class PostgreSqlTest {
     }
   }
 
+  @Test fun testStringAggOrderBy() {
+    database.dogQueries.insertDog("Tilda", "Pomeranian")
+    database.dogQueries.insertDog("Bruno", "Pomeranian")
+    database.dogQueries.insertDog("Mads", "Broholmer")
+
+    database.dogQueries.selectDogsStringAggNameOrderBy().executeAsList().let {
+      assertThat(it).containsExactly(
+        SelectDogsStringAggNameOrderBy("Broholmer", "Mads"),
+        SelectDogsStringAggNameOrderBy("Pomeranian", "Bruno,Tilda"),
+      )
+    }
+  }
+
   @Test fun testSerial() {
     database.run {
       oneEntityQueries.transaction {

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -315,6 +315,22 @@ class PostgreSqlTest {
     }
   }
 
+  @Test fun testCoalesceArrayAgg() {
+    database.dogQueries.insertDog("Tilda", "Pomeranian")
+    database.dogQueries.insertDog("Bruno", "Pomeranian")
+    database.dogQueries.insertDog("Mads", "Broholmer")
+
+    database.dogQueries.selectDogsCoalesceArrayAggName().executeAsList().zip(
+      listOf(
+        SelectDogsCoalesceArrayAggName("Broholmer", arrayOf("Mads")),
+        SelectDogsCoalesceArrayAggName("Pomeranian", arrayOf("Tilda", "Bruno")),
+      ),
+    ).forEach { dog ->
+      assertThat(dog.first.breed).isEqualTo(dog.second.breed)
+      assertThat(dog.first.coalesce).isEqualTo(dog.second.coalesce) // isEqualTo works with Array equality
+    }
+  }
+
   @Test fun testArrayAggOrderBy() {
     database.dogQueries.insertDog("Tilda", "Pomeranian")
     database.dogQueries.insertDog("Bruno", "Pomeranian")

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -299,6 +299,22 @@ class PostgreSqlTest {
     }
   }
 
+  @Test fun testArrayAgg() {
+    database.dogQueries.insertDog("Tilda", "Pomeranian")
+    database.dogQueries.insertDog("Bruno", "Pomeranian")
+    database.dogQueries.insertDog("Mads", "Broholmer")
+
+    database.dogQueries.selectDogsArrayAggName().executeAsList().zip(
+      listOf(
+        SelectDogsArrayAggName("Broholmer", arrayOf("Mads")),
+        SelectDogsArrayAggName("Pomeranian", arrayOf("Tilda", "Bruno")),
+      ),
+    ).forEach { dog ->
+      assertThat(dog.first.breed).isEqualTo(dog.second.breed)
+      assertThat(dog.first.expr).isEqualTo(dog.second.expr) // isEqualTo works with Array equality
+    }
+  }
+
   @Test fun testArrayAggOrderBy() {
     database.dogQueries.insertDog("Tilda", "Pomeranian")
     database.dogQueries.insertDog("Bruno", "Pomeranian")
@@ -308,6 +324,22 @@ class PostgreSqlTest {
       listOf(
         SelectDogsArrayAggNameOrderBy("Broholmer", arrayOf("Mads")),
         SelectDogsArrayAggNameOrderBy("Pomeranian", arrayOf("Bruno", "Tilda")),
+      ),
+    ).forEach { dog ->
+      assertThat(dog.first.breed).isEqualTo(dog.second.breed)
+      assertThat(dog.first.expr).isEqualTo(dog.second.expr) // isEqualTo works with Array equality
+    }
+  }
+
+  @Test fun testArrayAggOrderByWhereFilter() {
+    database.dogQueries.insertDog("Tilda", "Pomeranian")
+    database.dogQueries.insertDog("Bruno", "Pomeranian")
+    database.dogQueries.insertDog("Mads", "Broholmer")
+
+    database.dogQueries.selectDogsArrayAggNameOrderByWhereFilter().executeAsList().zip(
+      listOf(
+        SelectDogsArrayAggNameOrderByWhereFilter("Broholmer", arrayOf("Mads")),
+        SelectDogsArrayAggNameOrderByWhereFilter("Pomeranian", arrayOf("Tilda", "Bruno")),
       ),
     ).forEach { dog ->
       assertThat(dog.first.breed).isEqualTo(dog.second.breed)

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -299,6 +299,22 @@ class PostgreSqlTest {
     }
   }
 
+  @Test fun testArrayAggOrderBy() {
+    database.dogQueries.insertDog("Tilda", "Pomeranian")
+    database.dogQueries.insertDog("Bruno", "Pomeranian")
+    database.dogQueries.insertDog("Mads", "Broholmer")
+
+    database.dogQueries.selectDogsArrayAggNameOrderBy().executeAsList().zip(
+      listOf(
+        SelectDogsArrayAggNameOrderBy("Broholmer", arrayOf("Mads")),
+        SelectDogsArrayAggNameOrderBy("Pomeranian", arrayOf("Bruno", "Tilda")),
+      ),
+    ).forEach { dog ->
+      assertThat(dog.first.breed).isEqualTo(dog.second.breed)
+      assertThat(dog.first.expr).isEqualTo(dog.second.expr) // isEqualTo works with Array equality
+    }
+  }
+
   @Test fun testSerial() {
     database.run {
       oneEntityQueries.transaction {


### PR DESCRIPTION
🚧 🍔 
fixes #4703 

Supports `string_agg` - function requires a `separator` argument with optional `ORDER BY`
See fixture tests for variations
``` sql
SELECT articles.id, slug, title, description,
COALESCE (string_agg (DISTINCT tag, ',' ORDER BY tag DESC) 
FILTER (WHERE tag IS NOT NULL)) AS articleTags
FROM articles
LEFT JOIN tags ON articles.id = tags.article_id
JOIN users ON articles.author_id = users.id
GROUP BY articles.id, users.id;
```
Keep existing function `string_agg` for the simple use and new grammar for complex cases

Supports `array_agg` and single parameter use-case. Returns `kotlin.Array<T>`

``` sql
SELECT breed,
array_agg(DISTINCT name ORDER BY name DESC) FILTER (WHERE is_good = 1)
FROM dog
GROUP BY breed
ORDER BY breed;
```

Adds Integration tests
 * Including Array types in data classes means equality checks won't work for structural equals

Work-arounds ➰ :
* Resolve the Expr for array_agg in PostgreSqlTypeResolver
* `coalesce`, `nullif` function needs to support array type