### PR TITLE
Set compatibility for build logic

### DIFF
--- a/buildLogic/build.gradle
+++ b/buildLogic/build.gradle
@@ -1,0 +1,19 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
+plugins {
+  alias(libs.plugins.kotlin.jvm) apply false
+}
+
+allprojects {
+  tasks.withType(JavaCompile).configureEach {
+    sourceCompatibility = '11'
+    targetCompatibility = '11'
+  }
+
+  tasks.withType(KotlinJvmCompile).configureEach {
+    compilerOptions {
+      jvmTarget = JvmTarget.JVM_11
+    }
+  }
+}


### PR DESCRIPTION
Otherwise you can't use with JDK 25 currently.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
