### PR TITLE
Fix typo in generateAsync description

### DIFF
--- a/docs/common/gradle.md
+++ b/docs/common/gradle.md
@@ -214,7 +214,7 @@ Defaults to `false`.
 
 Type: `Property<Boolean>`
 
-If set to true, SQLDelight will generate suspending query methods for us with asynchronous drivers.
+If set to true, SQLDelight will generate suspending query methods for use with asynchronous drivers.
 
 Defaults to `false`.
 


### PR DESCRIPTION
The gradle docs for `generateAsync` should state `for use` instead of `for us`. Thanks!