### PR TITLE
Share gradle test kit directory between test suites

### DIFF
--- a/sqldelight-gradle-plugin/src/grammarkitTest/kotlin/app/cash/sqldelight/GrammarkitDialectIntegrationTests.kt
+++ b/sqldelight-gradle-plugin/src/grammarkitTest/kotlin/app/cash/sqldelight/GrammarkitDialectIntegrationTests.kt
@@ -33,6 +33,6 @@ class GrammarkitDialectIntegrationTests {
       |
       """.trimMargin(),
     )
-    return withProjectDir(projectRoot)
+    return withProjectDir(projectRoot).withTestKitDir(File("build/gradle-test-kit").absoluteFile)
   }
 }

--- a/sqldelight-gradle-plugin/src/instrumentationTest/kotlin/app/cash/sqldelight/WithCommonConfiguration.kt
+++ b/sqldelight-gradle-plugin/src/instrumentationTest/kotlin/app/cash/sqldelight/WithCommonConfiguration.kt
@@ -14,5 +14,5 @@ internal fun GradleRunner.withCommonConfiguration(projectRoot: File): GradleRunn
   File(projectRoot, "local.properties").apply {
     if (!exists()) writeText("sdk.dir=${androidHome()}\n")
   }
-  return withProjectDir(projectRoot)
+  return withProjectDir(projectRoot).withTestKitDir(File("build/gradle-test-kit").absoluteFile)
 }

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/WithCommonConfiguration.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/WithCommonConfiguration.kt
@@ -11,5 +11,5 @@ internal fun GradleRunner.withCommonConfiguration(projectRoot: File): GradleRunn
       |
     """.trimMargin(),
   )
-  return withProjectDir(projectRoot)
+  return withProjectDir(projectRoot).withTestKitDir(File("build/gradle-test-kit").absoluteFile)
 }


### PR DESCRIPTION
Reduces the amount of disk space needed to run tests by sharing installs/caches

Part of why our CI runs are failing right now is because we're running out of disk space. The gradle test kit directory eats up a lot of space and a separate one is created for each test suite.