### PR TITLE
[CHORE] Enable gradle configuration-cache, parallel and caching

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,8 @@
 org.gradle.jvmargs=-Xmx16g -XX:MaxMetaspaceSize=4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configuration-cache=true
+
 GROUP=app.cash.sqldelight
 VERSION_NAME=2.1.0-SNAPSHOT
 


### PR DESCRIPTION
### Issue 
While setting up the project locally it took around 25 min running configuration alone 

### Tested commands

*  `./gradlew build`
* `./gradlew publishToMavenLocal`

### Workflows 
In case some work flow can turn off using `--no-configuration-cache`

If this was tested before and caused build issue can ignore :D 