### PR TITLE
Remove old minSdk declared in manifest

### DIFF
--- a/sqldelight-gradle-plugin/src/test/integration-android/src/main/AndroidManifest.xml
+++ b/sqldelight-gradle-plugin/src/test/integration-android/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-  <uses-sdk android:minSdkVersion="9"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
 </manifest>


### PR DESCRIPTION
It wasn't honored, anyway.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
