### PR TITLE
Fix local Gradle execution without a BuildScan

### DIFF
--- a/sample-web/settings.gradle
+++ b/sample-web/settings.gradle
@@ -26,7 +26,7 @@ develocity {
     termsOfUseUrl = 'https://gradle.com/terms-of-service'
     termsOfUseAgree = 'yes'
     publishing {
-      onlyIf { System.getenv("CI") }
+      onlyIf { System.getenv("CI") != null }
     }
     tag "CI"
   }

--- a/sample/settings.gradle
+++ b/sample/settings.gradle
@@ -26,7 +26,7 @@ develocity {
     termsOfUseUrl = 'https://gradle.com/terms-of-service'
     termsOfUseAgree = 'yes'
     publishing {
-      onlyIf { System.getenv("CI") }
+      onlyIf { System.getenv("CI") != null }
     }
     tag "CI"
   }

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,7 +18,7 @@ develocity {
     termsOfUseUrl = 'https://gradle.com/terms-of-service'
     termsOfUseAgree = 'yes'
     publishing {
-      onlyIf { System.getenv("CI") }
+      onlyIf { System.getenv("CI") != null }
     }
     tag "CI"
   }


### PR DESCRIPTION
Otherwise we get this warning due the changed api.
```
WARNING: Error invoking build scan publishingCondition action
        Cannot invoke "java.lang.Boolean.booleanValue()" because the return value of "java.lang.reflect.InvocationHandler.invoke(Object, java.lang.reflect.Method, Object[])" is null
```