### PR TITLE
Allow tags and snapshots to publish concurrently

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -8,7 +8,7 @@ on:
       - '*'
 
 concurrency:
-  group: "release"
+  group: "release-${{ github.ref }}"
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Previously, when doing a release, the commit gets pushed up before the tag. So this concurrency grouping prevented the tag from publishing while we wait for the commit to publish the next snapshot. This should separate the branch and the tag and allow them to run at the same time.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
