### PR TITLE
Fix 5399 PostgreSql numeric resolver

### DIFF
--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
@@ -1147,6 +1147,7 @@ class InterfaceGeneration {
     |inr INTEGER,
     |jsn JSON,
     |jsb JSON,
+    |num NUMERIC,
     |tim TIME,
     |tms TIMESTAMP,
     |tmz TIMESTAMPTZ,
@@ -1167,6 +1168,7 @@ class InterfaceGeneration {
     |inr IS NOT NULL AS has_integer,
     |jsn IS NOT NULL AS has_json,
     |jsb IS NOT NULL AS has_jsob,
+    |num IS NOT NULL AS has_num,
     |sml IS NOT NULL AS has_smallint,
     |tim IS NOT NULL AS has_time,
     |tms IS NOT NULL AS has_timestamp,
@@ -1205,6 +1207,7 @@ class InterfaceGeneration {
     |    has_integer: Boolean,
     |    has_json: Boolean,
     |    has_jsob: Boolean,
+    |    has_num: Boolean,
     |    has_smallint: Boolean,
     |    has_time: Boolean,
     |    has_timestamp: Boolean,
@@ -1222,6 +1225,7 @@ class InterfaceGeneration {
     |  |inr IS NOT NULL AS has_integer,
     |  |jsn IS NOT NULL AS has_json,
     |  |jsb IS NOT NULL AS has_jsob,
+    |  |num IS NOT NULL AS has_num,
     |  |sml IS NOT NULL AS has_smallint,
     |  |tim IS NOT NULL AS has_time,
     |  |tms IS NOT NULL AS has_timestamp,
@@ -1247,11 +1251,12 @@ class InterfaceGeneration {
     |      cursor.getBoolean(11)!!,
     |      cursor.getBoolean(12)!!,
     |      cursor.getBoolean(13)!!
+    |      cursor.getBoolean(14)!!
     |    )
     |  }
     |
     |  public fun selectIsNotNull(): Query<SelectIsNotNull> = selectIsNotNull { has_bigint, has_boolean,
-    |      has_byte, has_date, has_integer, has_json, has_jsob, has_smallint, has_time, has_timestamp,
+    |      has_byte, has_date, has_integer, has_json, has_jsob, has_num, has_smallint, has_time, has_timestamp,
     |      has_timestamptz, has_tsvector, has_uuid, has_varchar ->
     |    SelectIsNotNull(
     |      has_bigint,
@@ -1261,6 +1266,7 @@ class InterfaceGeneration {
     |      has_integer,
     |      has_json,
     |      has_jsob,
+    |      has_num,
     |      has_smallint,
     |      has_time,
     |      has_timestamp,
@@ -1272,6 +1278,118 @@ class InterfaceGeneration {
     |  }
     |}
     |
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `postgres using numeric returns BigDecimal`() {
+    val file = FixtureCompiler.parseSql(
+      """
+        |CREATE TABLE sales (
+        |  product_id INTEGER,
+        |  sale_date DATE,
+        |  sale_amount NUMERIC
+        |);
+        |
+        |select:
+        |SELECT
+        |  sum(sale_amount) AS sum_amount,
+        |  sale_amount * sale_amount AS product_amount,
+        |  array_agg(sale_amount) AS agg_amount,
+        |  generate_series(sale_amount, 2) AS generate_amount
+        |FROM sales
+        |GROUP BY sale_amount;
+      """.trimMargin(),
+      temporaryFolder,
+      fileName = "NumericFunctions.sq",
+      dialect = PostgreSqlDialect(),
+    )
+
+    val table = file.tables(false).single()
+    val tableGenerator = TableInterfaceGenerator(table)
+
+    assertThat(tableGenerator.kotlinImplementationSpec().toString()).isEqualTo(
+      """
+      |public data class Sales(
+      |  public val product_id: kotlin.Int?,
+      |  public val sale_date: java.time.LocalDate?,
+      |  public val sale_amount: java.math.BigDecimal?,
+      |)
+      |
+      """.trimMargin(),
+    )
+
+    val query = file.namedQueries.first()
+    val queryGenerator = QueryInterfaceGenerator(query)
+    assertThat(queryGenerator.kotlinImplementationSpec().toString()).isEqualTo(
+      """
+      |public data class Select(
+      |  public val sum_amount: java.math.BigDecimal?,
+      |  public val product_amount: java.math.BigDecimal?,
+      |  public val agg_amount: kotlin.Array<java.math.BigDecimal?>,
+      |  public val generate_amount: java.math.BigDecimal,
+      |)
+      |
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `postgres using numeric window function returns BigDecimal`() {
+    val file = FixtureCompiler.parseSql(
+      """
+        |CREATE TABLE sales (
+        |  product_id INTEGER,
+        |  sale_date DATE,
+        |  sale_amount NUMERIC
+        |);
+        |
+        |select:
+        |SELECT
+        |  product_id,
+        |  sale_date,
+        |  lag(sale_amount, 1) OVER (PARTITION BY product_id ORDER BY sale_date) AS prev_sale_amount,
+        |  lead(sale_amount, 1) OVER (PARTITION BY product_id ORDER BY sale_date) AS next_sale_amount,
+        |  first_value(sale_amount) OVER (PARTITION BY product_id ORDER BY sale_date) AS first_sale_amount,
+        |  last_value(sale_amount) OVER (PARTITION BY product_id ORDER BY sale_date RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS last_sale_amount,
+        |  nth_value(sale_amount, 2) OVER (PARTITION BY product_id ORDER BY sale_date) AS second_sale_amount
+        |FROM sales
+        |ORDER BY product_id, sale_date;
+      """.trimMargin(),
+      temporaryFolder,
+      fileName = "NumericWindowsFunctions.sq",
+      dialect = PostgreSqlDialect(),
+    )
+
+    val table = file.tables(false).single()
+    val tableGenerator = TableInterfaceGenerator(table)
+
+    assertThat(tableGenerator.kotlinImplementationSpec().toString()).isEqualTo(
+      """
+      |public data class Sales(
+      |  public val product_id: kotlin.Int?,
+      |  public val sale_date: java.time.LocalDate?,
+      |  public val sale_amount: java.math.BigDecimal?,
+      |)
+      |
+      """.trimMargin(),
+    )
+
+    val query = file.namedQueries.first()
+    val queryGenerator = QueryInterfaceGenerator(query)
+    assertThat(queryGenerator.kotlinImplementationSpec().toString()).isEqualTo(
+      """
+      |public data class Select(
+      |  public val product_id: kotlin.Int?,
+      |  public val sale_date: java.time.LocalDate?,
+      |  public val prev_sale_amount: java.math.BigDecimal?,
+      |  public val next_sale_amount: java.math.BigDecimal?,
+      |  public val first_sale_amount: java.math.BigDecimal?,
+      |  public val last_sale_amount: java.math.BigDecimal?,
+      |  public val second_sale_amount: java.math.BigDecimal?,
+      |)
+      |
       """.trimMargin(),
     )
   }

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
@@ -1250,14 +1250,14 @@ class InterfaceGeneration {
     |      cursor.getBoolean(10)!!,
     |      cursor.getBoolean(11)!!,
     |      cursor.getBoolean(12)!!,
-    |      cursor.getBoolean(13)!!
+    |      cursor.getBoolean(13)!!,
     |      cursor.getBoolean(14)!!
     |    )
     |  }
     |
     |  public fun selectIsNotNull(): Query<SelectIsNotNull> = selectIsNotNull { has_bigint, has_boolean,
-    |      has_byte, has_date, has_integer, has_json, has_jsob, has_num, has_smallint, has_time, has_timestamp,
-    |      has_timestamptz, has_tsvector, has_uuid, has_varchar ->
+    |      has_byte, has_date, has_integer, has_json, has_jsob, has_num, has_smallint, has_time,
+    |      has_timestamp, has_timestamptz, has_tsvector, has_uuid, has_varchar ->
     |    SelectIsNotNull(
     |      has_bigint,
     |      has_boolean,


### PR DESCRIPTION
fixes #5399 

After https://github.com/cashapp/sqldelight/issues/1882 there are some functions and expression that can use `NUMERIC`
and need to compile to `BIGDECIMAL` in the query interface

* Add `NUMERIC` to resolver functions/expressions 
* Add Interface tests to check generation