### PR TITLE
Reduce the number of gradle versions we check

### DIFF
--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/integrations/GradleVersionsTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/integrations/GradleVersionsTest.kt
@@ -20,6 +20,7 @@ import com.google.common.truth.Truth.assertThat
 import java.io.File
 import java.nio.file.Files
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.util.GradleVersion
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -35,8 +36,7 @@ class GradleVersionsTest(private val gradleVersion: String) {
       // We use version catalogs in tests too but this feature is only stable since 7.4.
       // Test MIN_GRADLE_VERSION too if MIN_GRADLE_VERSION is higher than 7.4.
       "7.4.2",
-      "7.6.1",
-      "8.0.2",
+      GradleVersion.current().version,
     )
   }
 


### PR DESCRIPTION
Test against the minimum and current versions of gradle (that SQLDelight was built against)

This slightly reduces the amount of stuff we need to download (by a few hundred MB)