### PR TITLE
Fix sonatype snapshots repository link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ SQLite
 ## Snapshots
 
 Snapshots of the development version (including the IDE plugin zip) are available in
-[Sonatype's `snapshots` repository](https://oss.sonatype.org/content/repositories/snapshots/com/squareup/sqldelight/). Note that the coordinates are all app.cash.sqldelight instead of com.squareup.cash for the 2.0.0+ SNAPSHOTs.
+[Sonatype's `snapshots` repository](https://oss.sonatype.org/content/repositories/snapshots/app/cash/sqldelight/). Note that the coordinates are all app.cash.sqldelight instead of com.squareup.cash for the 2.0.0+ SNAPSHOTs.
 
 Documentation pages for the latest snapshot version can be [found here](https://cashapp.github.io/sqldelight/snapshot).
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ SQLite
 ## Snapshots
 
 Snapshots of the development version (including the IDE plugin zip) are available in
-[Sonatype's `snapshots` repository](https://oss.sonatype.org/content/repositories/snapshots/). Note that the coordinates are all app.cash.sqldelight instead of com.squareup.cash for the 2.0.0+ SNAPSHOTs.
+[Sonatype's `snapshots` repository](https://oss.sonatype.org/content/repositories/snapshots/com/squareup/sqldelight/). Note that the coordinates are all app.cash.sqldelight instead of com.squareup.cash for the 2.0.0+ SNAPSHOTs.
 
 Documentation pages for the latest snapshot version can be [found here](https://cashapp.github.io/sqldelight/snapshot).
 


### PR DESCRIPTION
I think the link was pointing to the wrong URL, because https://oss.sonatype.org/content/repositories/snapshots/ leads to an error page:

<img width="1072" alt="SCR-20240422-pzmj" src="https://github.com/cashapp/sqldelight/assets/1320020/28dd8222-4878-4b95-a34e-27f6c4df11b0">

I updated it to what I think was the intended destination: https://oss.sonatype.org/content/repositories/snapshots/app/cash/sqldelight/