### PR TITLE
Make JVM samples consistent with other platforms

### DIFF
--- a/docs/jvm_sqlite/index.md
+++ b/docs/jvm_sqlite/index.md
@@ -20,19 +20,17 @@ your project.
     }
     ```
 
-An instance of the driver can be constructed as shown below. The constructor accepts a JDBC 
+An instance of the driver can be constructed as shown below. The constructor accepts a JDBC
 connection string that specifies the location of the database file. The `IN_MEMORY`
 constant can also be passed to the constructor to create an in-memory database.
 
 === "On-Disk"
     ```kotlin
-    val driver: SqlDriver = JdbcSqliteDriver("jdbc:sqlite:test.db")
-    Database.Schema.create(driver)
+    val driver: SqlDriver = JdbcSqliteDriver("jdbc:sqlite:test.db", Properties(), Database.Schema)
     ```
 === "In-Memory"
     ```kotlin
-    val driver: SqlDriver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
-    Database.Schema.create(driver)
+    val driver: SqlDriver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY, Properties(), Database.Schema)
     ```
 
 {% include 'common/index_queries.md' %}

--- a/docs/multiplatform_sqlite/index.md
+++ b/docs/multiplatform_sqlite/index.md
@@ -9,16 +9,16 @@ Each target platform has its own driver implementation.
 
 === "Kotlin"
     ```kotlin
-    kotlin { 
+    kotlin {
       sourceSets.androidMain.dependencies {
         implementation("app.cash.sqldelight:android-driver:{{ versions.sqldelight }}")
       }
-    
+
       // or iosMain, windowsMain, etc.
       sourceSets.nativeMain.dependencies {
         implementation("app.cash.sqldelight:native-driver:{{ versions.sqldelight }}")
       }
-    
+
       sourceSets.jvmMain.dependencies {
         implementation("app.cash.sqldelight:sqlite-driver:{{ versions.sqldelight }}")
       }
@@ -26,16 +26,16 @@ Each target platform has its own driver implementation.
     ```
 === "Groovy"
     ```groovy
-    kotlin { 
+    kotlin {
       sourceSets.androidMain.dependencies {
         implementation "app.cash.sqldelight:android-driver:{{ versions.sqldelight }}"
       }
-    
+
       // or iosMain, windowsMain, etc.
       sourceSets.nativeMain.dependencies {
         implementation "app.cash.sqldelight:native-driver:{{ versions.sqldelight }}"
       }
-    
+
       sourceSets.jvmMain.dependencies {
         implementation "app.cash.sqldelight:sqlite-driver:{{ versions.sqldelight }}"
       }
@@ -44,7 +44,7 @@ Each target platform has its own driver implementation.
 
 ## Constructing Driver Instances
 
-Create a common factory class or method to obtain a `SqlDriver` instance. 
+Create a common factory class or method to obtain a `SqlDriver` instance.
 
 ```kotlin title="src/commonMain/kotlin"
 import com.example.Database
@@ -67,7 +67,7 @@ Then implement this for each target platform:
     ```kotlin
     actual class DriverFactory(private val context: Context) {
       actual fun createDriver(): SqlDriver {
-        return AndroidSqliteDriver(Database.Schema, context, "test.db") 
+        return AndroidSqliteDriver(Database.Schema, context, "test.db")
       }
     }
     ```
@@ -83,8 +83,7 @@ Then implement this for each target platform:
     ```kotlin
     actual class DriverFactory {
       actual fun createDriver(): SqlDriver {
-        val driver: SqlDriver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
-        Database.Schema.create(driver)
+        val driver: SqlDriver = JdbcSqliteDriver("jdbc:sqlite:test.db", Properties(), Database.Schema)
         return driver
       }
     }


### PR DESCRIPTION
The JVM code samples do not use the `PRAGMA user_version`-based migration logic, which is a bit misleading because samples for other platforms do.

The inconsistency is particularly visible in the Multiplatform case, where the android and native samples will set `user_version=1`, but the JVM sample will produce `user_version=0`, resulting in some headaches down the road.