### PR TITLE
Fix 5155 PostgreSql window functions

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -136,7 +136,7 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
     "quote_nullable" -> IntermediateType(TEXT).asNullable()
     "date_trunc" -> encapsulatingType(exprList, TIMESTAMP_TIMEZONE, TIMESTAMP)
     "date_part" -> IntermediateType(REAL)
-    "percentile_disc" -> IntermediateType(REAL).asNullable()
+    "percentile_disc", "cume_dist", "percent_rank" -> IntermediateType(REAL).asNullable()
     "now" -> IntermediateType(TIMESTAMP_TIMEZONE)
     "corr", "covar_pop", "covar_samp", "regr_avgx", "regr_avgy", "regr_intercept",
     "regr_r2", "regr_slope", "regr_sxx", "regr_sxy", "regr_syy",
@@ -184,6 +184,9 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
     "to_tsvector" -> IntermediateType(PostgreSqlType.TSVECTOR)
     "ts_rank" -> encapsulatingType(exprList, REAL, TEXT)
     "websearch_to_tsquery" -> IntermediateType(TEXT)
+    "rank", "dense_rank", "row_number" -> IntermediateType(INTEGER)
+    "ntile" -> IntermediateType(INTEGER).asNullable()
+    "lag", "lead", "first_value", "last_value", "nth_value" -> encapsulatingTypePreferringKotlin(exprList, SMALL_INT, PostgreSqlType.INTEGER, INTEGER, BIG_INT, REAL, TEXT, TIMESTAMP_TIMEZONE, TIMESTAMP, DATE).asNullable()
     else -> null
   }
 

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -13,8 +13,10 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ALL"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ALTER"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ALWAYS"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.AND"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.AS"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ASC"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.BETWEEN"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.BY"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.CASCADE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.COLLATE"
@@ -55,6 +57,7 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.LIMIT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.LP"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.MINUS"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.MULTIPLY"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.NO"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.NOT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.NOTHING"
@@ -63,11 +66,13 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ON"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.OR"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ORDER"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.PARTITION"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.PLUS"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.PRIMARY"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.RENAME"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.REPLACE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ROLLBACK"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.ROW"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.RP"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.SELECT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.SET"
@@ -96,6 +101,7 @@ overrides ::= type_name
   | insert_stmt
   | update_stmt_limited
   | generated_clause
+  | result_column
   | alter_table_rules
   | compound_select_stmt
   | extension_expr
@@ -370,8 +376,41 @@ extension_expr ::= regex_match_operator_expression | match_operator_expression |
   override = true
 }
 
-window_function_expr ::= {function_expr} 'WITHIN' GROUP LP ORDER BY <<expr '-1'>> ( COMMA <<expr '-1'>> ) * RP {
+window_function_expr ::= {function_expr}
+  ( ['FILTER' LP WHERE <<expr '-1'>> RP] 'OVER' ( window_defn | window_name) | 'WITHIN' GROUP LP ORDER BY <<expr '-1'>> ( COMMA <<expr '-1'>> ) * RP ) {
   mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.WindowFunctionMixin"
+}
+
+base_window_name ::= id
+window_name ::= id
+
+window_defn ::= LP [ base_window_name ]
+  [ PARTITION BY <<expr '-1'>> ( COMMA <<expr '-1'>> ) * ]
+  [ ORDER BY {ordering_term} ( COMMA {ordering_term} ) * ]
+  [ frame_spec ]
+RP {
+  pin = 1
+  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.WindowDefinitionMixin"
+}
+
+frame_spec ::= ( 'RANGE' | 'ROWS' | 'GROUPS' )
+  (
+    BETWEEN (
+      'UNBOUNDED' 'PRECEDING' |
+      'CURRENT' ROW |
+      <<expr '-1'>> 'PRECEDING' |
+      <<expr '-1'>> 'FOLLOWING'
+    ) AND (
+      'UNBOUNDED' 'FOLLOWING' |
+      'CURRENT' ROW |
+      <<expr '-1'>> 'PRECEDING' |
+      <<expr '-1'>> 'FOLLOWING'
+    ) |
+    'UNBOUNDED' 'PRECEDING' |
+    'CURRENT' ROW |
+    <<expr '-1'>> 'PRECEDING'
+  ) [ 'EXCLUDE' NO 'OTHERS' | 'EXCLUDE' 'CURRENT' ROW | 'EXCLUDE' GROUP | 'EXCLUDE' 'TIES' ] {
+  pin = 1
 }
 
 boolean_not_expression ::= NOT (boolean_literal | {column_name})

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/WindowDefinitionMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/WindowDefinitionMixin.kt
@@ -1,0 +1,14 @@
+package app.cash.sqldelight.dialects.postgresql.grammar.mixins
+
+import com.alecstrong.sql.psi.core.psi.FromQuery
+import com.alecstrong.sql.psi.core.psi.QueryElement
+import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
+import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.parentOfType
+
+abstract class WindowDefinitionMixin(node: ASTNode) : SqlCompositeElementImpl(node) {
+  override fun queryAvailable(child: PsiElement): Collection<QueryElement.QueryResult> {
+    return parentOfType<FromQuery>()!!.fromQuery()
+  }
+}

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/window_functions/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/window_functions/Test.s
@@ -1,0 +1,67 @@
+CREATE TABLE scores (
+  id INTEGER NOT NULL,
+  name TEXT NOT NULL,
+  points INTEGER NOT NULL
+);
+
+SELECT
+  name,
+  RANK() OVER (ORDER BY points DESC) rank,
+  DENSE_RANK() OVER (ORDER BY points DESC) dense_rank,
+  ROW_NUMBER() OVER (ORDER BY points DESC) row_num,
+  LAG(points) OVER (ORDER BY points DESC) lag,
+  LEAD(points) OVER (ORDER BY points DESC) lead,
+  NTILE(6) OVER (ORDER BY points DESC) ntile,
+  CUME_DIST() OVER (ORDER BY points DESC) cume_dist,
+  PERCENT_RANK() OVER (ORDER BY points DESC) percent_rank
+FROM scores;
+
+SELECT
+  name,
+  avg(points) OVER (
+    PARTITION BY name
+    ORDER BY points
+    ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+  ) AS moving_avg
+FROM scores;
+
+SELECT
+  name,
+  sum(points) OVER (
+    PARTITION BY name
+    ORDER BY points
+    RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+  ) AS running_total
+FROM scores;
+
+SELECT
+  name,
+  sum(points) OVER (
+    PARTITION BY name
+    ORDER BY points
+    RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    EXCLUDE CURRENT ROW
+  ) AS running_total
+FROM scores;
+
+SELECT
+  name,
+  points,
+  lag(points) OVER (
+    PARTITION BY name
+    ORDER BY points
+    ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING
+    EXCLUDE GROUP
+  ) AS prev_point
+FROM scores;
+
+SELECT
+  name,
+  points,
+  lag(points) OVER (
+    PARTITION BY name
+    ORDER BY points
+    ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING
+    EXCLUDE NO OTHERS
+  ) AS prev_point
+FROM scores;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Functions.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Functions.sq
@@ -23,3 +23,4 @@ SELECT generate_series(
     CAST(:finish AS TIMESTAMPTZ),
     CAST('1 hour' AS INTERVAL)
 );
+

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/WindowFunctions.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/WindowFunctions.sq
@@ -1,0 +1,33 @@
+CREATE TABLE scores (
+  name TEXT NOT NULL,
+  points INTEGER NOT NULL
+);
+
+insert:
+INSERT INTO scores (name, points)
+VALUES (?, ?);
+
+selectRank:
+SELECT
+  name,
+  RANK () OVER (
+  ORDER BY points DESC
+  ) rank
+FROM scores;
+
+selectOver:
+SELECT
+  name,
+  DENSE_RANK() OVER (ORDER BY points DESC) dense_rank,
+  ROW_NUMBER() OVER (ORDER BY points DESC) row_num,
+  LAG(3) OVER (ORDER BY points DESC) lag,
+  LEAD(points) OVER (ORDER BY points DESC) lead,
+  NTILE(6) OVER (ORDER BY points DESC) ntile,
+  CUME_DIST() OVER (ORDER BY points DESC) cume_dist,
+  PERCENT_RANK() OVER (
+	PARTITION BY name
+    ORDER BY points DESC
+    ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING
+    EXCLUDE NO OTHERS
+  ) percent_rank
+FROM scores;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -865,4 +865,34 @@ class PostgreSqlTest {
       assertThat(first()).isEqualTo("thomas")
     }
   }
+
+  @Test
+  fun testRankOver() {
+    database.windowFunctionsQueries.insert("t", 2)
+    database.windowFunctionsQueries.insert("q", 3)
+    database.windowFunctionsQueries.insert("p", 1)
+
+    with(database.windowFunctionsQueries.selectRank().executeAsList()) {
+      assertThat(first().name).isEqualTo("q")
+      assertThat(first().rank).isEqualTo(1)
+    }
+  }
+
+  @Test
+  fun testOver() {
+    database.windowFunctionsQueries.insert("a", 10)
+    database.windowFunctionsQueries.insert("b", 11)
+    database.windowFunctionsQueries.insert("c", 12)
+
+    with(database.windowFunctionsQueries.selectOver().executeAsList()) {
+      assertThat(first().name).isEqualTo("c")
+      assertThat(first().dense_rank).isEqualTo(1)
+      assertThat(first().row_num).isEqualTo(1)
+      assertThat(first().lag).isNull()
+      assertThat(first().lead).isEqualTo(11)
+      assertThat(first().ntile).isEqualTo(1)
+      assertThat(first().cume_dist).isEqualTo(0.3333333333333333)
+      assertThat(first().percent_rank).isEqualTo(0)
+    }
+  }
 }


### PR DESCRIPTION
fixes #5155 

🚧 Initial implementation was tried from hsql 😖 That doesn't appear to work though as no way to resolve to an `expr`

Current approach is to use `function_expr` so the `expr` resolves to a `IntermediateType`, then define additional functions `rank`, `row_number` etc and still able to use existing `sum`, `avg` etc

- Adds Windows Functions to PostgreSqlTypeResolver https://www.postgresql.org/docs/15/functions-window.html 
- Adds test for interface table generation has correct columns
- Adds integration tests of various window functions
- Not supported is validating clause `FILTER (WHERE ... )` when `FILTER is not implemented for non-aggregate window functions` and other validations https://github.com/postgres/postgres/blob/b29cbd3da4e37db17026b9fe58fb46fe83f467bf/src/backend/parser/parse_func.c#L871C25-L871C35
- Not supported in grammar is `WINDOW` clause*

https://www.postgresql.org/docs/15/sql-expressions.html#SYNTAX-WINDOW-FUNCTIONS

📜 Grammar 
```
function_name ([expression [, expression ... ]]) [ FILTER ( WHERE filter_clause ) ] OVER window_name
function_name ([expression [, expression ... ]]) [ FILTER ( WHERE filter_clause ) ] OVER ( window_definition )
function_name ( * ) [ FILTER ( WHERE filter_clause ) ] OVER window_name
function_name ( * ) [ FILTER ( WHERE filter_clause ) ] OVER ( window_definition )
where window_definition has the syntax

[ existing_window_name ]
[ PARTITION BY expression [, ...] ]
[ ORDER BY expression [ ASC | DESC | USING operator ] [ NULLS { FIRST | LAST } ] [, ...] ]
[ frame_clause ]
The optional frame_clause can be one of

{ RANGE | ROWS | GROUPS } frame_start [ frame_exclusion ]
{ RANGE | ROWS | GROUPS } BETWEEN frame_start AND frame_end [ frame_exclusion ]
where frame_start and frame_end can be one of

UNBOUNDED PRECEDING
offset PRECEDING
CURRENT ROW
offset FOLLOWING
UNBOUNDED FOLLOWING
and frame_exclusion can be one of

EXCLUDE CURRENT ROW
EXCLUDE GROUP
EXCLUDE TIES
EXCLUDE NO OTHERS
```
```sql
SELECT
  name,
  RANK() OVER (ORDER BY points DESC) rank,
  DENSE_RANK() OVER (ORDER BY points DESC) dense_rank,
  ROW_NUMBER() OVER (ORDER BY points DESC) row_num,
  LAG(points) OVER (ORDER BY points DESC) lag,
  LEAD(points) OVER (ORDER BY points DESC) lead,
  NTILE(6) OVER (ORDER BY points DESC) ntile,
  CUME_DIST() OVER (ORDER BY points DESC) cume_dist,
  PERCENT_RANK() OVER (ORDER BY points DESC) percent_rank
FROM scores;

SELECT
  name,
  avg(points) OVER (
    PARTITION BY name
    ORDER BY points
    ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
  ) AS moving_avg
FROM scores;

SELECT
  name,
  sum(points) OVER (
    PARTITION BY name
    ORDER BY points
    RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
    EXCLUDE CURRENT ROW 
  ) AS running_total
FROM scores;
```

*Not supported `WINDOW`
```
SELECT wf1() OVER w
FROM table_name 
WINDOW w AS (PARTITION BY c1 ORDER BY c2);
```