### PR TITLE
Fix 5288 adds PostgreSql drop constraint

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -75,6 +75,7 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.REGEXP"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.RENAME"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.REPLACE"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.RESTRICT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ROLLBACK"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ROW"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.RP"
@@ -327,6 +328,7 @@ alter_table_rules ::= (
   {alter_table_add_column}
   | {alter_table_rename_table}
   | alter_table_rename_column
+  | alter_table_drop_constraint
   | alter_table_drop_column
   | alter_table_add_constraint
   | alter_table_alter_column
@@ -358,6 +360,10 @@ alter_table_drop_column ::= DROP [ COLUMN ] {column_name} {
 
 alter_table_add_constraint ::= ADD table_constraint {
     mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.AlterTableAddConstraintMixin"
+}
+
+alter_table_drop_constraint ::= DROP CONSTRAINT [ IF EXISTS ] {identifier} [ RESTRICT | CASCADE ] {
+  pin = 2
 }
 
 type_clause ::= 'TYPE'

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/alter-table-drop-constraint/1.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/alter-table-drop-constraint/1.s
@@ -1,0 +1,27 @@
+CREATE TABLE test (
+  external_event_id TEXT
+);
+
+ALTER TABLE test
+  ADD CONSTRAINT idx_external_event_id
+  UNIQUE (external_event_id);
+
+CREATE TABLE t1 (
+  c1 INTEGER,
+  t1 TEXT,
+  t2 VARCHAR(255),
+  t3 CHAR(10)
+);
+
+ALTER TABLE t1
+  ADD CONSTRAINT chk_c1 CHECK (c1 > 0),
+  ADD CONSTRAINT chk_t2 CHECK (CHAR_LENGTH(t2) > 0);
+
+ALTER TABLE t1
+  DROP CONSTRAINT chk_c1;
+
+ALTER TABLE t1
+  DROP CONSTRAINT chk_t2 RESTRICT;
+
+ALTER TABLE test
+  DROP CONSTRAINT IF EXISTS idx_external_event_id CASCADE;


### PR DESCRIPTION
fixes #5288 

* Added grammar `DROP CONSTRAINT [ IF EXISTS ]  constraint_name [ RESTRICT | CASCADE ]`
  * moved higher in precedence as `DROP COLUMN` conflicts     
* Added fixture test

Note: Currently there is no way, at compile time, to verify that a named check constraints exist