### PR TITLE
Backport stable output path fix from (#4269) to 1.5.x

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/com/squareup/sqldelight/gradle/SqlDelightDatabase.kt
@@ -224,7 +224,5 @@ class SqlDelightDatabase(
     }
   }
 
-  private val Source.outputDir get() =
-    if (sources.size > 1) File(generatedSourcesDirectory, name)
-    else generatedSourcesDirectory
+  private val Source.outputDir get() = File(generatedSourcesDirectory, name)
 }

--- a/sqldelight-gradle-plugin/src/test/integration-android-variants/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-android-variants/build.gradle
@@ -43,3 +43,9 @@ android {
     exclude 'LICENSE.txt'
   }
 }
+
+androidComponents {
+  beforeVariants(selector().withBuildType("release")) {
+    enable = project.properties["debugOnly"] != "true"
+  }
+}

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/integrations/IntegrationTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/integrations/IntegrationTest.kt
@@ -188,6 +188,22 @@ class IntegrationTest {
   }
 
   @Test
+  fun integrationTestsAndroidSingleVariant() {
+    val projectLocation = File("src/test/integration-android-variants")
+    val outputDir = File(projectLocation, "build/generated/sqldelight/code/QueryWrapper")
+    val runner = GradleRunner.create()
+      .withCommonConfiguration(projectLocation)
+      .forwardOutput()
+
+    val generateDebugResult = runner
+      .withArguments("clean", "generateDebugQueryWrapperInterface", "-PdebugOnly=true")
+      .build()
+    assertThat(generateDebugResult.output).contains("BUILD SUCCESSFUL")
+
+    assertThat(File(outputDir, "debug").exists()).isTrue()
+  }
+
+  @Test
   @Category(Instrumentation::class)
   fun integrationTestsAndroidLibrary() {
     val integrationRoot = File("src/test/integration-android-library")

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/properties/MultiModuleTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/properties/MultiModuleTests.kt
@@ -28,7 +28,7 @@ class MultiModuleTests {
     assertThat(properties.compilationUnits).hasSize(1)
 
     with(properties.compilationUnits[0]) {
-      assertThat(outputDirectoryFile).isEqualTo(File(fixtureRoot, "build/generated/sqldelight/code/Database"))
+      assertThat(outputDirectoryFile).isEqualTo(File(fixtureRoot, "build/generated/sqldelight/code/Database/main"))
       assertThat(sourceFolders).containsExactly(
         SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false),
         SqlDelightSourceFolderImpl(File(fixtureRoot, "../ProjectB/src/main/sqldelight"), true)
@@ -166,7 +166,7 @@ class MultiModuleTests {
           SqlDelightSourceFolderImpl(File(fixtureRoot, "../middleB/src/main/sqldelight"), true),
           SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false),
         ),
-        outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/Database"),
+        outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/Database/main"),
       )
     )
   }

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/properties/PropertiesFileTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/properties/PropertiesFileTest.kt
@@ -28,7 +28,7 @@ class PropertiesFileTest {
     assertThat(properties.compilationUnits).hasSize(1)
 
     with(properties.compilationUnits[0]) {
-      assertThat(outputDirectoryFile).isEqualTo(File(fixtureRoot, "build/generated/sqldelight/code/Database"))
+      assertThat(outputDirectoryFile).isEqualTo(File(fixtureRoot, "build/generated/sqldelight/code/Database/main"))
       assertThat(sourceFolders).containsExactly(
         SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false)
       )
@@ -102,7 +102,7 @@ class PropertiesFileTest {
           sourceFolders = listOf(
             SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), dependency = false)
           ),
-          outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CashDatabase"),
+          outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CashDatabase/main"),
         )
       )
     }

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/CompilationUnitTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/CompilationUnitTests.kt
@@ -47,7 +47,7 @@ class CompilationUnitTests {
           SqlDelightCompilationUnitImpl(
             name = "main",
             sourceFolders = listOf(SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false)),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb")
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/main")
           )
         )
       }
@@ -95,7 +95,7 @@ class CompilationUnitTests {
               SqlDelightCompilationUnitImpl(
                 name = "main",
                 sourceFolders = listOf(SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false)),
-                outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
+                outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/main"),
               )
             ),
             dependencies = emptyList(),
@@ -112,7 +112,7 @@ class CompilationUnitTests {
                   SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/otherdb"), false),
                   SqlDelightSourceFolderImpl(File(fixtureRoot, "src/main/sqldelight"), false),
                 ),
-                outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/OtherDb"),
+                outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/OtherDb/main"),
               )
             ),
             dependencies = emptyList(),
@@ -170,7 +170,7 @@ class CompilationUnitTests {
           SqlDelightCompilationUnitImpl(
             name = "commonMain",
             sourceFolders = listOf(SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb")
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/commonMain")
           )
         )
       }
@@ -249,7 +249,7 @@ class CompilationUnitTests {
           SqlDelightCompilationUnitImpl(
             name = "commonMain",
             sourceFolders = listOf(SqlDelightSourceFolderImpl(File(fixtureRoot, "src/commonMain/sqldelight"), false)),
-            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb"),
+            outputDirectoryFile = File(fixtureRoot, "build/generated/sqldelight/code/CommonDb/commonMain"),
           )
         )
       }

--- a/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/MigrationTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/com/squareup/sqldelight/tests/MigrationTest.kt
@@ -158,7 +158,7 @@ class MigrationTest {
 
     assertThat(output.output).contains("BUILD SUCCESSFUL")
 
-    val generatedDatabase = File(fixtureRoot, "build/generated/sqldelight/code/Database/com/example/sqldelightmigrations/DatabaseImpl.kt")
+    val generatedDatabase = File(fixtureRoot, "build/generated/sqldelight/code/Database/main/com/example/sqldelightmigrations/DatabaseImpl.kt")
     assertThat(generatedDatabase.exists()).isTrue()
     assertThat(generatedDatabase.readText()).contains(
       """


### PR DESCRIPTION
Backports a fix from #4269 to the `1.5.3` branch.