### PR TITLE
Add 5137 PostgreSql Regex operators

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -275,7 +275,7 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
           IntermediateType(PostgreSqlType.JSON)
         }
       }
-      matchOperatorExpression != null -> {
+      matchOperatorExpression != null || regexMatchOperatorExpression != null -> {
         IntermediateType(BOOLEAN)
       }
       else -> parentResolver.resolvedType(this)

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -361,7 +361,7 @@ compound_select_stmt ::= [ {with_clause} ] {select_stmt}  ( {compound_operator} 
   override = true
 }
 
-extension_expr ::= match_operator_expression | array_agg_stmt| string_agg_stmt | json_expression | boolean_literal | boolean_not_expression | window_function_expr {
+extension_expr ::= regex_match_operator_expression | match_operator_expression | array_agg_stmt| string_agg_stmt | json_expression | boolean_literal | boolean_not_expression | window_function_expr {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlExtensionExprImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlExtensionExpr"
   override = true
@@ -386,6 +386,13 @@ match_operator ::= '@@'
 
 match_operator_expression ::= ( {function_expr} | {column_expr} ) match_operator <<expr '-1'>> {
   mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.MatchOperatorExpressionMixin"
+  pin = 2
+}
+
+regex_match_operator ::= '~*' | '~' | '!~*' | '!~'
+
+regex_match_operator_expression ::= ( {function_expr} | {column_expr} ) regex_match_operator <<expr '-1'>> {
+  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.RegExMatchOperatorExpressionMixin"
   pin = 2
 }
 

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/RegExMatchOperatorExpressionMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/RegExMatchOperatorExpressionMixin.kt
@@ -1,0 +1,31 @@
+package app.cash.sqldelight.dialects.postgresql.grammar.mixins
+
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlRegexMatchOperatorExpression
+import com.alecstrong.sql.psi.core.SqlAnnotationHolder
+import com.alecstrong.sql.psi.core.psi.SqlBinaryExpr
+import com.alecstrong.sql.psi.core.psi.SqlColumnDef
+import com.alecstrong.sql.psi.core.psi.SqlColumnName
+import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
+import com.alecstrong.sql.psi.core.psi.SqlExpr
+import com.intellij.lang.ASTNode
+
+/**
+ * Regular expression operators provide a more powerful means for pattern matching than the LIKE and SIMILAR TO operators.
+ */
+internal abstract class RegExMatchOperatorExpressionMixin(node: ASTNode) :
+  SqlCompositeElementImpl(node),
+  SqlBinaryExpr,
+  PostgreSqlRegexMatchOperatorExpression {
+
+  override fun annotate(annotationHolder: SqlAnnotationHolder) {
+    val columnType = ((firstChild.firstChild.reference?.resolve() as? SqlColumnName)?.parent as? SqlColumnDef)?.columnType?.typeName?.text
+    when {
+      columnType == null -> super.annotate(annotationHolder)
+      columnType != "TEXT" -> annotationHolder.createErrorAnnotation(firstChild.firstChild, """operator does not exist: $columnType ${regexMatchOperator.text} unknown""")
+    }
+    super.annotate(annotationHolder)
+  }
+  override fun getExprList(): List<SqlExpr> {
+    return children.filterIsInstance<SqlExpr>()
+  }
+}

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/RegExMatchOperatorExpressionMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/RegExMatchOperatorExpressionMixin.kt
@@ -1,6 +1,7 @@
 package app.cash.sqldelight.dialects.postgresql.grammar.mixins
 
 import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlRegexMatchOperatorExpression
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlTypeName
 import com.alecstrong.sql.psi.core.SqlAnnotationHolder
 import com.alecstrong.sql.psi.core.psi.SqlBinaryExpr
 import com.alecstrong.sql.psi.core.psi.SqlColumnDef
@@ -8,7 +9,6 @@ import com.alecstrong.sql.psi.core.psi.SqlColumnName
 import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
 import com.alecstrong.sql.psi.core.psi.SqlExpr
 import com.intellij.lang.ASTNode
-
 /**
  * Regular expression operators provide a more powerful means for pattern matching than the LIKE and SIMILAR TO operators.
  */
@@ -18,14 +18,22 @@ internal abstract class RegExMatchOperatorExpressionMixin(node: ASTNode) :
   PostgreSqlRegexMatchOperatorExpression {
 
   override fun annotate(annotationHolder: SqlAnnotationHolder) {
-    val columnType = ((firstChild.firstChild.reference?.resolve() as? SqlColumnName)?.parent as? SqlColumnDef)?.columnType?.typeName?.text
-    when {
-      columnType == null -> super.annotate(annotationHolder)
-      columnType != "TEXT" -> annotationHolder.createErrorAnnotation(firstChild.firstChild, """operator does not exist: $columnType ${regexMatchOperator.text} unknown""")
+    ((firstChild.firstChild.reference?.resolve() as? SqlColumnName)?.parent as? SqlColumnDef)?.isStringDataType()?.let { isText ->
+      if (!isText) {
+        annotationHolder.createErrorAnnotation(
+          firstChild.firstChild,
+          """operator ${regexMatchOperator.text} can only be performed on text""",
+        )
+      }
     }
     super.annotate(annotationHolder)
   }
   override fun getExprList(): List<SqlExpr> {
     return children.filterIsInstance<SqlExpr>()
+  }
+
+  private fun SqlColumnDef.isStringDataType(): Boolean {
+    val typeName = columnType.typeName as PostgreSqlTypeName
+    return typeName.stringDataType != null
   }
 }

--- a/dialects/postgresql/src/test/kotlin/app/cash/sqldelight/dialects/postgres/PostgreSqlFixturesTest.kt
+++ b/dialects/postgresql/src/test/kotlin/app/cash/sqldelight/dialects/postgres/PostgreSqlFixturesTest.kt
@@ -18,7 +18,7 @@ class PostgreSqlFixturesTest(name: String, fixtureRoot: File) : FixturesTest(nam
     "BLOB" to "TEXT",
     "id TEXT GENERATED ALWAYS AS (2) UNIQUE NOT NULL" to "id TEXT GENERATED ALWAYS AS (2) STORED UNIQUE NOT NULL",
     "'(', ')', ',', '.', <binary like operator real>, BETWEEN or IN expected, got ','"
-      to "'#-', '(', ')', ',', '.', <binary like operator real>, <jsona binary operator real>, <jsonb boolean operator real>, '@@', BETWEEN or IN expected, got ','",
+      to "'#-', '(', ')', ',', '.', <binary like operator real>, <jsona binary operator real>, <jsonb boolean operator real>, <regex match operator real>, '@@', BETWEEN or IN expected, got ','",
   )
 
   override fun setupDialect() {

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/regex-match-ops/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/regex-match-ops/Test.s
@@ -1,5 +1,6 @@
 CREATE TABLE regexops(
   t TEXT NOT NULL,
+  c VARCHAR(50) NOT NULL,
   i INTEGER
 );
 
@@ -10,8 +11,11 @@ SELECT t
 FROM regexops
 WHERE t ~ ?;
 
---error[col 7]: operator does not exist: INTEGER ~ unknown
+SELECT c
+FROM regexops
+WHERE c ~ ?;
+
+--error[col 7]: operator ~ can only be performed on text
 SELECT i ~ ?
 FROM regexops;
-
 

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/regex-match-ops/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/regex-match-ops/Test.s
@@ -1,0 +1,17 @@
+CREATE TABLE regexops(
+  t TEXT NOT NULL,
+  i INTEGER
+);
+
+SELECT concat(t, 'test') ~ ?, t ~* ?, t !~ ?, t !~* ?
+FROM regexops;
+
+SELECT t
+FROM regexops
+WHERE t ~ ?;
+
+--error[col 7]: operator does not exist: INTEGER ~ unknown
+SELECT i ~ ?
+FROM regexops;
+
+

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/RegExOps.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/RegExOps.sq
@@ -1,0 +1,16 @@
+CREATE TABLE regexops(
+  t TEXT NOT NULL
+);
+
+insert:
+INSERT INTO regexops (t) VALUES (?);
+
+matchRegExOps:
+SELECT concat(t, 'test') ~ ?, t ~* ?, t !~ ?, t !~* ?
+FROM regexops;
+
+matchRegExWhere:
+SELECT t
+FROM regexops
+WHERE t ~ ?;
+

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -846,4 +846,23 @@ class PostgreSqlTest {
       assertThat(first()).isEqualTo("0.030396355")
     }
   }
+
+  @Test
+  fun testMatchRegExOps() {
+    database.regExOpsQueries.insert("thomas")
+    with(database.regExOpsQueries.matchRegExOps("t.*ma", "T.*ma", "t.*max", "T.*ma").executeAsList()) {
+      assertThat(first().expr).isTrue()
+      assertThat(first().expr_).isTrue()
+      assertThat(first().expr__).isTrue()
+      assertThat(first().expr___).isFalse()
+    }
+  }
+
+  @Test
+  fun testMatchRegExWhere() {
+    database.regExOpsQueries.insert("thomas")
+    with(database.regExOpsQueries.matchRegExWhere("t.*ma").executeAsList()) {
+      assertThat(first()).isEqualTo("thomas")
+    }
+  }
 }


### PR DESCRIPTION
fixes #5137 

POSIX regular expressions provide a more powerful means for pattern matching than the LIKE and SIMILAR TO operators.

GiST and GIN index operator classes that allow you to create an index over a text column for the purpose of very fast similarity searches. These index types support similarity operators, and additionally support trigram-based index searches for LIKE, ILIKE, ~, ~*

* Added regex operators in grammar
 ```
text ~ text → boolean
text ~* text → boolean
text !~ text → boolean
text !~* text → boolean
```
* Added integration tests
```sql
CREATE TABLE regexops(
  t TEXT NOT NULL
);

insert:
INSERT INTO regexops (t) VALUES (?);

matchRegExOps:
SELECT concat(t, 'test') ~ ?, t ~* ?, t !~ ?, t !~* ?
FROM regexops;

matchRegExWhere:
SELECT t
FROM regexops
WHERE t ~ ?;
```