### PR TITLE
Increase Android minSDK to 21

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ paging3 = "3.1.1"
 ktlint = "1.2.1"
 agp = "8.3.1"
 compileSdk = "34"
-minSdk = "16"
+minSdk = "21"
 sqlPsi = "0.4.8"
 testContainers = "1.19.7"
 


### PR DESCRIPTION
Technically, we don't need to increase the minSDK, but the Play Store requires 21 since August 2023 and Jetpack Compose requires 21 too. So I don't see a reason to keep this low level. 

Any thoughts?

[(Theoretically with api 21 the min sqlite version increased from 3.7 to 3.8 but this has no real effect for us because there is no <3.7 dialect.)](https://developer.android.com/reference/android/database/sqlite/package-summary)

See also https://apilevels.com