### PR TITLE
Use assignment syntax where appropriate

### DIFF
--- a/drivers/android-driver/build.gradle
+++ b/drivers/android-driver/build.gradle
@@ -11,7 +11,7 @@ base {
 }
 
 android {
-  compileSdk libs.versions.compileSdk.get() as int
+  compileSdk = libs.versions.compileSdk.get() as int
   namespace = "app.cash.sqldelight.driver.android"
 
   lint {
@@ -19,7 +19,7 @@ android {
   }
 
   defaultConfig {
-    minSdk libs.versions.minSdk.get() as int
+    minSdk = libs.versions.minSdk.get() as int
   }
 
   buildFeatures {

--- a/sample/android/build.gradle
+++ b/sample/android/build.gradle
@@ -8,7 +8,7 @@ kotlin.jvmToolchain {
 }
 
 android {
-  compileSdk libs.versions.compileSdk.get() as int
+  compileSdk = libs.versions.compileSdk.get() as int
   namespace = "com.example.sqldelight.hockey"
 
   defaultConfig {

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/android/PackageName.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/android/PackageName.kt
@@ -12,7 +12,7 @@ internal fun Project.packageName(): String {
     |SqlDelight requires a package name to be set. This can be done via the android namespace:
     |
     |android {
-    |  namespace "com.example.mypackage"
+    |  namespace = "com.example.mypackage"
     |}
     |
     |or the sqldelight configuration:

--- a/sqldelight-gradle-plugin/src/test/fulfilled-table-variant/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/fulfilled-table-variant/build.gradle
@@ -4,9 +4,9 @@ plugins {
 }
 
 android {
-  namespace "com.example.sqldelight"
+  namespace = "com.example.sqldelight"
 
-  compileSdk libs.versions.compileSdk.get() as int
+  compileSdk = libs.versions.compileSdk.get() as int
 
   lint {
     textReport true

--- a/sqldelight-gradle-plugin/src/test/integration-android-library/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-android-library/build.gradle
@@ -25,12 +25,12 @@ sqldelight {
 }
 
 android {
-  namespace "app.cash.sqldelight.integration"
+  namespace = "app.cash.sqldelight.integration"
 
-  compileSdk libs.versions.compileSdk.get() as int
+  compileSdk = libs.versions.compileSdk.get() as int
 
   defaultConfig {
-    minSdk libs.versions.minSdk.get() as int
+    minSdk = libs.versions.minSdk.get() as int
 
     testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
   }

--- a/sqldelight-gradle-plugin/src/test/integration-android-variants/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-android-variants/build.gradle
@@ -22,12 +22,12 @@ sqldelight {
 }
 
 android {
-  namespace "app.cash.sqldelight.integration"
+  namespace = "app.cash.sqldelight.integration"
 
-  compileSdk libs.versions.compileSdk.get() as int
+  compileSdk = libs.versions.compileSdk.get() as int
 
   defaultConfig {
-    minSdk libs.versions.minSdk.get() as int
+    minSdk = libs.versions.minSdk.get() as int
   }
 
   compileOptions {

--- a/sqldelight-gradle-plugin/src/test/integration-android/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-android/build.gradle
@@ -25,12 +25,12 @@ sqldelight {
 }
 
 android {
-  namespace "app.cash.sqldelight.integration"
+  namespace = "app.cash.sqldelight.integration"
 
-  compileSdk libs.versions.compileSdk.get() as int
+  compileSdk = libs.versions.compileSdk.get() as int
 
   defaultConfig {
-    minSdk libs.versions.minSdk.get() as int
+    minSdk = libs.versions.minSdk.get() as int
 
     testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
   }

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/CompilationUnitTests.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/CompilationUnitTests.kt
@@ -175,8 +175,8 @@ class CompilationUnitTests {
         |}
         |
         |android {
-        |  namespace 'com.example.namespace'
-        |  compileSdk libs.versions.compileSdk.get() as int
+        |  namespace = 'com.example.namespace'
+        |  compileSdk = libs.versions.compileSdk.get() as int
         |
         |  buildTypes {
         |    release {}
@@ -246,8 +246,8 @@ class CompilationUnitTests {
         |}
         |
         |android {
-        |  namespace 'com.example.namespace'
-        |  compileSdk libs.versions.compileSdk.get() as int
+        |  namespace = 'com.example.namespace'
+        |  compileSdk = libs.versions.compileSdk.get() as int
         |
         |  buildTypes {
         |    release {}

--- a/sqldelight-gradle-plugin/src/test/library-project/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/library-project/build.gradle
@@ -4,9 +4,9 @@ plugins {
 }
 
 android {
-  namespace "com.example.sqldelight"
+  namespace = "com.example.sqldelight"
 
-  compileSdk libs.versions.compileSdk.get() as int
+  compileSdk = libs.versions.compileSdk.get() as int
 
   lint {
     textReport true

--- a/sqldelight-gradle-plugin/src/test/multi-module/AndroidProject/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/multi-module/AndroidProject/build.gradle
@@ -16,9 +16,9 @@ sqldelight {
 }
 
 android {
-  namespace "com.example.sqldelight"
+  namespace = "com.example.sqldelight"
 
-  compileSdk libs.versions.compileSdk.get() as int
+  compileSdk = libs.versions.compileSdk.get() as int
 
   compileOptions {
     sourceCompatibility = '1.8'

--- a/sqldelight-gradle-plugin/src/test/multi-module/MultiplatformProject/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/multi-module/MultiplatformProject/build.gradle
@@ -16,9 +16,9 @@ sqldelight {
 }
 
 android {
-  namespace "app.cash.sqldelight.multiplatform.project"
+  namespace = "app.cash.sqldelight.multiplatform.project"
 
-  compileSdk libs.versions.compileSdk.get() as int
+  compileSdk = libs.versions.compileSdk.get() as int
 
   compileOptions {
     sourceCompatibility = '1.8'

--- a/sqldelight-gradle-plugin/src/test/no-kotlin-android-agp8/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/no-kotlin-android-agp8/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-  compileSdk libs.versions.compileSdk.get() as int
+  compileSdk = libs.versions.compileSdk.get() as int
 
   lint {
     textReport true

--- a/sqldelight-gradle-plugin/src/test/properties-file-android/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/properties-file-android/build.gradle
@@ -4,9 +4,9 @@ plugins {
 }
 
 android {
-  namespace "com.example"
+  namespace = "com.example"
 
-  compileSdk libs.versions.compileSdk.get() as int
+  compileSdk = libs.versions.compileSdk.get() as int
 
   defaultConfig {
     minSdk 30

--- a/sqldelight-gradle-plugin/src/test/schema-file-android/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/schema-file-android/build.gradle
@@ -4,9 +4,9 @@ plugins {
 }
 
 android {
-  namespace "com.example.sqldelight"
+  namespace = "com.example.sqldelight"
 
-  compileSdk libs.versions.compileSdk.get() as int
+  compileSdk = libs.versions.compileSdk.get() as int
 
   lint {
     textReport true

--- a/sqldelight-gradle-plugin/src/test/variants/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/variants/build.gradle
@@ -7,12 +7,12 @@ apply plugin: 'com.android.application'
 apply plugin: 'app.cash.sqldelight'
 
 android {
-  namespace "com.example.sqldelight"
+  namespace = "com.example.sqldelight"
 
-  compileSdk libs.versions.compileSdk.get() as int
+  compileSdk = libs.versions.compileSdk.get() as int
 
   defaultConfig {
-    minSdk libs.versions.minSdk.get() as int
+    minSdk = libs.versions.minSdk.get() as int
   }
 
   lint {

--- a/sqldelight-gradle-plugin/src/test/working-variants/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/working-variants/build.gradle
@@ -4,9 +4,9 @@ plugins {
 }
 
 android {
-  namespace "com.example.sqldelight"
+  namespace = "com.example.sqldelight"
 
-  compileSdk libs.versions.compileSdk.get() as int
+  compileSdk = libs.versions.compileSdk.get() as int
 
   defaultConfig {
     applicationId "com.sample"


### PR DESCRIPTION
Future Groovy will remove the ability to call these as functions (which is what the space implicitly is doing).

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
