### PR TITLE
Fix 5331 add PostgreSql XML type

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlType.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlType.kt
@@ -23,6 +23,7 @@ internal enum class PostgreSqlType(override val javaType: TypeName) : DialectTyp
   NUMERIC(ClassName("java.math", "BigDecimal")),
   JSON(STRING),
   TSVECTOR(STRING),
+  XML(STRING),
   ;
 
   override fun prepareStatementBinder(columnIndex: CodeBlock, value: CodeBlock): CodeBlock {
@@ -43,6 +44,12 @@ internal enum class PostgreSqlType(override val javaType: TypeName) : DialectTyp
         value,
         MemberName(ClassName("java.sql", "Types"), "OTHER"),
       )
+      XML -> CodeBlock.of(
+        "bindObject(%L, %L, %M)\n",
+        columnIndex,
+        value,
+        MemberName(ClassName("java.sql", "Types"), "SQLXML"),
+      )
     }
   }
 
@@ -54,7 +61,7 @@ internal enum class PostgreSqlType(override val javaType: TypeName) : DialectTyp
         BIG_INT -> "$cursorName.getLong($columnIndex)"
         DATE, TIME, TIMESTAMP, TIMESTAMP_TIMEZONE, INTERVAL, UUID -> "$cursorName.getObject<%T>($columnIndex)"
         NUMERIC -> "$cursorName.getBigDecimal($columnIndex)"
-        JSON, TSVECTOR -> "$cursorName.getString($columnIndex)"
+        JSON, TSVECTOR, XML -> "$cursorName.getString($columnIndex)"
       },
       javaType,
     )

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -74,6 +74,7 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
         booleanDataType != null -> BOOLEAN
         blobDataType != null -> BLOB
         tsvectorDataType != null -> PostgreSqlType.TSVECTOR
+        xmlDataType != null -> PostgreSqlType.XML
         else -> throw IllegalArgumentException("Unknown kotlin type for sql type ${this.text}")
       },
     )

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -155,7 +155,8 @@ type_name ::= (
   boolean_data_type |
   json_data_type |
   blob_data_type |
-  tsvector_data_type
+  tsvector_data_type |
+  xml_data_type
 ) [ '[]' ] {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlTypeNameImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlTypeName"
@@ -223,6 +224,8 @@ json_data_type ::= 'JSON' | 'JSONB'
 blob_data_type ::= 'BYTEA'
 
 tsvector_data_type ::= 'TSVECTOR'
+
+xml_data_type ::= 'XML'
 
 interval_expression ::= 'INTERVAL' string_literal
 

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/xml-type/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/xml-type/Test.s
@@ -1,0 +1,7 @@
+CREATE TABLE Test (
+  x1 XML NOT NULL,
+  x2 XML
+);
+
+SELECT x1, x2
+FROM Test;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Xml.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Xml.sq
@@ -1,0 +1,11 @@
+CREATE TABLE Xml_Test(
+  x1 XML NOT NULL,
+  x2 XML
+);
+
+insert:
+INSERT INTO Xml_Test (x1, x2) VALUES (?, ?);
+
+select:
+SELECT x1, x2
+FROM Xml_Test;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -928,4 +928,15 @@ class PostgreSqlTest {
       assertThat(expr_________).isEqualTo(OffsetDateTime.of(2001, 2, 17, 2, 38, 40, 0, ZoneOffset.ofHours(0)))
     }
   }
+
+  @Test
+  fun testXml() {
+    val a = "<?xml version=\"1.0\"?><book><title>Manual</title><chapter>test</chapter></book>"
+    val b = "<book><title>Manual</title><chapter>test</chapter></book>"
+    database.xmlQueries.insert(a, b)
+    with(database.xmlQueries.select().executeAsOne()) {
+      assertThat(x1).isEqualTo(b) // results are returned without <?xml...?>
+      assertThat(x2).isEqualTo(b)
+    }
+  }
 }


### PR DESCRIPTION
fixes #5331 

https://www.postgresql.org/docs/16/datatype-xml.html

```
CREATE TABLE Test(
   x XML
);

insert:
INSERT INTO Test(x) VALUES ('<simple>test</simple>');

insertX:
INSERT INTO Test(x) VALUES (?);
```

```
sample.xQueries.insertX("<a>test</a>")
```

* Added `XML` data type works with String input and output
  *  type is supported for insert (binds to SQLXML) and select (String)
  *  none of the functions are supported https://www.postgresql.org/docs/16/functions-xml.html
* Added integration test

Note: 
Support for "::xml" type casting is already in another pr https://github.com/cashapp/sqldelight/pull/5261