### PR TITLE
Fixes 5059 add brin gist

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -169,16 +169,19 @@ table_constraint ::= [ CONSTRAINT {identifier} ] (
   override = true
 }
 
-gin_operator_class_stmt ::= 'array_ops' | 'jsonb_ops' | 'jsonb_path_ops' | 'tsvector_ops'
+operator_class_stmt ::= {identifier} [ LP {identifier} EQ ( {identifier} | {numeric_literal} ) { RP ]
+storage_parameter ::= TRUE | FALSE | 'ON' | 'OFF' | {identifier} | {numeric_literal}
+storage_parameters ::= 'autosummarize' | 'buffering' | 'deduplicate_items' | 'fastupdate' | 'fillfactor' | 'gin_pending_list_limit' | 'pages_per_range'
+with_storage_parameter ::= WITH LP storage_parameters EQ ( storage_parameter ) ( COMMA storage_parameters EQ ( storage_parameter ) ) * RP
+index_method ::=  'BRIN' | 'BTREE' | 'GIN' | 'GIST' | 'HASH'
 
 create_index_stmt ::= CREATE [ UNIQUE ] INDEX [ 'CONCURRENTLY' ] [ IF NOT EXISTS ] [ {database_name} DOT ] {index_name} ON {table_name}
- ( USING 'GIN' LP {indexed_column} [ gin_operator_class_stmt ] ( COMMA {indexed_column} [ gin_operator_class_stmt ] ) * RP | LP {indexed_column} ( COMMA {indexed_column} ) * RP [ WHERE <<expr '-1'>> ] ) {
+ ( USING index_method LP {indexed_column} [ operator_class_stmt ] ( COMMA {indexed_column} [ operator_class_stmt ] ) * RP [ with_storage_parameter ] | LP {indexed_column} [ operator_class_stmt ] ( COMMA {indexed_column} [ operator_class_stmt ] ) * RP [ WHERE <<expr '-1'>> ] )  {
+  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.CreateIndexMixin"
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlCreateIndexStmtImpl"
-  implements = "com.alecstrong.sql.psi.core.psi.SqlGeneratedClause"
   override = true
   pin = 6
 }
-
 
 identity_clause ::= 'IDENTITY' [ LP [ 'SEQUENCE' 'NAME' sequence_name ] [ sequence_parameters* ] RP ]
 

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/CreateIndexMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/CreateIndexMixin.kt
@@ -27,32 +27,24 @@ internal abstract class CreateIndexMixin(node: ASTNode) :
               "pages_per_range" -> pagesPerRange(sp.second, annotationHolder)
               else -> unrecongizedParameter(sp.first, annotationHolder)
             }
-            "btree" -> {
-              when (sp.first.text) {
-                "fillfactor" -> fillFactor(sp.second, annotationHolder)
-                "deduplicate_items" -> deduplicateItems(sp.second, annotationHolder)
-                else -> unrecongizedParameter(sp.first, annotationHolder)
-              }
+            "btree" -> when (sp.first.text) {
+              "fillfactor" -> fillFactor(sp.second, annotationHolder)
+              "deduplicate_items" -> deduplicateItems(sp.second, annotationHolder)
+              else -> unrecongizedParameter(sp.first, annotationHolder)
             }
-            "gin" -> {
-              when (sp.first.text) {
-                "fastupdate" -> fastUpdate(sp.second, annotationHolder)
-                "gin_pending_list_limit" -> ginPendingListLimit(sp.second, annotationHolder)
-                else -> unrecongizedParameter(sp.first, annotationHolder)
-              }
+            "gin" -> when (sp.first.text) {
+              "fastupdate" -> fastUpdate(sp.second, annotationHolder)
+              "gin_pending_list_limit" -> ginPendingListLimit(sp.second, annotationHolder)
+              else -> unrecongizedParameter(sp.first, annotationHolder)
             }
-            "gist" -> {
-              when (sp.first.text) {
-                "fillfactor" -> fillFactor(sp.second, annotationHolder)
-                "buffering" -> buffering(sp.second, annotationHolder)
-                else -> unrecongizedParameter(sp.first, annotationHolder)
-              }
+            "gist" -> when (sp.first.text) {
+              "fillfactor" -> fillFactor(sp.second, annotationHolder)
+              "buffering" -> buffering(sp.second, annotationHolder)
+              else -> unrecongizedParameter(sp.first, annotationHolder)
             }
-            "hash" -> {
-              when (sp.first.text) {
-                "fillfactor" -> fillFactor(sp.second, annotationHolder)
-                else -> unrecongizedParameter(sp.first, annotationHolder)
-              }
+            "hash" -> when (sp.first.text) {
+              "fillfactor" -> fillFactor(sp.second, annotationHolder)
+              else -> unrecongizedParameter(sp.first, annotationHolder)
             }
           }
         }

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/CreateIndexMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/CreateIndexMixin.kt
@@ -1,0 +1,154 @@
+package app.cash.sqldelight.dialects.postgresql.grammar.mixins
+
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlCreateIndexStmt
+import com.alecstrong.sql.psi.core.SqlAnnotationHolder
+import com.alecstrong.sql.psi.core.psi.impl.SqlCreateIndexStmtImpl
+import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
+/**
+ * Storage parameter list 'autosummarize' | 'buffering' | 'deduplicate_items' | 'fastupdate' | 'fillfactor' | 'gin_pending_list_limit' | 'pages_per_range'
+ * btree, hash, gist = [fillfactor (10-100) ]
+ * btree = [deduplicate_items (0|1|on|off|true|false)]
+ * gist = [buffering (auto|on|off)]
+ * gin = [fastupdate (on|off|true|false), gin_pending_list_limit (64-2147483647) ]
+ * brin = [autosummarize (on|off|true|false), pages_per_range (1-2147483647) ]
+ */
+internal abstract class CreateIndexMixin(node: ASTNode) :
+  SqlCreateIndexStmtImpl(node), PostgreSqlCreateIndexStmt {
+
+  override fun annotate(annotationHolder: SqlAnnotationHolder) {
+    withStorageParameter?.let { wsp ->
+      wsp.storageParametersList.zip(wsp.storageParameterList).forEach {
+          sp ->
+        indexMethod?.let { im ->
+          when (im.text.lowercase()) {
+            "brin" -> when (sp.first.text) {
+              "autosummarize" -> autoSummarize(sp.second, annotationHolder)
+              "pages_per_range" -> pagesPerRange(sp.second, annotationHolder)
+              else -> unrecongizedParameter(sp.first, annotationHolder)
+            }
+            "btree" -> {
+              when (sp.first.text) {
+                "fillfactor" -> fillFactor(sp.second, annotationHolder)
+                "deduplicate_items" -> deduplicateItems(sp.second, annotationHolder)
+                else -> unrecongizedParameter(sp.first, annotationHolder)
+              }
+            }
+            "gin" -> {
+              when (sp.first.text) {
+                "fastupdate" -> fastUpdate(sp.second, annotationHolder)
+                "gin_pending_list_limit" -> ginPendingListLimit(sp.second, annotationHolder)
+                else -> unrecongizedParameter(sp.first, annotationHolder)
+              }
+            }
+            "gist" -> {
+              when (sp.first.text) {
+                "fillfactor" -> fillFactor(sp.second, annotationHolder)
+                "buffering" -> buffering(sp.second, annotationHolder)
+                else -> unrecongizedParameter(sp.first, annotationHolder)
+              }
+            }
+            "hash" -> {
+              when (sp.first.text) {
+                "fillfactor" -> fillFactor(sp.second, annotationHolder)
+                else -> unrecongizedParameter(sp.first, annotationHolder)
+              }
+            }
+          }
+        }
+      }
+    }
+    super.annotate(annotationHolder)
+  }
+
+  companion object {
+
+    private val pgBooleans = listOf("1", "0", "on", "off", "true", "false")
+
+    fun autoSummarize(input: PsiElement, annotationHolder: SqlAnnotationHolder) {
+      input.text.let { value ->
+        if (value.lowercase() !in pgBooleans) {
+          annotationHolder.createErrorAnnotation(
+            input,
+            """invalid value for boolean option "autosummarize" $value""",
+          )
+        }
+      }
+    }
+
+    fun buffering(input: PsiElement, annotationHolder: SqlAnnotationHolder) {
+      input.text.let { value ->
+        if (value.lowercase() !in listOf("auto", "on", "off")) {
+          annotationHolder.createErrorAnnotation(
+            input,
+            """invalid value for enum option "buffering" $value""",
+          )
+        }
+      }
+    }
+
+    fun deduplicateItems(input: PsiElement, annotationHolder: SqlAnnotationHolder) {
+      input.text.let { value ->
+        if (value.lowercase() !in pgBooleans) {
+          annotationHolder.createErrorAnnotation(
+            input,
+            """invalid value for boolean option "deduplicate_items" $value""",
+          )
+        }
+      }
+    }
+
+    fun fastUpdate(input: PsiElement, annotationHolder: SqlAnnotationHolder) {
+      input.text.let { value ->
+        if (value.lowercase() !in pgBooleans) {
+          annotationHolder.createErrorAnnotation(
+            input,
+            """invalid value for boolean option "fastupdate" $value""",
+          )
+        }
+      }
+    }
+
+    fun fillFactor(input: PsiElement, annotationHolder: SqlAnnotationHolder) {
+      input.text.toInt().let { value ->
+        if (value !in 10..100) {
+          annotationHolder.createErrorAnnotation(
+            input,
+            """value $value out of bounds for option "fillfactor"""",
+          )
+        }
+      }
+    }
+
+    fun ginPendingListLimit(input: PsiElement, annotationHolder: SqlAnnotationHolder) {
+      input.text.toInt().let { value ->
+        if (value !in 64..Int.MAX_VALUE) {
+          annotationHolder.createErrorAnnotation(
+            input,
+            """value $value out of bounds for option "gin_pending_list_limit"""",
+          )
+        }
+      }
+    }
+
+    fun pagesPerRange(input: PsiElement, annotationHolder: SqlAnnotationHolder) {
+      input.text.toInt().let { value ->
+        if (value !in 1..Int.MAX_VALUE) {
+          annotationHolder.createErrorAnnotation(
+            input,
+            """value $value out of bounds for option "pages_per_range"""",
+          )
+        }
+      }
+    }
+
+    fun unrecongizedParameter(input: PsiElement, annotationHolder: SqlAnnotationHolder) {
+      input.text.let { parameter ->
+        annotationHolder.createErrorAnnotation(
+          input,
+          """unrecognized parameter "$parameter"""",
+        )
+      }
+    }
+  }
+}

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/create-index/Sample.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/create-index/Sample.s
@@ -7,14 +7,56 @@ CREATE TABLE abg (
 
 CREATE INDEX CONCURRENTLY beta_gamma_idx ON abg (beta, gamma);
 
+CREATE INDEX gamma_index_name ON abg (gamma) WHERE beta = 'some_value';
+
+CREATE INDEX alpha_index_name ON abg USING BTREE (alpha) WITH (fillfactor = 70, deduplicate_items = on);
+
+CREATE INDEX beta_gamma_index_name ON abg USING HASH (beta) WITH (fillfactor = 20);
+-- error[col 87]: invalid value for boolean option "deduplicate_items" yes
+CREATE INDEX alpha_index_name_err ON abg USING BTREE (alpha) WITH (deduplicate_items = yes);
+-- error[col 83]: value 1 out of bounds for option "fillfactor"
+CREATE INDEX beta_gamma_index_name_err ON abg USING HASH (beta) WITH (fillfactor = 1);
+-- error[col 76]:  unrecognized parameter "autosummarize"
+CREATE INDEX beta_gamma_index_name_err_param ON abg USING HASH (beta) WITH (autosummarize = off);
 
 CREATE TABLE json_gin(
   alpha JSONB,
   beta JSONB
 );
 
+CREATE TABLE json_gist(
+  alpha JSONB,
+  beta JSONB
+);
+
+CREATE TABLE text_search(
+  alpha TSVECTOR,
+  beta TEXT
+);
+
 CREATE INDEX gin_alpha_1 ON json_gin USING GIN (alpha);
 CREATE INDEX gin_alpha_beta_2 ON json_gin USING GIN (alpha, beta);
 CREATE INDEX gin_alpha_beta_3 ON json_gin USING GIN (alpha jsonb_ops, beta);
-CREATE INDEX gin_alpha_beta_4 ON json_gin USING GIN (alpha, beta jsonb_path_ops);
-CREATE INDEX gin_alpha_beta_5 ON json_gin USING GIN (alpha jsonb_path_ops, beta jsonb_ops);
+CREATE INDEX gin_alpha_beta_4 ON json_gin USING GIN (alpha, beta jsonb_path_ops) WITH (fastupdate = off);
+CREATE INDEX gin_alpha_beta_5 ON json_gin USING GIN (alpha jsonb_path_ops, beta jsonb_ops) WITH (gin_pending_list_limit = 2048);
+
+CREATE INDEX gist_alpha_1 ON text_search USING GIST (alpha) WITH (fillfactor = 75);
+CREATE INDEX gist_alpha_2 ON text_search USING GIST (alpha) WITH (buffering = on);
+
+CREATE INDEX tsv_gist_alpha_1 ON text_search USING GIST (alpha);
+CREATE INDEX tsv_gin_alpha_1 ON text_search USING GIN (alpha);
+CREATE INDEX trgm_gist_beta_1 ON text_search USING GIST (beta gist_trgm_ops(siglen=32));
+CREATE INDEX trgm_gist_beta_2 ON text_search USING GIN (beta gin_trgm_ops);
+
+CREATE INDEX beta_index ON text_search (beta varchar_pattern_ops);
+
+CREATE INDEX ts_brin_beta_1 ON text_search USING BRIN (beta) WITH (autosummarize = on, pages_per_range = 6);
+
+-- error[col 128]: value 1 out of bounds for option "gin_pending_list_limit"
+CREATE INDEX gin_alpha_beta_error_1 ON json_gin USING GIN (alpha jsonb_path_ops, beta jsonb_ops) WITH (gin_pending_list_limit = 1);
+-- error[col 106]: invalid value for boolean option "fastupdate" yes
+CREATE INDEX gin_alpha_beta_error_2 ON json_gin USING GIN (alpha, beta jsonb_path_ops) WITH (fastupdate = yes);
+-- error[col 91]:  value 0 out of bounds for option "pages_per_range"
+CREATE INDEX ts_brin_beta_error_1 ON text_search USING BRIN (beta) WITH (pages_per_range = 0);
+-- error[col 87]: invalid value for boolean option "autosummarize" no
+CREATE INDEX ts_brin_beta_error_2 ON text_search USING BRIN (beta) WITH (autosummarize=no);


### PR DESCRIPTION
fixes #5059

* Updated `CREATE INDEX` to support operator classes e.g `jsonb_path_ops`, storage parameters e.g `gin_pending_list_limit` and index methods for `BRIN`, `BTREE`,  `GIN`, `GIST`, `HASH`

* Added integration tests for index methods and storage parameters

There are many op classes and it may not be possible to validate them, extra ones are added by extensions, and the data types they support

The optional WITH clause specifies storage parameters for the index. Each index method has its own set of allowed storage parameters.  https://www.postgresql.org/docs/16/sql-createindex.html#SQL-CREATEINDEX-STORAGE-PARAMETERS

Index storage parameters **are** possible to validate, along with the arguments

```
'autosummarize' | 'buffering' | 'deduplicate_items' | 'fastupdate' | 'fillfactor' | 'gin_pending_list_limit' | 'pages_per_range'
```

e.g 
```sql
CREATE INDEX gin_alpha ON json_gin USING GIN (alpha jsonb_path_ops) WITH (gin_pending_list_limit = 2048);
```

Added `CreateIndexMixin` to annotate errors with storage parameters 
Updated fixtures with different index methods and invalid options 

📔 `ALTER INDEX` is not currently implemented in any grammar as is non-standard (as sqlite doesn't support `ALTER INDEX`) 
   - https://www.postgresql.org/docs/current/sql-alterindex.html
   - SET ( storage_parameter [= value] [, ... ] )
   - RESET ( storage_parameter [, ... ] ) 

Currently `DROP INDEX` must be used instead