### PR TITLE
Fix 5313 Postgresql async bind parameter

### DIFF
--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/async/AsyncMutatorQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/async/AsyncMutatorQueryTypeTest.kt
@@ -1,6 +1,7 @@
 package app.cash.sqldelight.core.queries.async
 
 import app.cash.sqldelight.core.compiler.MutatorQueryGenerator
+import app.cash.sqldelight.dialects.postgresql.PostgreSqlDialect
 import app.cash.sqldelight.test.util.FixtureCompiler
 import app.cash.sqldelight.test.util.withUnderscores
 import com.google.common.truth.Truth.assertThat
@@ -135,6 +136,47 @@ class AsyncMutatorQueryTypeTest {
       |        bindString(1, value_?.let { data_Adapter.value_Adapter.encode(it) })
       |      }.await()
       |  notifyQueries(${mutator.id.withUnderscores}) { emit ->
+      |    emit("data")
+      |  }
+      |}
+      |
+      """.trimMargin(),
+    )
+  }
+
+  @Test fun `Bind parameters`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE data (
+      |  id INTEGER PRIMARY KEY,
+      |  value TEXT
+      |);
+      |
+      |insertData:
+      |INSERT INTO data
+      |VALUES ?;
+      """.trimMargin(),
+      tempFolder,
+      dialect = PostgreSqlDialect(),
+      fileName = "Data.sq",
+      generateAsync = true,
+    )
+
+    val mutator = file.namedMutators.first()
+    val generator = MutatorQueryGenerator(mutator)
+
+    assertThat(generator.function().toString()).isEqualTo(
+      """
+      |public suspend fun insertData(data_: com.example.Data_) {
+      |  driver.execute(208_179_736, ""${'"'}
+      |      |INSERT INTO data (id, value)
+      |      |VALUES (${'$'}1, ${'$'}2)
+      |      ""${'"'}.trimMargin(), 2) {
+      |        check(this is app.cash.sqldelight.driver.r2dbc.R2dbcPreparedStatement)
+      |        bindInt(0, data_.id)
+      |        bindString(1, data_.value_)
+      |      }.await()
+      |  notifyQueries(208_179_736) { emit ->
       |    emit("data")
       |  }
       |}

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/async/AsyncMutatorQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/async/AsyncMutatorQueryTypeTest.kt
@@ -144,7 +144,7 @@ class AsyncMutatorQueryTypeTest {
     )
   }
 
-  @Test fun `Bind parameters`() {
+  @Test fun `Async Postgresql INSERT VALUES use correct bind parameter with the table data class`() {
     val file = FixtureCompiler.parseSql(
       """
       |CREATE TABLE data (


### PR DESCRIPTION
fixes #5313 

Uses [`app.cash.sqldelight.dialects.postgresql.grammar.mixins.BindParameterMixin`](https://github.com/cashapp/sqldelight/blob/6a8142b6fbbdd81874285114de4ffe3fbd43003f/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/BindParameterMixin.kt#L8) to set correct bind parameter `$index` or `?`

Added test for generated code show correct indexed parameters are encoded