### PR TITLE
Fix 5330 add Postgresql ILIKE operator

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -44,6 +44,7 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.FOREIGN"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.FROM"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.GENERATED"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.GLOB"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.GROUP"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.HAVING"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ID"
@@ -54,8 +55,10 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.INSERT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.INTO"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.KEY"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.LIKE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.LIMIT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.LP"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.MATCH"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.MINUS"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.MULTIPLY"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.NO"
@@ -69,6 +72,7 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.PARTITION"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.PLUS"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.PRIMARY"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.REGEXP"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.RENAME"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.REPLACE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.ROLLBACK"
@@ -109,6 +113,7 @@ overrides ::= type_name
   | create_index_stmt
   | select_stmt
   | ordering_term
+  | binary_like_operator
   | literal_value
 
 column_constraint ::= [ CONSTRAINT {identifier} ] (
@@ -189,6 +194,12 @@ create_index_stmt ::= CREATE [ UNIQUE ] INDEX [ 'CONCURRENTLY' ] [ IF NOT EXISTS
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlCreateIndexStmtImpl"
   override = true
   pin = 6
+}
+
+binary_like_operator ::= ( 'ILIKE' | LIKE | GLOB | REGEXP | MATCH ) {
+   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlBinaryLikeOperatorImpl"
+   implements = "com.alecstrong.sql.psi.core.psi.SqlBinaryLikeOperator"
+   override = true
 }
 
 identity_clause ::= 'IDENTITY' [ LP [ 'SEQUENCE' 'NAME' sequence_name ] [ sequence_parameters* ] RP ]
@@ -442,7 +453,7 @@ match_operator_expression ::= ( {function_expr} | {column_expr} ) match_operator
   pin = 2
 }
 
-regex_match_operator ::= '~*' | '~' | '!~*' | '!~'
+regex_match_operator ::=  '~~*' | '~*' | '!~~*' | '!~*' | '~~' | '~' | '!~~' | '!~'
 
 regex_match_operator_expression ::= ( {function_expr} | {column_expr} ) regex_match_operator <<expr '-1'>> {
   mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.RegExMatchOperatorExpressionMixin"

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/like-operators/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/like-operators/Test.s
@@ -1,0 +1,17 @@
+CREATE TABLE Test (
+   txt TEXT NOT NULL
+);
+
+SELECT * FROM Test WHERE txt LIKE 'testing%';
+
+SELECT * FROM Test WHERE txt ILIKE 'test%';
+
+SELECT * FROM Test WHERE txt ~~ 'testin%';
+
+SELECT * FROM Test WHERE txt ~~* '%esting%';
+
+SELECT txt !~~ 'testing%' FROM Test;
+
+SELECT txt !~~* 'testing%' FROM Test;
+
+SELECT txt ILIKE 'test%' FROM Test;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Like.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Like.sq
@@ -1,0 +1,24 @@
+CREATE TABLE Test_Like (
+   txt TEXT NOT NULL
+);
+
+insert:
+INSERT INTO Test_Like (txt) VALUES(?);
+
+selectWhereLike:
+SELECT * FROM Test_Like WHERE txt LIKE ?;
+
+selectWhereILike:
+SELECT * FROM Test_Like WHERE txt ILIKE ?;
+
+selectWhereLikeRegex:
+SELECT * FROM Test_Like WHERE txt ~~ 'testin%';
+
+selectWhereILikeRegex:
+SELECT * FROM Test_Like WHERE txt ~~* '%esting%';
+
+selectLikeRegex:
+SELECT txt ~~ 'testing%', txt !~~ 'testing%' FROM Test_Like;
+
+selectILikeRegex:
+SELECT txt ~~* 'testing%', txt !~~* 'testing%' FROM Test_Like;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -867,6 +867,42 @@ class PostgreSqlTest {
   }
 
   @Test
+  fun testLike() {
+    database.likeQueries.insert("testing")
+
+    with(database.likeQueries.selectWhereLike("test%").executeAsList()) {
+      assertThat(first()).isEqualTo("testing")
+    }
+
+    with(database.likeQueries.selectWhereLikeRegex().executeAsList()) {
+      assertThat(first()).isEqualTo("testing")
+    }
+
+    with(database.likeQueries.selectLikeRegex().executeAsList()) {
+      assertThat(first().expr).isTrue()
+      assertThat(first().expr_).isFalse()
+    }
+  }
+
+  @Test
+  fun testILike() {
+    database.likeQueries.insert("TESTING")
+
+    with(database.likeQueries.selectWhereILike("test%").executeAsList()) {
+      assertThat(first()).isEqualTo("TESTING")
+    }
+
+    with(database.likeQueries.selectWhereILikeRegex().executeAsList()) {
+      assertThat(first()).isEqualTo("TESTING")
+    }
+
+    with(database.likeQueries.selectILikeRegex().executeAsList()) {
+      assertThat(first().expr).isTrue()
+      assertThat(first().expr_).isFalse()
+    }
+  }
+
+  @Test
   fun testRankOver() {
     database.windowFunctionsQueries.insert("t", 2)
     database.windowFunctionsQueries.insert("q", 3)


### PR DESCRIPTION
fixes #5330 

https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE

* Added `ILIKE` operator - extended existing rule even though it has Sqlite operators GLOB, MATCH, REGEX, 
* Added Regex
  * operator `~~` is equivalent to LIKE, and `~~*` corresponds to ILIKE. There are also `!~~` and `!~~*` operators 
that represent NOT LIKE and NOT ILIKE
* Added integration test