### PR TITLE
Fixes json operator binding for 5040

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -372,7 +372,7 @@ boolean_not_expression ::= NOT (boolean_literal | {column_name})
 
 boolean_literal ::= TRUE | FALSE
 
-json_expression ::= {column_name} ( jsona_binary_operator | jsonb_binary_operator | jsonb_boolean_operator ) <<expr '-1'>> {
+json_expression ::= {column_expr} ( jsona_binary_operator | jsonb_binary_operator | jsonb_boolean_operator ) <<expr '-1'>> {
   mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.JsonExpressionMixin"
   pin = 2
 }

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/JsonExpressionMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/JsonExpressionMixin.kt
@@ -2,22 +2,29 @@ package app.cash.sqldelight.dialects.postgresql.grammar.mixins
 
 import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlJsonExpression
 import com.alecstrong.sql.psi.core.SqlAnnotationHolder
+import com.alecstrong.sql.psi.core.psi.SqlBinaryExpr
 import com.alecstrong.sql.psi.core.psi.SqlColumnDef
 import com.alecstrong.sql.psi.core.psi.SqlColumnName
 import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
+import com.alecstrong.sql.psi.core.psi.SqlExpr
 import com.intellij.lang.ASTNode
 
 internal abstract class JsonExpressionMixin(node: ASTNode) :
   SqlCompositeElementImpl(node),
+  SqlBinaryExpr,
   PostgreSqlJsonExpression {
   override fun annotate(annotationHolder: SqlAnnotationHolder) {
-    val columnType = ((firstChild.reference?.resolve() as? SqlColumnName)?.parent as? SqlColumnDef)?.columnType?.typeName?.text
+    val columnType = ((firstChild.firstChild.reference?.resolve() as? SqlColumnName)?.parent as? SqlColumnDef)?.columnType?.typeName?.text
     if (columnType == null || columnType !in arrayOf("JSON", "JSONB")) {
-      annotationHolder.createErrorAnnotation(firstChild, "Left side of json expression must be a json column.")
+      annotationHolder.createErrorAnnotation(firstChild.firstChild, "Left side of json expression must be a json column.")
     }
     if ((jsonbBinaryOperator != null || jsonbBooleanOperator != null) && columnType != "JSONB") {
-      annotationHolder.createErrorAnnotation(firstChild, "Left side of jsonb expression must be a jsonb column.")
+      annotationHolder.createErrorAnnotation(firstChild.firstChild, "Left side of jsonb expression must be a jsonb column.")
     }
     super.annotate(annotationHolder)
+  }
+
+  override fun getExprList(): List<SqlExpr> {
+    return children.filterIsInstance<SqlExpr>()
   }
 }

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Json.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Json.sq
@@ -41,3 +41,18 @@ FROM TestJson;
 selectJsonPretty:
 SELECT jsonb_pretty(datab)
 FROM TestJson;
+
+selectJsonbPath:
+SELECT *
+FROM TestJson
+WHERE datab @> ?;
+
+selectJsonPathEquals:
+SELECT *
+FROM TestJson
+WHERE data ->> 'a' = ? AND datab ->> 'b' = ?;
+
+selectJsonbContains:
+SELECT *
+FROM TestJson
+WHERE datab ?? ?;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -757,4 +757,29 @@ class PostgreSqlTest {
       assertThat(first()).isEqualTo("""[{"a": 123}, {"b": 2}]""")
     }
   }
+
+  @Test
+  fun testSelectJsonbPath() {
+    database.jsonQueries.insertLiteral("""{}""", """[{"a":1},{"b":2}]""", """{}""", emptyArray<String>())
+    with(database.jsonQueries.selectJsonbPath("""[{"a":1}]""").executeAsList()) {
+      assertThat(first().datab).isEqualTo("""[{"a": 1}, {"b": 2}]""")
+    }
+  }
+
+  @Test
+  fun testSelectJsonPathEquality() {
+    database.jsonQueries.insertLiteral("""{"a": 1}""", """{"b":2}""", """{}""", emptyArray<String>())
+    with(database.jsonQueries.selectJsonPathEquals("1", "2").executeAsList()) {
+      assertThat(first().data_).isEqualTo("""{"a": 1}""")
+      assertThat(first().datab).isEqualTo("""{"b": 2}""")
+    }
+  }
+
+  @Test
+  fun testSelectJsonbContains() {
+    database.jsonQueries.insertLiteral("""{}""", """{"b":2}""", """{}""", emptyArray<String>())
+    with(database.jsonQueries.selectJsonbContains("b").executeAsList()) {
+      assertThat(first().datab).isEqualTo("""{"b": 2}""")
+    }
+  }
 }


### PR DESCRIPTION
📟  Follow up from PR https://github.com/cashapp/sqldelight/pull/5041

Added the binary operator expressions support
Added Integration tests for binary operator binding

e.g 
```sql

SELECT *
FROM TestJson
WHERE datab @> ?;

```
👐  This required making the json expression use a column expression with the json operator so that a sql expression is evaluated