### PR TITLE
Fix 5407 PostgreSql create or replace view

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -19,6 +19,7 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.BETWEEN"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.BY"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.CASCADE"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.CHECK"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.COLLATE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.COLUMN"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.COMMA"
@@ -72,6 +73,7 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.PARTITION"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.PLUS"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.PRIMARY"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.RECURSIVE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.REGEXP"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.RENAME"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.REPLACE"
@@ -90,6 +92,7 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.UPDATE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.USING"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.VALUES"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.VIEW"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.WHERE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.WITH"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.WITHOUT"
@@ -113,6 +116,7 @@ overrides ::= type_name
   | extension_expr
   | extension_stmt
   | create_index_stmt
+  | create_view_stmt
   | select_stmt
   | ordering_term
   | binary_like_operator
@@ -195,6 +199,12 @@ create_index_stmt ::= CREATE [ UNIQUE ] INDEX [ 'CONCURRENTLY' ] [ IF NOT EXISTS
  ( USING index_method LP {indexed_column} [ operator_class_stmt ] ( COMMA {indexed_column} [ operator_class_stmt ] ) * RP [ with_storage_parameter ] | LP {indexed_column} [ operator_class_stmt ] ( COMMA {indexed_column} [ operator_class_stmt ] ) * RP [ WHERE <<expr '-1'>> ] )  {
   mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.CreateIndexMixin"
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlCreateIndexStmtImpl"
+  override = true
+  pin = 6
+}
+
+create_view_stmt ::= CREATE [ OR REPLACE ] [ TEMP | TEMPORARY ] [ RECURSIVE ] VIEW [ {database_name} DOT ] {view_name} [ LP {column_alias} ( COMMA {column_alias} ) * RP ] AS {compound_select_stmt} [ WITH [ 'CASCADED' | 'LOCAL' ] CHECK 'OPTION' ] {
+  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.CreateOrReplaceViewMixin"
   override = true
   pin = 6
 }

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/CreateOrReplaceViewMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/CreateOrReplaceViewMixin.kt
@@ -1,0 +1,28 @@
+package app.cash.sqldelight.dialects.postgresql.grammar.mixins
+
+import com.alecstrong.sql.psi.core.SqlAnnotationHolder
+import com.alecstrong.sql.psi.core.psi.QueryElement
+import com.alecstrong.sql.psi.core.psi.impl.SqlCreateViewStmtImpl
+import com.intellij.lang.ASTNode
+
+/**
+ * See sql-psi com.alecstrong.sql.psi.core.psi.mixins.CreateViewMixin where `REPLACE` is enabled
+ * Add annotations to check replace has identical set of columns in same order, but allows appending columns
+ */
+internal abstract class CreateOrReplaceViewMixin(
+  node: ASTNode,
+) : SqlCreateViewStmtImpl(node) {
+
+  override fun annotate(annotationHolder: SqlAnnotationHolder) {
+    val currentColumns: List<QueryElement.QueryColumn> = tableAvailable(this, viewName.name).flatMap { it.columns }
+    val newColumns = compoundSelectStmt!!.queryExposed().flatMap { it.columns }
+    if (currentColumns.size > newColumns.size) {
+      annotationHolder.createErrorAnnotation(this, "Cannot drop columns from ${viewName.name}")
+    }
+
+    currentColumns.zip(newColumns).firstOrNull { (current, new) -> current != new }?.let { (current, new) ->
+      annotationHolder.createErrorAnnotation(this, """Cannot change name of view column "${current.element.text}" to "${new.element.text}"""")
+    }
+    super.annotate(annotationHolder)
+  }
+}

--- a/dialects/postgresql/src/test/kotlin/app/cash/sqldelight/dialects/postgres/PostgreSqlFixturesTest.kt
+++ b/dialects/postgresql/src/test/kotlin/app/cash/sqldelight/dialects/postgres/PostgreSqlFixturesTest.kt
@@ -16,6 +16,7 @@ class PostgreSqlFixturesTest(name: String, fixtureRoot: File) : FixturesTest(nam
     "?1" to "?",
     "?2" to "?",
     "BLOB" to "TEXT",
+    "CREATE VIEW IF NOT EXISTS" to "CREATE OR REPLACE VIEW",
     "id TEXT GENERATED ALWAYS AS (2) UNIQUE NOT NULL" to "id TEXT GENERATED ALWAYS AS (2) STORED UNIQUE NOT NULL",
     "'(', ')', ',', '.', <binary like operator real>, BETWEEN or IN expected, got ','"
       to "'#-', '(', ')', ',', '.', '::', <binary like operator real>, <contains operator real>, <jsona binary operator real>, <jsonb boolean operator real>, <regex match operator real>, '@@', AT, BETWEEN or IN expected, got ','",

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/create-or-replace-view/Sample.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/create-or-replace-view/Sample.s
@@ -1,0 +1,9 @@
+CREATE TABLE abc (
+    a INTEGER PRIMARY KEY,
+    b TEXT NOT NULL,
+    c NUMERIC NOT NULL
+);
+
+CREATE VIEW viewabc AS SELECT a, b FROM abc;
+
+CREATE OR REPLACE VIEW viewabc AS SELECT a, b, c FROM abc;

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/migrations/MigrationQueryTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/migrations/MigrationQueryTest.kt
@@ -37,6 +37,10 @@ class MigrationQueryTest {
     checkFixtureCompiles("varying-query-migration-packages", PostgreSqlDialect())
   }
 
+  @Test fun `create or replace view`() {
+    checkFixtureCompiles("create-or-replace-view", PostgreSqlDialect())
+  }
+
   private fun checkFixtureCompiles(fixtureRoot: String, dialect: SqlDelightDialect = SqliteDialect()) {
     val result = FixtureCompiler.compileFixture(
       overrideDialect = dialect,

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/com/example/migrations/1.sqm
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/com/example/migrations/1.sqm
@@ -1,0 +1,7 @@
+CREATE TABLE test (
+  a TEXT,
+  b INTEGER,
+  c NUMERIC,
+  d TEXT,
+  e INTEGER
+);

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/com/example/migrations/2.sqm
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/com/example/migrations/2.sqm
@@ -1,0 +1,1 @@
+CREATE VIEW v_test AS SELECT a, b FROM test;

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/com/example/migrations/3.sqm
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/com/example/migrations/3.sqm
@@ -1,0 +1,1 @@
+CREATE OR REPLACE VIEW v_test AS SELECT a, b, c FROM test;

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/com/example/queries/Data.sq
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/com/example/queries/Data.sq
@@ -1,0 +1,3 @@
+select:
+SELECT a, b, c
+FROM v_test;

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/DataQueries.kt
@@ -1,0 +1,39 @@
+package com.example.queries
+
+import app.cash.sqldelight.Query
+import app.cash.sqldelight.TransacterImpl
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.jdbc.JdbcCursor
+import com.example.migrations.V_test
+import java.math.BigDecimal
+import kotlin.Any
+import kotlin.Int
+import kotlin.String
+
+public class DataQueries(
+  driver: SqlDriver,
+) : TransacterImpl(driver) {
+  public fun <T : Any> select(mapper: (
+    a: String?,
+    b: Int?,
+    c: BigDecimal?,
+  ) -> T): Query<T> = Query(-1_042_942_063, arrayOf("test"), driver, "Data.sq", "select", """
+  |SELECT a, b, c
+  |FROM test
+  """.trimMargin()) { cursor ->
+    check(cursor is JdbcCursor)
+    mapper(
+      cursor.getString(0),
+      cursor.getInt(1),
+      cursor.getBigDecimal(2)
+    )
+  }
+
+  public fun select(): Query<V_test> = select { a, b, c ->
+    V_test(
+      a,
+      b,
+      c
+    )
+  }
+}

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/migrations/Test.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/migrations/Test.kt
@@ -1,0 +1,13 @@
+package com.example.migrations
+
+import java.math.BigDecimal
+import kotlin.Int
+import kotlin.String
+
+public data class Test(
+  public val a: String?,
+  public val b: Int?,
+  public val c: BigDecimal?,
+  public val d: String?,
+  public val e: Int?,
+)

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/migrations/V_test.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/migrations/V_test.kt
@@ -1,0 +1,11 @@
+package com.example.migrations
+
+import java.math.BigDecimal
+import kotlin.Int
+import kotlin.String
+
+public data class V_test(
+  public val a: String?,
+  public val b: Int?,
+  public val c: BigDecimal?,
+)

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/queries/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/queries/DataQueries.kt
@@ -1,0 +1,39 @@
+package com.example.queries
+
+import app.cash.sqldelight.Query
+import app.cash.sqldelight.TransacterImpl
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.jdbc.JdbcCursor
+import com.example.migrations.V_test
+import java.math.BigDecimal
+import kotlin.Any
+import kotlin.Int
+import kotlin.String
+
+public class DataQueries(
+  driver: SqlDriver,
+) : TransacterImpl(driver) {
+  public fun <T : Any> select(mapper: (
+    a: String?,
+    b: Int?,
+    c: BigDecimal?,
+  ) -> T): Query<T> = Query(879_500_825, arrayOf("test"), driver, "Data.sq", "select", """
+  |SELECT a, b, c
+  |FROM v_test
+  """.trimMargin()) { cursor ->
+    check(cursor is JdbcCursor)
+    mapper(
+      cursor.getString(0),
+      cursor.getInt(1),
+      cursor.getBigDecimal(2)
+    )
+  }
+
+  public fun select(): Query<V_test> = select { a, b, c ->
+    V_test(
+      a,
+      b,
+      c
+    )
+  }
+}


### PR DESCRIPTION
fixes #5407 

* Add grammar for `CREATE OR REPLACE VIEW`
* Add basic annotations where only appending new column is allowed by PostgreSql
* Add fixture test
* Add migration test

Awaiting on https://github.com/AlecKazakova/sql-psi/pull/644 where updates are needed
to supported schema changes in views