### PR TITLE
Add 5199 support postgresql order by nulls

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -108,6 +108,7 @@ overrides ::= type_name
   | extension_stmt
   | create_index_stmt
   | select_stmt
+  | ordering_term
 
 column_constraint ::= [ CONSTRAINT {identifier} ] (
   PRIMARY KEY [ ASC | DESC ] {conflict_clause} |
@@ -532,3 +533,9 @@ set_timezone ::= 'TIME' 'ZONE'
 | 'LOCAL'
 | set_value
 )
+
+ordering_term ::= <<expr '-1'>> [ ASC | DESC ] [ 'NULLS' ( 'FIRST' | 'LAST' ) ] {
+  extends = "com.alecstrong.sql.psi.core.psi.impl.SqlOrderingTermImpl"
+  implements = "com.alecstrong.sql.psi.core.psi.SqlOrderingTerm"
+  override = true
+}

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/order-by-nulls/Sample.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/order-by-nulls/Sample.s
@@ -1,0 +1,28 @@
+CREATE TABLE table_name(
+  column1 TEXT,
+  column2 DATE,
+  column3 INTEGER
+);
+
+SELECT column1, column2
+FROM table_name
+ORDER BY column1 NULLS FIRST, column2 DESC;
+
+SELECT column1, column2
+FROM table_name
+ORDER BY column1 DESC NULLS LAST, column2;
+
+SELECT column1, column2, column3
+FROM table_name
+ORDER BY column1 NULLS FIRST, column2 NULLS LAST, column3;
+
+SELECT
+  column1,
+  column2,
+  column3
+FROM
+  table_name
+ORDER BY
+  column1 ASC,
+  column2 DESC,
+  column3;


### PR DESCRIPTION
fixes #5199

* Added override `ordering_term` grammar for PostgreSql  https://www.postgresql.org/docs/current/queries-order.html
* Added fixture test

Other `ORDER BY` rules in grammar use `ordering_term`