### PR TITLE
Fix StringBuilder capacity

### DIFF
--- a/runtime/src/commonMain/kotlin/app/cash/sqldelight/Transacter.kt
+++ b/runtime/src/commonMain/kotlin/app/cash/sqldelight/Transacter.kt
@@ -323,12 +323,12 @@ abstract class BaseTransacterImpl(protected val driver: SqlDriver) {
   }
 
   /**
-   * For internal use, creates a string in the format (?, ?, ?) where there are [count] offset.
+   * For internal use, creates a string in the format (?, ?, ?) where there are [count] question marks.
    */
   protected fun createArguments(count: Int): String {
     if (count == 0) return "()"
 
-    return buildString(count + 2) {
+    return buildString(count * 2 + 1) {
       append("(?")
       repeat(count - 1) {
         append(",?")


### PR DESCRIPTION
The capacity of `StringBuilder` was calculated wrongly leading to unnecessary reallocations.