### PR TITLE
Fix 5172 PostgreSql select distinct

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -351,7 +351,7 @@ distinct_on_expr ::= DISTINCT ON LP {result_column} ( COMMA {result_column} ) * 
   implements = "com.alecstrong.sql.psi.core.psi.SqlCompositeElement"
 }
 
-select_stmt ::= SELECT ( [ distinct_on_expr ] | [ DISTINCT | ALL ] ) {result_column} ( COMMA {result_column} ) * [ FROM {join_clause} ] [ WHERE <<expr '-1'>> ] [{group_by}] [HAVING <<expr '-1'>>] | VALUES {values_expression} ( COMMA {values_expression} ) * {
+select_stmt ::= SELECT ( distinct_on_expr | [ DISTINCT | ALL ] ) {result_column} ( COMMA {result_column} ) * [ FROM {join_clause} ] [ WHERE <<expr '-1'>> ] [{group_by}] [HAVING <<expr '-1'>>] | VALUES {values_expression} ( COMMA {values_expression} ) * {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlSelectStmtImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlSelectStmt"
   override = true

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/select-distinct/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/select-distinct/Test.s
@@ -1,0 +1,13 @@
+CREATE TABLE person (
+    id INTEGER PRIMARY KEY,
+    name TEXT,
+    created_at TIMESTAMPTZ
+);
+
+SELECT DISTINCT name FROM person;
+
+SELECT DISTINCT id, name FROM person ORDER BY name;
+
+SELECT DISTINCT name FROM person WHERE name LIKE 'A%';
+
+SELECT DISTINCT SUBSTR(name, 1, 1) FROM person;


### PR DESCRIPTION
fixes #5172 

For some reason the additional optional [ distinct_on_expr ] causes the SELECT not to match DISTINCT.
Removed as it seems to work with `distinct_on_expr` or optionally distinct/all

There appears not to be any tests for `SELECT DISTINCT` - if so it would have found the regression 👿 

* Updated Grammar
* Added fixture tests
