### PR TITLE
Update deprecated usage of Project.getBuildDir() in gradle plugin build file

### DIFF
--- a/sqldelight-gradle-plugin/src/test/schema-output/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/schema-output/build.gradle
@@ -8,7 +8,7 @@ sqldelight {
     MyDatabase {
       packageName = "app.cash.sqldelight.mysql.integration"
       dialect("app.cash.sqldelight:mysql-dialect:${app.cash.sqldelight.VersionKt.VERSION}")
-      migrationOutputDirectory = file("build/resources/migrations")
+      migrationOutputDirectory = layout.buildDirectory.dir("resources/migrations")
       migrationOutputFileFormat = ".sql"
     }
   }


### PR DESCRIPTION
Follow up to #5117 

---

The `migrationOutputDirectory` configuration in the gradle plugin's build file is using `Project.getBuildDir()`, which was [deprecated in Gradle 8.3](https://github.com/gradle/gradle/issues/20210).

This PR updates that to use the recommended `ProjectLayout.getBuildDirectory()` method instead. Note: `getBuildDirectory()` was introduced in Gradle 4.1.