### PR TITLE
Update server migrations doc

### DIFF
--- a/docs/common/migrations_server.md
+++ b/docs/common/migrations_server.md
@@ -8,7 +8,7 @@ services to read from:
 sqldelight {
   databases {
     Database {
-      migrationOutputDirectory = file("$buildDir/resources/main/migrations")
+      migrationOutputDirectory = layout.buildDirectory.dir("resources/main/migrations")
       migrationOutputFileFormat = ".sql" // Defaults to .sql
   }
 }


### PR DESCRIPTION
The example `migrationOutputDirectory` configuration in `migrations_server.md` is using `Project.getBuildDir()`, which was [deprecated in Gradle 8.3](https://github.com/gradle/gradle/issues/20210).

This PR updates that example to use the recommended `ProjectLayout.getBuildDirectory()` method instead. Note: `getBuildDirectory()` was introduced in Gradle 4.1.