### PR TITLE
Publish NPM after artifacts

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -72,6 +72,7 @@ jobs:
     if: github.repository == 'sqldelight/sqldelight'
     permissions:
       contents: read
+    needs: publish_archives
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Artifacts are most likely to fail, so just wait for them (we do the same with the IDE plugin).

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
