### PR TITLE
Replace Markdown references with @-mentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,35 +9,35 @@ Nothing yet!
 [2.2.1]: https://github.com/sqldelight/sqldelight/releases/tag/2.2.1
 
 ### Added
-- [PostgreSQL Dialect] Fix Postgres numeric/integer/biginteger type mapping (#5994 by [Griffio][griffio])
-- [Compiler] Improve the compiler error message to include source file location when a CAST is required (#5979 by [Griffio][griffio])
-- [PostgreSQL Dialect] Add support for Postgres JSON operator path extraction (#5971 by [Griffio][griffio])
-- [SQLite Dialect] Add Sqlite 3.35 support for MATERIALIZED query planner hint using Common Table Expressions (#5961 by [Griffio][griffio])
-- [PostgreSQL Dialect] Add support for MATERIALIZED query planner hint using Common Table Expressions (#5961 by [Griffio][griffio])
-- [PostgreSQL Dialect] Add support for Postgres JSON Aggregate FILTER (#5957 by [Griffio][griffio])
-- [PostgreSQL Dialect] Add support for Postgres Enums (#5935 by [Griffio][griffio])
-- [PostgreSQL Dialect] Add limited support for Postgres Triggers (#5932 by [Griffio][griffio])
-- [PostgreSQL Dialect] Add predicate to check whether SQL expression can be parsed as JSON (#5843 by [Griffio][griffio])
-- [PostgreSQL Dialect] Add limited support for PostgreSql Comment On statement (#5808 by [Griffio][griffio])
-- [MySQL Dialect] Add support for index visibility options (#5785 by [Oren Kislev][orenkislev-faire])
-- [PostgreSql Dialect] Add support for TSQUERY data type (#5779 by [Griffio][griffio])
-- [Gradle Plugin] Add support for version catalogs when adding modules (#5755 by [Michael Rittmeister][DRSchlaubi])
+- [PostgreSQL Dialect] Fix Postgres numeric/integer/biginteger type mapping (#5994 by @griffio)
+- [Compiler] Improve the compiler error message to include source file location when a CAST is required (#5979 by @griffio)
+- [PostgreSQL Dialect] Add support for Postgres JSON operator path extraction (#5971 by @griffio)
+- [SQLite Dialect] Add Sqlite 3.35 support for MATERIALIZED query planner hint using Common Table Expressions (#5961 by @griffio)
+- [PostgreSQL Dialect] Add support for MATERIALIZED query planner hint using Common Table Expressions (#5961 by @griffio)
+- [PostgreSQL Dialect] Add support for Postgres JSON Aggregate FILTER (#5957 by @griffio)
+- [PostgreSQL Dialect] Add support for Postgres Enums (#5935 by @griffio)
+- [PostgreSQL Dialect] Add limited support for Postgres Triggers (#5932 by @griffio)
+- [PostgreSQL Dialect] Add predicate to check whether SQL expression can be parsed as JSON (#5843 by @griffio)
+- [PostgreSQL Dialect] Add limited support for PostgreSql Comment On statement (#5808 by @griffio)
+- [MySQL Dialect] Add support for index visibility options (#5785 by @orenkislev-faire)
+- [PostgreSql Dialect] Add support for TSQUERY data type (#5779 by @griffio)
+- [Gradle Plugin] Add support for version catalogs when adding modules (#5755 by @DRSchlaubi)
 
 ### Changed
 - In-development snapshots are now published to the Central Portal Snapshots repository at https://central.sonatype.com/repository/maven-snapshots/.
-- [Compiler] Simplified default generated queries using constructor references (#5814 by [Jon Poulton][jonapoul])
+- [Compiler] Simplified default generated queries using constructor references (#5814 by @jonapoul)
 
 ### Fixed
-- [Compiler] Fix stack overflow when using View containing Common Table Expression (#5928 by [Griffio][griffio])
-- [Gradle Plugin] Fix crash when opening SqlDelight tool window to add "New Connection" (#5906 by [Griffio][griffio])
-- [IntelliJ Plugin] Avoid threading-related crash in the copy-to-sqlite gutter action (#5901 by [Griffio][griffio])
-- [IntelliJ Plugin] Fix for PostgreSql dialect when using schema statements CREATE INDEX and CREATE VIEW (#5772 by [Griffio][griffio])
-- [Compiler] Fix FTS stack overflow when referencing columns (#5896 by [Griffio][griffio])
-- [Compiler] Fix With Recursive stack overflow (#5892 by [Griffio][griffio])
-- [Compiler] Fix Notify for Insert|Update|Delete Returning statements (#5851 by [Griffio][griffio])
-- [Compiler] Fix async result type for transaction blocks returning Long (#5836 by [Griffio][griffio])
-- [Compiler] Optimize SQL parameter binding from O(n²) to O(n) complexity (#5898 by [Chen Frenkel][chenf7])
-- [SQLite Dialect] Fix Sqlite 3.18 missing functions (#5759 by [Griffio][griffio])
+- [Compiler] Fix stack overflow when using View containing Common Table Expression (#5928 by @griffio)
+- [Gradle Plugin] Fix crash when opening SqlDelight tool window to add "New Connection" (#5906 by @griffio)
+- [IntelliJ Plugin] Avoid threading-related crash in the copy-to-sqlite gutter action (#5901 by @griffio)
+- [IntelliJ Plugin] Fix for PostgreSql dialect when using schema statements CREATE INDEX and CREATE VIEW (#5772 by @griffio)
+- [Compiler] Fix FTS stack overflow when referencing columns (#5896 by @griffio)
+- [Compiler] Fix With Recursive stack overflow (#5892 by @griffio)
+- [Compiler] Fix Notify for Insert|Update|Delete Returning statements (#5851 by @griffio)
+- [Compiler] Fix async result type for transaction blocks returning Long (#5836 by @griffio)
+- [Compiler] Optimize SQL parameter binding from O(n²) to O(n) complexity (#5898 by @chenf7)
+- [SQLite Dialect] Fix Sqlite 3.18 missing functions (#5759 by @griffio)
 
 
 ## [2.2.0] - 2025-11-13
@@ -50,59 +50,59 @@ Failed release with partially published artifacts. Use 2.2.1!
 [2.1.0]: https://github.com/sqldelight/sqldelight/releases/tag/2.1.0
 
 ### Added
-- [WASM Driver] Add support for wasmJs to web worker driver (#5534 by [Ilya Gulya][IlyaGulya])
-- [PostgreSQL Dialect] Support PostgreSql UnNest Array to rows  (#5673 by [Griffio][griffio])
-- [PostgreSQL Dialect] PostgreSql TSRANGE/TSTZRANGE support (#5297 by [Griffio][griffio])
-- [PostgreSQL Dialect] PostgreSql Right Full Join (#5086 by [Griffio][griffio])
-- [PostgreSQL Dialect] Postrgesql extract from temporal types (#5273 by [Griffio][griffio])
-- [PostgreSQL Dialect] PostgreSql array contains operators (#4933 by [Griffio][griffio])
-- [PostgreSQL Dialect] PostgreSql drop constraint (#5288 by [Griffio][griffio])
-- [PostgreSQL Dialect] Postgresql type casting (#5089 by [Griffio][griffio])
-- [PostgreSQL Dialect] PostgreSql lateral join operator for subquery (#5122 by [Griffio][griffio])
-- [PostgreSQL Dialect] Postgresql ILIKE operator (#5330 by [Griffio][griffio])
-- [PostgreSQL Dialect] PostgreSql XML type (#5331 by [Griffio][griffio])
-- [PostgreSQL Dialect] PostgreSql AT TIME ZONE (#5243 by [Griffio][griffio])
-- [PostgreSQL Dialect] Support postgresql order by nulls (#5199 by [Griffio][griffio])
-- [PostgreSQL Dialect] Add PostgreSQL current date/time function support (#5226 by [Drew Dobson][drewd])
-- [PostgreSQL Dialect] PostgreSql Regex operators (#5137 by [Griffio][griffio])
-- [PostgreSQL Dialect] add brin gist (#5059 by [Griffio][griffio])
-- [MySQL Dialect] Support RENAME INDEX for MySql dialect (#5212 by [Oren Kislev][orenkislev-faire])
-- [JSON Extension] Add alias to json table function (#5372 by [Griffio][griffio])
+- [WASM Driver] Add support for wasmJs to web worker driver (#5534 by @IlyaGulya)
+- [PostgreSQL Dialect] Support PostgreSql UnNest Array to rows  (#5673 by @griffio)
+- [PostgreSQL Dialect] PostgreSql TSRANGE/TSTZRANGE support (#5297 by @griffio)
+- [PostgreSQL Dialect] PostgreSql Right Full Join (#5086 by @griffio)
+- [PostgreSQL Dialect] Postrgesql extract from temporal types (#5273 by @griffio)
+- [PostgreSQL Dialect] PostgreSql array contains operators (#4933 by @griffio)
+- [PostgreSQL Dialect] PostgreSql drop constraint (#5288 by @griffio)
+- [PostgreSQL Dialect] Postgresql type casting (#5089 by @griffio)
+- [PostgreSQL Dialect] PostgreSql lateral join operator for subquery (#5122 by @griffio)
+- [PostgreSQL Dialect] Postgresql ILIKE operator (#5330 by @griffio)
+- [PostgreSQL Dialect] PostgreSql XML type (#5331 by @griffio)
+- [PostgreSQL Dialect] PostgreSql AT TIME ZONE (#5243 by @griffio)
+- [PostgreSQL Dialect] Support postgresql order by nulls (#5199 by @griffio)
+- [PostgreSQL Dialect] Add PostgreSQL current date/time function support (#5226 by @drewd)
+- [PostgreSQL Dialect] PostgreSql Regex operators (#5137 by @griffio)
+- [PostgreSQL Dialect] add brin gist (#5059 by @griffio)
+- [MySQL Dialect] Support RENAME INDEX for MySql dialect (#5212 by @orenkislev-faire)
+- [JSON Extension] Add alias to json table function (#5372 by @griffio)
 
 ### Changed
-- [Compiler] Generated query files return row counts for simple mutators (#4578 by [Marius Volkhart][MariusV])
-- [Native Driver] Update NativeSqlDatabase.kt to change readonly flag for DELETE, INSERT, and UPDATE statements (#5680 by [Griffio][griffio])
-- [PostgreSQL Dialect] Change PgInterval to String (#5403 by [Griffio][griffio])
-- [PostgreSQL Dialect] Support SqlDelight modules to implement PostgreSql extensions (#5677 by [Griffio][griffio])
+- [Compiler] Generated query files return row counts for simple mutators (#4578 by @MariusVolkhart)
+- [Native Driver] Update NativeSqlDatabase.kt to change readonly flag for DELETE, INSERT, and UPDATE statements (#5680 by @griffio)
+- [PostgreSQL Dialect] Change PgInterval to String (#5403 by @griffio)
+- [PostgreSQL Dialect] Support SqlDelight modules to implement PostgreSql extensions (#5677 by @griffio)
 
 ### Fixed
-- [Compiler] fix: notify queries when executing group statements with result (#5006 by [Vitor Hugo Schwaab][vitorhugods])
-- [Compiler] Fix SqlDelightModule type resolver (#5625 by [Griffio][griffio])
-- [Compiler] Fix 5501 insert object escaped column (#5503 by [Griffio][griffio])
-- [Compiler] Compiler: Improve error message such that path links are clickable with the correct line & char position. (#5604 by [Niklas Baudy][vanniktech])
+- [Compiler] fix: notify queries when executing group statements with result (#5006 by @vitorhugods)
+- [Compiler] Fix SqlDelightModule type resolver (#5625 by @griffio)
+- [Compiler] Fix 5501 insert object escaped column (#5503 by @griffio)
+- [Compiler] Compiler: Improve error message such that path links are clickable with the correct line & char position. (#5604 by @vanniktech)
 - [Compiler] Fix issue 5298: allow keywords to be used as table names
 - [Compiler] fix named executes and add test
-- [Compiler] Consider foreign key table constraints when sorting initialization statements (#5325 by [Leon Linhart][TheMrMilchmann])
-- [Compiler] Align error underlines properly when tabs are involved (#5224 by [Drew Dobson][drewd])
+- [Compiler] Consider foreign key table constraints when sorting initialization statements (#5325 by @TheMrMilchmann)
+- [Compiler] Align error underlines properly when tabs are involved (#5224 by @drewd)
 - [JDBC Driver] Fix memory leak for connectionManager during end of transaction
-- [JDBC Driver] Run SQLite migrations inside transaction as mentioned in documentation (#5218 by [Lukáš Moravec][morki])
-- [JDBC Driver] Fix leaking connections after transaction commit / rollback (#5205 by [Lukáš Moravec][morki])
-- [Gradle Plugin] Execute `DriverInitializer` before `GenerateSchemaTask` (#5562 by [Emeka Nwagu][nwagu])
-- [Runtime] Fix crash in LogSqliteDriver when real driver is Async (#5723 by [Eric Denman][edenman])
-- [Runtime] Fix StringBuilder capacity (#5192 by [Jan Bína][janbina])
-- [PostgreSQL Dialect] PostgreSql create or replace view (#5407 by [Griffio][griffio])
-- [PostgreSQL Dialect] Postgresql to_json (#5606 by [Griffio][griffio])
-- [PostgreSQL Dialect] PostgreSql numeric resolver (#5399 by [Griffio][griffio])
-- [PostgreSQL Dialect] sqlite windows function (#2799 by [Griffio][griffio])
-- [PostgreSQL Dialect] PostgreSql SELECT DISTINCT ON (#5345 by [Griffio][griffio])
-- [PostgreSQL Dialect] alter table add column if not exists (#5309 by [Griffio][griffio])
-- [PostgreSQL Dialect] Postgresql async bind parameter (#5313 by [Griffio][griffio])
-- [PostgreSQL Dialect] PostgreSql boolean literals (#5262 by [Griffio][griffio])
-- [PostgreSQL Dialect] PostgreSql window functions (#5155 by [Griffio][griffio])
-- [PostgreSQL Dialect] PostgreSql isNull isNotNull types (#5173 by [Griffio][griffio])
-- [PostgreSQL Dialect] PostgreSql select distinct (#5172 by [Griffio][griffio])
-- [Paging Extension] paging refresh initial load fix (#5615 by [Eva][evant])
-- [Paging Extension] Add MacOS native targets (#5324 by [Vitor Hugo Schwaab][vitorhugods])
+- [JDBC Driver] Run SQLite migrations inside transaction as mentioned in documentation (#5218 by @morki)
+- [JDBC Driver] Fix leaking connections after transaction commit / rollback (#5205 by @morki)
+- [Gradle Plugin] Execute `DriverInitializer` before `GenerateSchemaTask` (#5562 by @nwagu)
+- [Runtime] Fix crash in LogSqliteDriver when real driver is Async (#5723 by @edenman)
+- [Runtime] Fix StringBuilder capacity (#5192 by @janbina)
+- [PostgreSQL Dialect] PostgreSql create or replace view (#5407 by @griffio)
+- [PostgreSQL Dialect] Postgresql to_json (#5606 by @griffio)
+- [PostgreSQL Dialect] PostgreSql numeric resolver (#5399 by @griffio)
+- [PostgreSQL Dialect] sqlite windows function (#2799 by @griffio)
+- [PostgreSQL Dialect] PostgreSql SELECT DISTINCT ON (#5345 by @griffio)
+- [PostgreSQL Dialect] alter table add column if not exists (#5309 by @griffio)
+- [PostgreSQL Dialect] Postgresql async bind parameter (#5313 by @griffio)
+- [PostgreSQL Dialect] PostgreSql boolean literals (#5262 by @griffio)
+- [PostgreSQL Dialect] PostgreSql window functions (#5155 by @griffio)
+- [PostgreSQL Dialect] PostgreSql isNull isNotNull types (#5173 by @griffio)
+- [PostgreSQL Dialect] PostgreSql select distinct (#5172 by @griffio)
+- [Paging Extension] paging refresh initial load fix (#5615 by @evant)
+- [Paging Extension] Add MacOS native targets (#5324 by @vitorhugods)
 - [IntelliJ Plugin] K2 Support
 
 
@@ -110,39 +110,39 @@ Failed release with partially published artifacts. Use 2.2.1!
 [2.0.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.0.2
 
 ### Added
-- [PostgreSQL Dialect] Add PostgreSQL STRING_AGG function (#4950 by [André Danielsson][anddani])
-- [PostgreSQL Dialect] Add SET statement to pg dialect (#4927 by [Bastien de Luca][de-luca])
-- [PostgreSQL Dialect] Add PostgreSql alter column sequence parameters (#4916 by [Griffio][griffio])
-- [PostgreSQL Dialect] Add postgresql alter column default support for insert statement (#4912 by [Griffio][griffio])
-- [PostgreSQL Dialect] Add PostgreSql alter sequence and drop sequence (#4920 by [Griffio][griffio])
-- [PostgreSQL Dialect] Add Postgres Regex function definitions (#5025 by [Marius Volkhart][MariusV])
-- [PostgreSQL Dialect] Add grammar for GIN (#5027 by [Griffio][griffio])
+- [PostgreSQL Dialect] Add PostgreSQL STRING_AGG function (#4950 by @anddani)
+- [PostgreSQL Dialect] Add SET statement to pg dialect (#4927 by @de-luca)
+- [PostgreSQL Dialect] Add PostgreSql alter column sequence parameters (#4916 by @griffio)
+- [PostgreSQL Dialect] Add postgresql alter column default support for insert statement (#4912 by @griffio)
+- [PostgreSQL Dialect] Add PostgreSql alter sequence and drop sequence (#4920 by @griffio)
+- [PostgreSQL Dialect] Add Postgres Regex function definitions (#5025 by @MariusVolkhart)
+- [PostgreSQL Dialect] Add grammar for GIN (#5027 by @griffio)
 
 ### Changed
 - [IDE Plugin] Minimum version of 2023.1 / Android Studio Iguana
-- [Compiler] Allow overriding the type nullability in encapsulatingType (#4882 by [Eliezer Graber][eygraber])
+- [Compiler] Allow overriding the type nullability in encapsulatingType (#4882 by @eygraber)
 - [Compiler] Inline the column names for SELECT *
-- [Gradle Plugin] switch to processIsolation (#5068 by [Emeka Nwagu][nwagu])
-- [Android Runtime] Increase Android minSDK to 21 (#5094 by [Philip Wedemann][hfhbd])
-- [Drivers] Expose more JDBC/R2DBC statement methods for dialect authors (#5098 by [Philip Wedemann][hfhbd])
+- [Gradle Plugin] switch to processIsolation (#5068 by @nwagu)
+- [Android Runtime] Increase Android minSDK to 21 (#5094 by @hfhbd)
+- [Drivers] Expose more JDBC/R2DBC statement methods for dialect authors (#5098 by @hfhbd)
 
 ### Fixed
-- [PostgreSQL Dialect] Fix postgresql alter table alter column (#4868 by [Griffio][griffio])
-- [PostgreSQL Dialect] Fix 4448 missing import for table model (#4885 by [Griffio][griffio])
-- [PostgreSQL Dialect] Fixes 4932 postgresql default constraint functions (#4934 by [Griffio][griffio])
-- [PostgreSQL Dialect] fixes 4879 postgresql class-cast error in alter table rename column during migrations (#4880 by [Griffio][griffio])
-- [PostgreSQL Dialect] Fix 4474 PostgreSql create extension (#4541 by [Griffio][griffio])
-- [PostgreSQL Dialect] Fixes 5018 PostgreSql add Primary Key not nullable types (#5020 by [Griffio][griffio])
-- [PostgreSQL Dialect] Fixes 4703 aggregate expressions (#5071 by [Griffio][griffio])
-- [PostgreSQL Dialect] Fixes 5028 PostgreSql json (#5030 by [Griffio][griffio])
-- [PostgreSQL Dialect] Fixes 5040 PostgreSql json operators (#5041 by [Griffio][griffio])
-- [PostgreSQL Dialect] Fixes json operator binding for 5040 (#5100 by [Griffio][griffio])
-- [PostgreSQL Dialect] Fixes 5082 tsvector (#5104 by [Griffio][griffio])
-- [PostgreSQL Dialect] Fixes 5032 column adjacency for PostgreSql UPDATE FROM statement (#5035 by [Griffio][griffio])
-- [SQLite Dialect] fixes 4897 sqlite alter table rename column (#4899 by [Griffio][griffio])
-- [IDE Plugin] Fix error handler crash (#4988 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] BugSnag fails to init in IDEA 2023.3 (by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] PluginException when opening .sq file in IntelliJ via plugin (by [Alexander Perfilyev][aperfilyev])
+- [PostgreSQL Dialect] Fix postgresql alter table alter column (#4868 by @griffio)
+- [PostgreSQL Dialect] Fix 4448 missing import for table model (#4885 by @griffio)
+- [PostgreSQL Dialect] Fixes 4932 postgresql default constraint functions (#4934 by @griffio)
+- [PostgreSQL Dialect] fixes 4879 postgresql class-cast error in alter table rename column during migrations (#4880 by @griffio)
+- [PostgreSQL Dialect] Fix 4474 PostgreSql create extension (#4541 by @griffio)
+- [PostgreSQL Dialect] Fixes 5018 PostgreSql add Primary Key not nullable types (#5020 by @griffio)
+- [PostgreSQL Dialect] Fixes 4703 aggregate expressions (#5071 by @griffio)
+- [PostgreSQL Dialect] Fixes 5028 PostgreSql json (#5030 by @griffio)
+- [PostgreSQL Dialect] Fixes 5040 PostgreSql json operators (#5041 by @griffio)
+- [PostgreSQL Dialect] Fixes json operator binding for 5040 (#5100 by @griffio)
+- [PostgreSQL Dialect] Fixes 5082 tsvector (#5104 by @griffio)
+- [PostgreSQL Dialect] Fixes 5032 column adjacency for PostgreSql UPDATE FROM statement (#5035 by @griffio)
+- [SQLite Dialect] fixes 4897 sqlite alter table rename column (#4899 by @griffio)
+- [IDE Plugin] Fix error handler crash (#4988 by @aperfilyev)
+- [IDE Plugin] BugSnag fails to init in IDEA 2023.3 (by @aperfilyev)
+- [IDE Plugin] PluginException when opening .sq file in IntelliJ via plugin (by @aperfilyev)
 - [IDE Plugin] Dont bundle the kotlin lib into the intellij plugin as its already a plugin dependency (#5126)
 - [IDE Plugin] Use the extensions array instead of stream (#5127)
 
@@ -150,64 +150,64 @@ Failed release with partially published artifacts. Use 2.2.1!
 [2.0.1]: https://github.com/sqldelight/sqldelight/releases/tag/2.0.1
 
 ### Added
-- [Compiler] Add support multi-column-expr when doing a SELECT (#4453 by [Adriel Martinez][Adriel-M])
-- [PostgreSQL Dialect] Add support for PostgreSQL CREATE INDEX CONCURRENTLY (#4531 by [Griffio][griffio])
-- [PostgreSQL Dialect] Allow PostgreSQL CTEs auxiliary statements to reference each other (#4493 by [Griffio][griffio])
-- [PostgreSQL Dialect] Add support for PostgreSQL types for binary expr and sum (#4539 by [Adriel Martinez][Adriel-M])
-- [PostgreSQL Dialect] Add support for PostgreSQL SELECT DISTINCT ON syntax (#4584 by [Griffio][griffio])
-- [PostgreSQL Dialect] Add support for PostgreSQL JSON functions in SELECT statements (#4590 by [Marius Volkhart][MariusV])
-- [PostgreSQL Dialect] Add generate_series PostgreSQL function (#4717 by [Griffio][griffio])
-- [PostgreSQL Dialect] Add additional Postgres String function definitions (#4752 by [Marius Volkhart][MariusV])
-- [PostgreSQL Dialect] Add DATE PostgreSQL type to min and max aggregate functions (#4816 by [André Danielsson][anddani])
-- [PostgreSQL Dialect] Add PostgreSql temporal types to SqlBinaryExpr (#4657 by [Griifio][griffio])
-- [PostgreSQL Dialect] Add TRUNCATE to postgres dialect (#4817 by [Bastien de Luca][de-luca])
-- [SQLite 3.35 Dialect] Allow multiple ON CONFLICT clauses that are evaluated in order (#4551 by [Griffio][griffio])
-- [JDBC Driver] Add Language annotations for more pleasant SQL editing (#4602 by [Marius Volkhart][MariusV])
-- [Native Driver] Native-driver: add support for linuxArm64 (#4792 by [Philip Wedemann][hfhbd])
-- [Android Driver] Add a windowSizeBytes parameter to AndroidSqliteDriver (#4804 by [Benoit Lubek][BoD])
-- [Paging3 Extension] feat: add initialOffset for OffsetQueryPagingSource (#4802 by [Mohamad Jaara][MohamadJaara])
+- [Compiler] Add support multi-column-expr when doing a SELECT (#4453 by @Adriel-M)
+- [PostgreSQL Dialect] Add support for PostgreSQL CREATE INDEX CONCURRENTLY (#4531 by @griffio)
+- [PostgreSQL Dialect] Allow PostgreSQL CTEs auxiliary statements to reference each other (#4493 by @griffio)
+- [PostgreSQL Dialect] Add support for PostgreSQL types for binary expr and sum (#4539 by @Adriel-M)
+- [PostgreSQL Dialect] Add support for PostgreSQL SELECT DISTINCT ON syntax (#4584 by @griffio)
+- [PostgreSQL Dialect] Add support for PostgreSQL JSON functions in SELECT statements (#4590 by @MariusVolkhart)
+- [PostgreSQL Dialect] Add generate_series PostgreSQL function (#4717 by @griffio)
+- [PostgreSQL Dialect] Add additional Postgres String function definitions (#4752 by @MariusVolkhart)
+- [PostgreSQL Dialect] Add DATE PostgreSQL type to min and max aggregate functions (#4816 by @anddani)
+- [PostgreSQL Dialect] Add PostgreSql temporal types to SqlBinaryExpr (#4657 by @griffio)
+- [PostgreSQL Dialect] Add TRUNCATE to postgres dialect (#4817 by @de-luca)
+- [SQLite 3.35 Dialect] Allow multiple ON CONFLICT clauses that are evaluated in order (#4551 by @griffio)
+- [JDBC Driver] Add Language annotations for more pleasant SQL editing (#4602 by @MariusVolkhart)
+- [Native Driver] Native-driver: add support for linuxArm64 (#4792 by @hfhbd)
+- [Android Driver] Add a windowSizeBytes parameter to AndroidSqliteDriver (#4804 by @BoD)
+- [Paging3 Extension] feat: add initialOffset for OffsetQueryPagingSource (#4802 by @MohamadJaara)
 
 ### Changed
-- [Compiler] Prefer Kotlin types where appropriate (#4517 by [Eliezer Graber][eygraber])
+- [Compiler] Prefer Kotlin types where appropriate (#4517 by @eygraber)
 - [Compiler] When doing a value type insert always include the column names (#4864)
-- [PostgreSQL Dialect] Remove experimental status from PostgreSQL dialect (#4443 by [Philip Wedemann][hfhbd])
-- [PostgreSQL Dialect] Update docs for PostgreSQL types (#4569 by [Marius Volkhart][MariusV])
-- [R2DBC Driver] Optimize performance when handling integer data types in PostgreSQL (#4588 by [Marius Volkhart][MariusV])
+- [PostgreSQL Dialect] Remove experimental status from PostgreSQL dialect (#4443 by @hfhbd)
+- [PostgreSQL Dialect] Update docs for PostgreSQL types (#4569 by @MariusVolkhart)
+- [R2DBC Driver] Optimize performance when handling integer data types in PostgreSQL (#4588 by @MariusVolkhart)
 
 ### Removed
-- [SQLite Javascript Driver] Remove sqljs-driver (#4613, #4670 by [Derek Ellis][dellisd])
+- [SQLite Javascript Driver] Remove sqljs-driver (#4613, #4670 by @dellisd)
 
 ### Fixed
-- [Compiler] Fix compilation of grouped statements with returns and no parameters (#4699 by [Griffio][griffio])
-- [Compiler] Bind arguments with SqlBinaryExpr (#4604 by [Griffio][griffio])
-- [IDE Plugin] Use IDEA Project JDK if set (#4689 by [Griffio][griffio])
+- [Compiler] Fix compilation of grouped statements with returns and no parameters (#4699 by @griffio)
+- [Compiler] Bind arguments with SqlBinaryExpr (#4604 by @griffio)
+- [IDE Plugin] Use IDEA Project JDK if set (#4689 by @griffio)
 - [IDE Plugin] Fix "Unknown element type: TYPE_NAME" error in IDEA 2023.2 and greater (#4727)
 - [IDE Plugin] Fixed some compatibility issues with 2023.2
-- [Gradle Plugin] Correct documentation of verifyMigrationTask Gradle task (#4713 by [Josh Friend][joshfriend])
-- [Gradle Plugin] Add Gradle task output message to help users generate a database before verifying a database (#4684 by [Jingwei][jingwei99])
-- [PostgreSQL Dialect] Fix the renaming of PostgreSQL columns multiple times (#4566 by [Griffio][griffio])
-- [PostgreSQL Dialect] Fix 4714 postgresql alter column nullability (#4831 by [Griffio][griffio])
-- [PostgreSQL Dialect] Fix 4837 alter table alter column (#4846 by [Griffio][griffio])
-- [PostgreSQL Dialect] Fix 4501 PostgreSql sequence (#4528 by [Griffio][griffio])
-- [SQLite Dialect] Allow JSON binary operator to be used on a column expression (#4776 by [Eliezer Graber][eygraber])
-- [SQLite Dialect] Update From false positive for multiple columns found with name (#4777 by [Eliezer Graber][eygraber])
-- [Native Driver] Support named in-memory databases (#4662 by [Matthew Nelson][05nelsonm])
-- [Native Driver] Ensure thread safety for query listener collection (#4567 by [Kevin Galligan][kpgalligan])
-- [JDBC Driver] Fix a connection leak in the ConnectionManager (#4589 by [Marius Volkhart][MariusV])
-- [JDBC Driver] Fix JdbcSqliteDriver url parsing when choosing ConnectionManager type (#4656 by [Matthew Nelson][05nelsonm])
+- [Gradle Plugin] Correct documentation of verifyMigrationTask Gradle task (#4713 by @joshfriend)
+- [Gradle Plugin] Add Gradle task output message to help users generate a database before verifying a database (#4684 by @jingwei99)
+- [PostgreSQL Dialect] Fix the renaming of PostgreSQL columns multiple times (#4566 by @griffio)
+- [PostgreSQL Dialect] Fix 4714 postgresql alter column nullability (#4831 by @griffio)
+- [PostgreSQL Dialect] Fix 4837 alter table alter column (#4846 by @griffio)
+- [PostgreSQL Dialect] Fix 4501 PostgreSql sequence (#4528 by @griffio)
+- [SQLite Dialect] Allow JSON binary operator to be used on a column expression (#4776 by @eygraber)
+- [SQLite Dialect] Update From false positive for multiple columns found with name (#4777 by @eygraber)
+- [Native Driver] Support named in-memory databases (#4662 by @05nelsonm)
+- [Native Driver] Ensure thread safety for query listener collection (#4567 by @kpgalligan)
+- [JDBC Driver] Fix a connection leak in the ConnectionManager (#4589 by @MariusVolkhart)
+- [JDBC Driver] Fix JdbcSqliteDriver url parsing when choosing ConnectionManager type (#4656 by @05nelsonm)
 
 ## [2.0.0] - 2023-07-26
 [2.0.0]: https://github.com/sqldelight/sqldelight/releases/tag/2.0.0
 
 ### Added
-- [MySQL Dialect] MySQL: support timestamp/bigint in IF expression (#4329 by [Mike Gershunovsky][shellderp])
-- [MySQL Dialect] MySQL: Add now (#4431 by [Philip Wedemann][hfhbd])
+- [MySQL Dialect] MySQL: support timestamp/bigint in IF expression (#4329 by @shellderp)
+- [MySQL Dialect] MySQL: Add now (#4431 by @hfhbd)
 - [Web Driver] Enable NPM package publishing (#4364)
 - [IDE Plugin] Allow users to show the stacktrace when the gradle tooling connect fails (#4383)
 
 ### Changed
-- [Sqlite Driver] Simplify using schema migrations for JdbcSqliteDriver (#3737 by [Lukáš Moravec][morki])
-- [R2DBC Driver] Real async R2DBC cursor (#4387 by [Philip Wedemann][hfhbd])
+- [Sqlite Driver] Simplify using schema migrations for JdbcSqliteDriver (#3737 by @morki)
+- [R2DBC Driver] Real async R2DBC cursor (#4387 by @hfhbd)
 
 ### Fixed
 - [IDE Plugin] Dont instantiate the database project service until needed (#4382)
@@ -218,109 +218,109 @@ Failed release with partially published artifacts. Use 2.2.1!
 - [IDE Plugin] Wait for the index to be ready before performing a search (#4419)
 - [IDE Plugin] Dont perform a goto if the index is unavailable (#4420)
 - [Compiler] Fix result expression for grouped statements (#4378)
-- [Compiler] Don't use virtual table as interface type (#4427 by [Philip Wedemann][hfhbd])
+- [Compiler] Don't use virtual table as interface type (#4427 by @hfhbd)
 
 ## [2.0.0-rc02] - 2023-06-27
 [2.0.0-rc02]: https://github.com/sqldelight/sqldelight/releases/tag/2.0.0-rc02
 
 ### Added
-- [MySQL Dialect] support lowercase date types and min and max on date types (#4243 by [Mike Gershunovsky][shellderp])
-- [MySQL Dialect] support mysql types for binary expr and sum (#4254 by [Mike Gershunovsky][shellderp])
-- [MySQL Dialect] support unsigned ints without display width (#4306 by [Mike Gershunovsky][shellderp])
+- [MySQL Dialect] support lowercase date types and min and max on date types (#4243 by @shellderp)
+- [MySQL Dialect] support mysql types for binary expr and sum (#4254 by @shellderp)
+- [MySQL Dialect] support unsigned ints without display width (#4306 by @shellderp)
 - [MySQL Dialect] Support LOCK IN SHARED MODE
-- [PostgreSQL Dialect] Add boolean and Timestamp to min max (#4245 by [Griffio][griffio])
-- [PostgreSQL Dialect] Postgres: Add window function support (#4283 by [Philip Wedemann][hfhbd])
-- [Runtime] Add linuxArm64, androidNative and watchosDeviceArm targets to runtime (#4258 by [Philip Wedemann][hfhbd])
-- [Paging Extension] Add linux and mingw x64 target to the paging extension (#4280 by [Cedric Hippmann][chippman])
+- [PostgreSQL Dialect] Add boolean and Timestamp to min max (#4245 by @griffio)
+- [PostgreSQL Dialect] Postgres: Add window function support (#4283 by @hfhbd)
+- [Runtime] Add linuxArm64, androidNative and watchosDeviceArm targets to runtime (#4258 by @hfhbd)
+- [Paging Extension] Add linux and mingw x64 target to the paging extension (#4280 by @chippman)
 
 ### Changed
 - [Gradle Plugin] Add automatic dialect support for Android API 34 (#4251)
-- [Paging Extension] Add support for SuspendingTransacter in QueryPagingSource (#4292 by [Ilya Polenov][daio])
-- [Runtime] Improve addListener api (#4244 by [Philip Wedemann][hfhbd])
-- [Runtime] Use Long as migration version (#4297 by [Philip Wedemann][hfhbd])
+- [Paging Extension] Add support for SuspendingTransacter in QueryPagingSource (#4292 by @daio)
+- [Runtime] Improve addListener api (#4244 by @hfhbd)
+- [Runtime] Use Long as migration version (#4297 by @hfhbd)
 
 ### Fixed
-- [Gradle Plugin] Use stable output path for generated source (#4269 by [Josh Friend][joshfriend])
-- [Gradle Plugin] Gradle tweaks (#4222 by [Matthew Haughton][3flex])
+- [Gradle Plugin] Use stable output path for generated source (#4269 by @joshfriend)
+- [Gradle Plugin] Gradle tweaks (#4222 by @3flex)
 
 ## [2.0.0-rc01] - 2023-05-29
 [2.0.0-rc01]: https://github.com/sqldelight/sqldelight/releases/tag/2.0.0-rc01
 
 ### Added
-- [Paging] Add js browser target to paging extensions (#3843 by [Sean Proctor][sproctor])
+- [Paging] Add js browser target to paging extensions (#3843 by @sproctor)
 - [Paging] Add iosSimulatorArm64 target to androidx-paging3 extension (#4117)
-- [PostgreSQL Dialect] add support and test for gen_random_uuid() (#3855 by [David Wheeler][davidwheeler123])
-- [PostgreSQL Dialect] Alter table add constraint postgres (#4116 by [Griffio][griffio])
-- [PostgreSQL Dialect] Alter table add constraint check (#4120 by [Griffio][griffio])
-- [PostgreSQL Dialect] Add postgreSql character length functions (#4121 by [Griffio][griffio])
-- [PostgreSQL Dialect] Add postgreSql column default interval (#4142 by [Griffio][griffio])
-- [PostgreSQL Dialect] Add postgreSql interval column result (#4152 by [Griffio][griffio])
-- [PostgreSQL Dialect] Add postgreSql Alter Column (#4165 by [Griffio][griffio])
-- [PostgreSQL Dialect] PostgreSQL: Add date_part (#4198 by [Philip Wedemann][hfhbd])
-- [MySQL Dialect] Add sql char length functions (#4134 by [Griffio][griffio])
-- [IDE Plugin] Add sqldelight directory suggestions (#3976 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Compact middle packages in project tree (#3992 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Add join clause completion (#4086 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Create view intention and live template (#4074 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Warn about missing WHERE inside DELETE or UPDATE (#4058 by [Alexander Perfilyev][aperfilyev])
-- [Gradle Plugin] Enable typesafe project accessors (#4005 by [Philip Wedemann][hfhbd])
+- [PostgreSQL Dialect] add support and test for gen_random_uuid() (#3855 by @davidwheeler123)
+- [PostgreSQL Dialect] Alter table add constraint postgres (#4116 by @griffio)
+- [PostgreSQL Dialect] Alter table add constraint check (#4120 by @griffio)
+- [PostgreSQL Dialect] Add postgreSql character length functions (#4121 by @griffio)
+- [PostgreSQL Dialect] Add postgreSql column default interval (#4142 by @griffio)
+- [PostgreSQL Dialect] Add postgreSql interval column result (#4152 by @griffio)
+- [PostgreSQL Dialect] Add postgreSql Alter Column (#4165 by @griffio)
+- [PostgreSQL Dialect] PostgreSQL: Add date_part (#4198 by @hfhbd)
+- [MySQL Dialect] Add sql char length functions (#4134 by @griffio)
+- [IDE Plugin] Add sqldelight directory suggestions (#3976 by @aperfilyev)
+- [IDE Plugin] Compact middle packages in project tree (#3992 by @aperfilyev)
+- [IDE Plugin] Add join clause completion (#4086 by @aperfilyev)
+- [IDE Plugin] Create view intention and live template (#4074 by @aperfilyev)
+- [IDE Plugin] Warn about missing WHERE inside DELETE or UPDATE (#4058 by @aperfilyev)
+- [Gradle Plugin] Enable typesafe project accessors (#4005 by @hfhbd)
 
 ### Changed
-- [Gradle Plugin] Allow registering DriverInitializer for VerifyMigrationTask with ServiceLoader mechanism (#3986 by [Alex Doubov][C2H6O])
-- [Gradle Plugin] Create explicit compiler env (#4079 by [Philip Wedemann][hfhbd])
+- [Gradle Plugin] Allow registering DriverInitializer for VerifyMigrationTask with ServiceLoader mechanism (#3986 by @C2H6O)
+- [Gradle Plugin] Create explicit compiler env (#4079 by @hfhbd)
 - [JS Driver] Split web worker driver into separate artifact
-- [JS Driver] Don't expose JsWorkerSqlCursor (#3874 by [Philip Wedemann][hfhbd])
+- [JS Driver] Don't expose JsWorkerSqlCursor (#3874 by @hfhbd)
 - [JS Driver] Disable publication of the sqljs driver (#4108)
 - [Runtime] Enforce that synchronous drivers require a synchronous schema initializer (#4013)
 - [Runtime] Improve async support for Cursors (#4102)
-- [Runtime] Remove deprecated targets (#4149 by [Philip Wedemann][hfhbd])
-- [Runtime] Remove support for old MM (#4148 by [Philip Wedemann][hfhbd])
+- [Runtime] Remove deprecated targets (#4149 by @hfhbd)
+- [Runtime] Remove support for old MM (#4148 by @hfhbd)
 
 ### Fixed
-- [R2DBC Driver] R2DBC: Await closing the driver (#4139 by [Philip Wedemann][hfhbd])
-- [Compiler] Include PRAGMAs from migrations in database create(SqlDriver) (#3845 by [Marius Volkhart][MariusV])
-- [Compiler] Fix codegen for RETURNING clause (#3872 by [Marius Volkhart][MariusV])
+- [R2DBC Driver] R2DBC: Await closing the driver (#4139 by @hfhbd)
+- [Compiler] Include PRAGMAs from migrations in database create(SqlDriver) (#3845 by @MariusVolkhart)
+- [Compiler] Fix codegen for RETURNING clause (#3872 by @MariusVolkhart)
 - [Compiler] Dont generate types for virtual tables (#4015)
-- [Gradle Plugin] Small Gradle plugin QoL improvements (#3930 by [Zac Sweers][zacsweers])
-- [IDE Plugin] Fix unresolved kotlin types (#3924 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Fix for expand wildcard intention to work with qualifier (#3979 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Use available jdk if java home is missing (#3925 by [Alexander Perfilyev][aperfilyev])
+- [Gradle Plugin] Small Gradle plugin QoL improvements (#3930 by @zacsweers)
+- [IDE Plugin] Fix unresolved kotlin types (#3924 by @aperfilyev)
+- [IDE Plugin] Fix for expand wildcard intention to work with qualifier (#3979 by @aperfilyev)
+- [IDE Plugin] Use available jdk if java home is missing (#3925 by @aperfilyev)
 - [IDE Plugin] Fix find usages on package names (#4010)
 - [IDE Plugin] Dont show auto imports for invalid elements (#4008)
 - [IDE Plugin] Do not resolve if a dialect is missing (#4009)
 - [IDE Plugin] Ignore IDE runs of the compiler during an invalidated state (#4016)
-- [IDE Plugin] Add support for IntelliJ 2023.1 (#4037 by [Madis Pink][madisp])
-- [IDE Plugin] Rename named argument usage on column rename (#4027 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Fix add migration popup (#4105 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Disable SchemaNeedsMigrationInspection in migration files (#4106 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Use sql column name for migration generation instead of type name (#4112 by [Alexander Perfilyev][aperfilyev])
+- [IDE Plugin] Add support for IntelliJ 2023.1 (#4037 by @madisp)
+- [IDE Plugin] Rename named argument usage on column rename (#4027 by @aperfilyev)
+- [IDE Plugin] Fix add migration popup (#4105 by @aperfilyev)
+- [IDE Plugin] Disable SchemaNeedsMigrationInspection in migration files (#4106 by @aperfilyev)
+- [IDE Plugin] Use sql column name for migration generation instead of type name (#4112 by @aperfilyev)
 
 ## [2.0.0-alpha05] - 2023-01-20
 [2.0.0-alpha05]: https://github.com/sqldelight/sqldelight/releases/tag/2.0.0-alpha05
 
 ### Added
-- [Paging] Multiplatform paging extension (by [Jeff Lockhart][jeffdgr8])
+- [Paging] Multiplatform paging extension (by @jeffdgr8)
 - [Runtime] Add fun modifier to Listener interface.
-- [SQLite Dialect] Add SQLite 3.33 support (UPDATE FROM) (by [Eliezer Graber][eygraber]))
-- [PostgreSQL Dialect] Support UPDATE FROM in postgresql (by [Eliezer Graber][eygraber]))
+- [SQLite Dialect] Add SQLite 3.33 support (UPDATE FROM) (by @eygraber))
+- [PostgreSQL Dialect] Support UPDATE FROM in postgresql (by @eygraber))
 
 ### Changed
-- [RDBC Driver] Expose the connection (by [Philip Wedemann][hfhbd])
+- [RDBC Driver] Expose the connection (by @hfhbd)
 - [Runtime] Move migration callbacks into main `migrate` fun
 - [Gradle Plugin] Hide Configurations from downstream projects
-- [Gradle Plugin] Only shade Intellij (by [Philip Wedemann][hfhbd])
-- [Gradle Plugin] Support Kotlin 1.8.0-Beta and add multi version Kotlin test (by [Philip Wedemann][hfhbd])
+- [Gradle Plugin] Only shade Intellij (by @hfhbd)
+- [Gradle Plugin] Support Kotlin 1.8.0-Beta and add multi version Kotlin test (by @hfhbd)
 
 ### Fixed
-- [RDBC Driver] Use javaObjectType instead (by [Philip Wedemann][hfhbd])
-- [RDBC Driver] Fix primitive null values in bindStatement (by [Philip Wedemann][hfhbd])
-- [RDBC Driver] Support R2DBC 1.0 (by [Philip Wedemann][hfhbd])
-- [PostgreSQL Dialect] Postgres: Fix Array without type parameter (by [Philip Wedemann][hfhbd])
-- [IDE Plugin] Bump intellij to 221.6008.13 (by [Philip Wedemann][hfhbd])
-- [Compiler] Resolve recursive origin table from pure views (by [Philip Wedemann][hfhbd])
-- [Compiler] Use value classes from table foreign key clause (by [Philip Wedemann][hfhbd])
-- [Compiler] Fix SelectQueryGenerator to support bind expression without parenthesis (by [Doogie Min][bellatoris])
-- [Compiler] Fix duplicate generation of ${name}Indexes variables when using transactions (by [Andreas Sacher][sachera])
+- [RDBC Driver] Use javaObjectType instead (by @hfhbd)
+- [RDBC Driver] Fix primitive null values in bindStatement (by @hfhbd)
+- [RDBC Driver] Support R2DBC 1.0 (by @hfhbd)
+- [PostgreSQL Dialect] Postgres: Fix Array without type parameter (by @hfhbd)
+- [IDE Plugin] Bump intellij to 221.6008.13 (by @hfhbd)
+- [Compiler] Resolve recursive origin table from pure views (by @hfhbd)
+- [Compiler] Use value classes from table foreign key clause (by @hfhbd)
+- [Compiler] Fix SelectQueryGenerator to support bind expression without parenthesis (by @bellatoris)
+- [Compiler] Fix duplicate generation of ${name}Indexes variables when using transactions (by @sachera)
 
 ## [1.5.5] - 2023-01-20
 [1.5.5]: https://github.com/sqldelight/sqldelight/releases/tag/1.5.5
@@ -342,42 +342,42 @@ This is a compatibility update for Kotlin 1.7.20 and AGP 7.3.0.
 - Dialect and Driver classes are final, use delegation instead.
 
 ### Added
-- [HSQL Dialect] Hsql: Support using DEFAULT for generated columns in Insert (#3372 by [Philip Wedemann][hfhbd])
-- [PostgreSQL Dialect] PostgreSQL: Support using DEFAULT for generated columns in INSERT  (#3373 by [Philip Wedemann][hfhbd])
-- [PostgreSQL Dialect] Add NOW() to PostgreSQL (#3403 by [Philip Wedemann][hfhbd])
-- [PostgreSQL Dialect] PostgreSQL Add NOT operator (#3504 by [Philip Wedemann][hfhbd])
+- [HSQL Dialect] Hsql: Support using DEFAULT for generated columns in Insert (#3372 by @hfhbd)
+- [PostgreSQL Dialect] PostgreSQL: Support using DEFAULT for generated columns in INSERT  (#3373 by @hfhbd)
+- [PostgreSQL Dialect] Add NOW() to PostgreSQL (#3403 by @hfhbd)
+- [PostgreSQL Dialect] PostgreSQL Add NOT operator (#3504 by @hfhbd)
 - [Paging] Allow passing in CoroutineContext to *QueryPagingSource (#3384)
 - [Gradle Plugin] Add better version catalog support for dialects (#3435)
-- [Native Driver] Add callback to hook into DatabaseConfiguration creation of NativeSqliteDriver (#3512 by [Sven Jacobs][svenjacobs])
+- [Native Driver] Add callback to hook into DatabaseConfiguration creation of NativeSqliteDriver (#3512 by @svenjacobs)
 
 ### Changed
 - [Paging] Add a default dispatcher to the KeyedQueryPagingSource backed QueryPagingSource function (#3385)
 - [Paging] Make OffsetQueryPagingSource only work with Int (#3386)
-- [Async Runtime] Move await* to upper class ExecutableQuery (#3524 by [Philip Wedemann][hfhbd])
+- [Async Runtime] Move await* to upper class ExecutableQuery (#3524 by @hfhbd)
 - [Coroutines Extensions] Remove default params to flow extensions (#3489)
 
 ### Fixed
-- [Gradle Plugin] Update to Kotlin 1.7.20 (#3542 by [Zac Sweers][zacsweers])
-- [R2DBC Driver] Adopt R2DBC changes which do not always send a value (#3525 by [Philip Wedemann][hfhbd])
-- [HSQL Dialect] Fix failing sqlite VerifyMigrationTask with Hsql (#3380 by [Philip Wedemann][hfhbd])
-- [Gradle Plugin] Convert tasks to use lazy configuration API (by [Matthew Haughton][3flex])
-- [Gradle Plugin] Avoid NPEs in Kotlin 1.7.20 (#3398 by [Zac Sweers][ZacSweers])
+- [Gradle Plugin] Update to Kotlin 1.7.20 (#3542 by @zacsweers)
+- [R2DBC Driver] Adopt R2DBC changes which do not always send a value (#3525 by @hfhbd)
+- [HSQL Dialect] Fix failing sqlite VerifyMigrationTask with Hsql (#3380 by @hfhbd)
+- [Gradle Plugin] Convert tasks to use lazy configuration API (by @3flex)
+- [Gradle Plugin] Avoid NPEs in Kotlin 1.7.20 (#3398 by @ZacSweers)
 - [Gradle Plugin] Fix description of squash migrations task (#3449)
-- [IDE Plugin] Fix NoSuchFieldError in newer Kotlin plugins (#3422 by [Madis Pink][madisp])
-- [IDE Plugin] IDEA: UnusedQueryInspection - fix ArrayIndexOutOfBoundsException. (#3427 by [Niklas Baudy][vanniktech])
+- [IDE Plugin] Fix NoSuchFieldError in newer Kotlin plugins (#3422 by @madisp)
+- [IDE Plugin] IDEA: UnusedQueryInspection - fix ArrayIndexOutOfBoundsException. (#3427 by @vanniktech)
 - [IDE Plugin] Use reflection for old kotlin plugin references
-- [Compiler] Custom dialect with extension function don't create imports (#3338 by [Philip Wedemann][hfhbd])
-- [Compiler] Fix escaping CodeBlock.of("${CodeBlock.toString()}") (#3340 by [Philip Wedemann][hfhbd])
+- [Compiler] Custom dialect with extension function don't create imports (#3338 by @hfhbd)
+- [Compiler] Fix escaping CodeBlock.of("${CodeBlock.toString()}") (#3340 by @hfhbd)
 - [Compiler] Await async execute statements in migrations (#3352)
-- [Compiler] Fix AS (#3370 by [Philip Wedemann][hfhbd])
-- [Compiler] `getObject`  method supports automatic filling of the actual type. (#3401 by [Rob X][robx])
+- [Compiler] Fix AS (#3370 by @hfhbd)
+- [Compiler] `getObject`  method supports automatic filling of the actual type. (#3401 by @robxyy)
 - [Compiler] Fix codegen for async grouped returning statements (#3411)
-- [Compiler] Infer the Kotlin type of bind parameter, if possible, or fail with a better error message (#3413 by [Philip Wedemann][hfhbd])
-- [Compiler] Don't allow ABS("foo") (#3430 by [Philip Wedemann][hfhbd])
-- [Compiler] Support inferring kotlin type from other parameters (#3431 by [Philip Wedemann][hfhbd])
-- [Compiler] Always create the database implementation (#3540 by [Philip Wedemann][hfhbd])
-- [Compiler] Relax javaDoc and add it to custom mapper function too (#3554 [Philip Wedemann][hfhbd])
-- [Compiler] Fix DEFAULT in binding (by [Philip Wedemann][hfhbd])
+- [Compiler] Infer the Kotlin type of bind parameter, if possible, or fail with a better error message (#3413 by @hfhbd)
+- [Compiler] Don't allow ABS("foo") (#3430 by @hfhbd)
+- [Compiler] Support inferring kotlin type from other parameters (#3431 by @hfhbd)
+- [Compiler] Always create the database implementation (#3540 by @hfhbd)
+- [Compiler] Relax javaDoc and add it to custom mapper function too (#3554 @hfhbd)
+- [Compiler] Fix DEFAULT in binding (by @hfhbd)
 - [Paging] Fix Paging 3 (#3396)
 - [Paging] Allow construction of OffsetQueryPagingSource with Long (#3409)
 - [Paging] Don't statically swap Dispatchers.Main (#3428)
@@ -400,36 +400,36 @@ sqldelight {
 - `PreparedStatement` APIs are now called with zero-based indexes.
 
 ### Added
-- [IDE Plugin] Added support for running SQLite, MySQL, and PostgreSQL commands against a running database (#2718 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Add support for the android studio DB inspector (#3107 by [Alexander Perfilyev][aperfilyev])
-- [Runtime] Add support for async drivers (#3168 by [Derek Ellis][dellisd])
-- [Native Driver] Support new kotlin native memory model (#3177 by [Kevin Galligan][kpgalligan])
-- [JS Driver] Add a driver for SqlJs workers (#3203 by [Derek Ellis][dellisd])
+- [IDE Plugin] Added support for running SQLite, MySQL, and PostgreSQL commands against a running database (#2718 by @aperfilyev)
+- [IDE Plugin] Add support for the android studio DB inspector (#3107 by @aperfilyev)
+- [Runtime] Add support for async drivers (#3168 by @dellisd)
+- [Native Driver] Support new kotlin native memory model (#3177 by @kpgalligan)
+- [JS Driver] Add a driver for SqlJs workers (#3203 by @dellisd)
 - [Gradle Plugin] Expose the classpath for SQLDelight tasks
 - [Gradle Plugin] Add a gradle task for squashing migrations
 - [Gradle Plugin] Add a flag to ignore schema definitions during migration checks
 - [MySQL Dialect] Support FOR SHARE and FOR UPDATE in MySQL (#3098)
 - [MySQL Dialect] Support MySQL index hints (#3099)
-- [PostgreSQL Dialect] Add date_trunc (#3295 by [Philip Wedemann][hfhbd])
+- [PostgreSQL Dialect] Add date_trunc (#3295 by @hfhbd)
 - [JSON Extensions] Support JSON table functions (#3090)
 
 ### Changed
 - [Runtime] Remove the AfterVersion type without the driver (#3091)
 - [Runtime] Move Schema type to top-level
-- [Runtime] Open dialect and resolver to support 3rd party implementations (#3232 by [Philip Wedemann][hfhbd])
+- [Runtime] Open dialect and resolver to support 3rd party implementations (#3232 by @hfhbd)
 - [Compiler] Include the dialect used to compile in failure reports (#3086)
-- [Compiler] Skip unused adapters (#3162 by [Eliezer Graber][eygraber])
-- [Compiler] Use zero based index in PrepareStatement (#3269 by [Philip Wedemann][hfhbd])
+- [Compiler] Skip unused adapters (#3162 by @eygraber)
+- [Compiler] Use zero based index in PrepareStatement (#3269 by @hfhbd)
 - [Gradle Plugin] Also make the dialect a proper gradle dependency instead of a string (#3085)
-- [Gradle Plugin] Gradle Verify Task: Throw when missing database file. (#3126 by [Niklas Baudy][vanniktech])
+- [Gradle Plugin] Gradle Verify Task: Throw when missing database file. (#3126 by @vanniktech)
 
 ### Fixed
-- [Gradle Plugin] Minor cleanups and tweaks to the Gradle plugin (#3171 by [Matthew Haughton][3flex])
+- [Gradle Plugin] Minor cleanups and tweaks to the Gradle plugin (#3171 by @3flex)
 - [Gradle Plugin] Dont use an AGP string for the generated directory
 - [Gradle Plugin] Use AGP namespace attribute (#3220)
-- [Gradle Plugin] Do not add kotlin-stdlib as a runtime dependency of the Gradle plugin (#3245 by [Martin Bonnin][mbonnin])
-- [Gradle Plugin] Simplify the multiplatform configuration (#3246 by [Martin Bonnin][mbonnin])
-- [Gradle Plugin] Support js only projects (#3310 by [Philip Wedemann][hfhbd])
+- [Gradle Plugin] Do not add kotlin-stdlib as a runtime dependency of the Gradle plugin (#3245 by @mbonnin)
+- [Gradle Plugin] Simplify the multiplatform configuration (#3246 by @mbonnin)
+- [Gradle Plugin] Support js only projects (#3310 by @hfhbd)
 - [IDE Plugin] Use java home for gradle tooling API (#3078)
 - [IDE Plugin] Load the JDBC driver on the correct classLoader inside the IDE plugin (#3080)
 - [IDE Plugin] Mark the file element as null before invalidating to avoid errors during already existing PSI changes (#3082)
@@ -443,11 +443,11 @@ sqldelight {
 - [Compiler] Find the top migration file faster (#3108)
 - [Compiler] Properly inherit nullability on the pipe operator
 - [Compiler] Support the iif ANSI SQL function
-- [Compiler] Don't generate empty query files (#3300 by [Philip Wedemann][hfhbd])
-- [Compiler] Fix adapter with question mark only (#3314 by [Philip Wedemann][hfhbd])
+- [Compiler] Don't generate empty query files (#3300 by @hfhbd)
+- [Compiler] Fix adapter with question mark only (#3314 by @hfhbd)
 - [PostgreSQL Dialect] Postgres primary key columns are always non-null (#3092)
-- [PostgreSQL Dialect] Fix copy with same name in multiple tables (#3297 by [Philip Wedemann][hfhbd])
-- [SQLite 3.35 Dialect] Only show an error when dropping an indexed column from the altered table (#3158 by [Eliezer Graber][eygraber])
+- [PostgreSQL Dialect] Fix copy with same name in multiple tables (#3297 by @hfhbd)
+- [SQLite 3.35 Dialect] Only show an error when dropping an indexed column from the altered table (#3158 by @eygraber)
 
 ## [2.0.0-alpha02] - 2022-04-13
 [2.0.0-alpha02]: https://github.com/sqldelight/sqldelight/releases/tag/2.0.0-alpha02
@@ -476,24 +476,24 @@ sqldelight {
 - [PostgreSQL] Support PostgreSQL NUMERIC type (#1882)
 - [PostgreSQL] Support returning queries inside of common table expressions (#2471)
 - [PostgreSQL] Support json specific operators
-- [PostgreSQL] Add Postgres Copy (by [Philip Wedemann][hfhbd])
+- [PostgreSQL] Add Postgres Copy (by @hfhbd)
 - [MySQL] Support MySQL Replace
 - [MySQL] Support NUMERIC/BigDecimal MySQL types (#2051)
 - [MySQL] Support MySQL truncate statement
-- [MySQL] Support json specific operators in Mysql (by [Eliezer Graber][eygraber])
-- [MySQL] Support MySql INTERVAL (#2969 by [Eliezer Graber][eygraber])
+- [MySQL] Support json specific operators in Mysql (by @eygraber)
+- [MySQL] Support MySql INTERVAL (#2969 by @eygraber)
 - [HSQL] Add HSQL Window functionality
-- [SQLite] Don't replace equality checks for nullable parameters in a WHERE (#1490 by [Eliezer Graber][eygraber])
-- [SQLite] Support Sqlite 3.35 returning statements (#1490 by [Eliezer Graber][eygraber])
+- [SQLite] Don't replace equality checks for nullable parameters in a WHERE (#1490 by @eygraber)
+- [SQLite] Support Sqlite 3.35 returning statements (#1490 by @eygraber)
 - [SQLite] Support GENERATED clause
-- [SQLite] Add support for Sqlite 3.38 dialect (by [Eliezer Graber][eygraber])
+- [SQLite] Add support for Sqlite 3.38 dialect (by @eygraber)
 
 ### Changed
 - [Compiler] Clean up generated code a bit
 - [Compiler] Forbid usage of table parameters in grouped statements (#1822)
 - [Compiler] Put grouped queries inside a transaction (#2785)
 - [Runtime] Return the updated row count from the drivers execute method
-- [Runtime] Confine SqlCursor to the critical section accessing the connection. (#2123 by [Anders Ha][andersio])
+- [Runtime] Confine SqlCursor to the critical section accessing the connection. (#2123 by @andersio)
 - [Gradle Plugin] Compare schema definitions for migrations (#841)
 - [PostgreSQL] Disallow double quotes for PG
 - [MySQL] Error on usage of == in MySQL (#2673)
@@ -545,19 +545,19 @@ The currently supported dialects are `mysql-dialect`, `postgresql-dialect`, `hsq
 - Primitive types must now be imported (for example `INTEGER AS Boolean` you have to `import kotlin.Boolean`), some previously supported types now need an adapter. Primitive adapters are available in `app.cash.sqldelight:primitive-adapters:2.0.0-alpha01` for most conversions (like `IntColumnAdapter` for doing `Integer AS kotlin.Int`).
 
 ### Added
-- [IDE Plugin] Basic suggested migration (by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Add import hint action (by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Add kotlin class completion (by [Alexander Perfilyev][aperfilyev])
-- [Gradle Plugin] Add shortcut for Gradle type safe project accessors (by [Philip Wedemann][hfhbd])
-- [Compiler] Customize codegen based on dialect (by [Marius Volkhart][MariusV])
-- [JDBC Driver] Add common types to JdbcDriver (by [Marius Volkhart][MariusV])
-- [SQLite] Add support for the sqlite 3.35 (by [Eliezer Graber][eygraber])
-- [SQLite] Add support for ALTER TABLE DROP COLUMN (by [Eliezer Graber][eygraber])
-- [SQLite] Add support for Sqlite 3.30 dialect (by [Eliezer Graber][eygraber])
-- [SQLite] Support NULLS FIRST/LAST in sqlite (by [Eliezer Graber][eygraber])
-- [HSQL] Add HSQL support for generated clause (by [Marius Volkhart][MariusV])
-- [HSQL] Add support for named parameters in HSQL (by [Marius Volkhart][MariusV])
-- [HSQL] Customize the HSQL insert query (by [Marius Volkhart][MariusV])
+- [IDE Plugin] Basic suggested migration (by @aperfilyev)
+- [IDE Plugin] Add import hint action (by @aperfilyev)
+- [IDE Plugin] Add kotlin class completion (by @aperfilyev)
+- [Gradle Plugin] Add shortcut for Gradle type safe project accessors (by @hfhbd)
+- [Compiler] Customize codegen based on dialect (by @MariusVolkhart)
+- [JDBC Driver] Add common types to JdbcDriver (by @MariusVolkhart)
+- [SQLite] Add support for the sqlite 3.35 (by @eygraber)
+- [SQLite] Add support for ALTER TABLE DROP COLUMN (by @eygraber)
+- [SQLite] Add support for Sqlite 3.30 dialect (by @eygraber)
+- [SQLite] Support NULLS FIRST/LAST in sqlite (by @eygraber)
+- [HSQL] Add HSQL support for generated clause (by @MariusVolkhart)
+- [HSQL] Add support for named parameters in HSQL (by @MariusVolkhart)
+- [HSQL] Customize the HSQL insert query (by @MariusVolkhart)
 
 ### Changed
 - [Everything] Package name has changed from com.squareup.sqldelight to app.cash.sqldelight.
@@ -565,53 +565,53 @@ The currently supported dialects are `mysql-dialect`, `postgresql-dialect`, `hsq
 - [Runtime] Switch to driver-implemented query notifications.
 - [Runtime] Extract default column adapters to separate module (#2056, #2060)
 - [Compiler] Let modules generate the queries implementations instead of redoing it in each module
-- [Compiler] Remove the custom toString generation of generated data classes. (by [Paul Woitaschek][PaulWoitaschek])
-- [JS Driver] Remove sql.js dependency from sqljs-driver (by [Derek Ellis][dellisd])
+- [Compiler] Remove the custom toString generation of generated data classes. (by @PaulWoitaschek)
+- [JS Driver] Remove sql.js dependency from sqljs-driver (by @dellisd)
 - [Paging] Remove the android paging 2 extension
 - [IDE Plugin] Add an editor banner while SQLDelight is syncing (#2511)
 - [IDE Plugin] Minimum supported IntelliJ version is 2021.1
 
 ### Fixed
-- [Runtime] Flatten listener list to reduce allocations and pointer chasing. (by [Anders Ha][andersio])
-- [IDE Plugin] Fix error message to allow jumping to error (by [Philip Wedemann][hfhbd])
-- [IDE Plugin] Add missing inspection descriptions (#2768 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Fix exception in GotoDeclarationHandler (#2531, #2688, #2804 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Highlight import keyword (by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Fix unresolved kotlin types (#1678 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Fix highlighting for unresolved package (#2543 by [Alexander Perfilyev][aperfilyev])
+- [Runtime] Flatten listener list to reduce allocations and pointer chasing. (by @andersio)
+- [IDE Plugin] Fix error message to allow jumping to error (by @hfhbd)
+- [IDE Plugin] Add missing inspection descriptions (#2768 by @aperfilyev)
+- [IDE Plugin] Fix exception in GotoDeclarationHandler (#2531, #2688, #2804 by @aperfilyev)
+- [IDE Plugin] Highlight import keyword (by @aperfilyev)
+- [IDE Plugin] Fix unresolved kotlin types (#1678 by @aperfilyev)
+- [IDE Plugin] Fix highlighting for unresolved package (#2543 by @aperfilyev)
 - [IDE Plugin] Dont attempt to inspect mismatched columns if the project index is not yet initialized
 - [IDE Plugin] Dont initialize the file index until a gradle sync has occurred
 - [IDE Plugin] Cancel the SQLDelight import if a gradle sync begins
 - [IDE Plugin] Regenerate the database outside of the thread an undo action is performed on
 - [IDE Plugin] If a reference cannot be resolves use a blank java type
 - [IDE Plugin] Correctly move off the main thread during file parsing and only move back on to write
-- [IDE Plugin] Improve compatibility with older IntelliJ versions (by [Matthew Haughton][3flex])
+- [IDE Plugin] Improve compatibility with older IntelliJ versions (by @3flex)
 - [IDE Plugin] Use faster annotation API
-- [Gradle Plugin] Explicitly support js/android plugins when adding runtime (by [Zac Sweers][ZacSweers])
-- [Gradle Plugin] Register migration output task without derviving schemas from migrations (#2744 by [Kevin Cianfarini][kevincianfarini])
+- [Gradle Plugin] Explicitly support js/android plugins when adding runtime (by @ZacSweers)
+- [Gradle Plugin] Register migration output task without derviving schemas from migrations (#2744 by @kevincianfarini)
 - [Gradle Plugin] If the migration task crashes, print the file it crashed running
-- [Gradle Plugin] Sort files when generating code to ensure idempotent outputs (by [Zac Sweers][ZacSweers])
+- [Gradle Plugin] Sort files when generating code to ensure idempotent outputs (by @ZacSweers)
 - [Compiler] Use faster APIs for iterating files and dont explore the entire PSI graph
-- [Compiler] Add keyword mangling to select function parameters (#2759 by [Alexander Perfilyev][aperfilyev])
-- [Compiler] Fix packageName for migration adapter (by [Philip Wedemann][hfhbd])
-- [Compiler] Emit annotations on properties instead of types (#2798 by [Alexander Perfilyev][aperfilyev])
-- [Compiler] Sort arguments before passing to a Query subtype (#2379 by [Alexander Perfilyev][aperfilyev])
+- [Compiler] Add keyword mangling to select function parameters (#2759 by @aperfilyev)
+- [Compiler] Fix packageName for migration adapter (by @hfhbd)
+- [Compiler] Emit annotations on properties instead of types (#2798 by @aperfilyev)
+- [Compiler] Sort arguments before passing to a Query subtype (#2379 by @aperfilyev)
 
 ## [1.5.3] - 2021-11-23
 [1.5.3]: https://github.com/sqldelight/sqldelight/releases/tag/1.5.3
 
 ### Added
-- [JDBC Driver] Open JdbcDriver for 3rd party driver implementations (#2672 by [Philip Wedemann][hfhbd])
-- [MySQL Dialect] Add missing functions for time increments (#2671 by [Sam Doward][sdoward])
-- [Coroutines Extension] Add M1 targets for coroutines-extensions (by [Philip Dukhov][PhilipDukhov])
+- [JDBC Driver] Open JdbcDriver for 3rd party driver implementations (#2672 by @hfhbd)
+- [MySQL Dialect] Add missing functions for time increments (#2671 by @sdoward)
+- [Coroutines Extension] Add M1 targets for coroutines-extensions (by @PhilipDukhov)
 
 ### Changed
-- [Paging3 Extension] Distribute sqldelight-android-paging3 as JAR instead of AAR (#2634 by [Marco Romano][julioromano])
+- [Paging3 Extension] Distribute sqldelight-android-paging3 as JAR instead of AAR (#2634 by @julioromano)
 - Property names which are also soft keywords will now be suffixed with underscores. For instance `value` will be exposed as `value_`
 
 ### Fixed
-- [Compiler] Don't extract variables for duplicate array parameters (by [Alexander Perfilyev][aperfilyev])
-- [Gradle Plugin] add kotlin.mpp.enableCompatibilityMetadataVariant. (#2628 by [Martin Bonnin][martinbonnin])
+- [Compiler] Don't extract variables for duplicate array parameters (by @aperfilyev)
+- [Gradle Plugin] add kotlin.mpp.enableCompatibilityMetadataVariant. (#2628 by @martinbonnin)
 - [IDE Plugin] Find usages processing requires a read action
 
 
@@ -619,25 +619,25 @@ The currently supported dialects are `mysql-dialect`, `postgresql-dialect`, `hsq
 [1.5.2]: https://github.com/sqldelight/sqldelight/releases/tag/1.5.2
 
 ### Added
-- [Gradle Plugin] HMPP support (#2548 by [Martin Bonnin][martinbonnin])
-- [IDE Plugin] Add NULL comparison inspection (by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Add inspection suppressor (#2519 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Mixed named and positional parameters inspection (by [Alexander Perfilyev][aperfilyev])
-- [SQLite Driver] Add mingwX86 target. (#2558 by [Nikita Kozhemyakin][enginegl])
+- [Gradle Plugin] HMPP support (#2548 by @martinbonnin)
+- [IDE Plugin] Add NULL comparison inspection (by @aperfilyev)
+- [IDE Plugin] Add inspection suppressor (#2519 by @aperfilyev)
+- [IDE Plugin] Mixed named and positional parameters inspection (by @aperfilyev)
+- [SQLite Driver] Add mingwX86 target. (#2558 by @enginegl)
 - [SQLite Driver] Add M1 targets
-- [SQLite Driver] Add linuxX64 support (#2456 by [Cedric Hippmann][chippmann])
+- [SQLite Driver] Add linuxX64 support (#2456 by @chippmann)
 - [MySQL Dialect] Add ROW_COUNT function to mysql (#2523)
-- [PostgreSQL Dialect] postgres rename, drop column (by [Juan Liska][pabl0rg])
+- [PostgreSQL Dialect] postgres rename, drop column (by @pabl0rg)
 - [PostgreSQL Dialect] PostgreSQL grammar doesn't recognize CITEXT
 - [PostgreSQL Dialect] Include TIMESTAMP WITH TIME ZONE and TIMESTAMPTZ
 - [PostgreSQL Dialect] Add grammar for PostgreSQL GENERATED columns
-- [Runtime] Provide SqlDriver as a parameter to AfterVersion (#2534, 2614 by [Ahmed El-Helw][ahmedre])
+- [Runtime] Provide SqlDriver as a parameter to AfterVersion (#2534, 2614 by @ahmedre)
 
 ### Changed
-- [Gradle Plugin] explicitely require Gradle 7.0 (#2572 by [Martin Bonnin][martinbonnin])
-- [Gradle Plugin] Make VerifyMigrationTask support Gradle's up-to-date checks (#2533 by [Matthew Haughton][3flex])
-- [IDE Plugin] Don't warn with "Join compares two columns of different types" when joining nullable with non-nullable type (#2550 by [Piotr Chmielowski][pchmielowski])
-- [IDE Plugin] Clarify the error for the lowercase 'as' in column type (by [Alexander Perfilyev][aperfilyev])
+- [Gradle Plugin] explicitely require Gradle 7.0 (#2572 by @martinbonnin)
+- [Gradle Plugin] Make VerifyMigrationTask support Gradle's up-to-date checks (#2533 by @3flex)
+- [IDE Plugin] Don't warn with "Join compares two columns of different types" when joining nullable with non-nullable type (#2550 by @pchmielowski)
+- [IDE Plugin] Clarify the error for the lowercase 'as' in column type (by @aperfilyev)
 
 ### Fixed
 - [IDE Plugin] Do not reparse under a new dialect if the project is already disposed (#2609)
@@ -645,81 +645,81 @@ The currently supported dialects are `mysql-dialect`, `postgresql-dialect`, `hsq
 - [IDE Plugin] Avoid crashing during the unused query inspection (#2610)
 - [IDE Plugin] Run the database sync write inside of a write action (#2605)
 - [IDE Plugin] Let the IDE schedule SQLDelight syncronization
-- [IDE Plugin] Fix npe in JavaTypeMixin (#2603 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Fix IndexOutOfBoundsException in MismatchJoinColumnInspection (#2602 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Add description for UnusedColumnInspection (#2600 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Wrap PsiElement.generatedVirtualFiles into read action (#2599 by [Alexander Perfilyev][aperfilyev])
+- [IDE Plugin] Fix npe in JavaTypeMixin (#2603 by @aperfilyev)
+- [IDE Plugin] Fix IndexOutOfBoundsException in MismatchJoinColumnInspection (#2602 by @aperfilyev)
+- [IDE Plugin] Add description for UnusedColumnInspection (#2600 by @aperfilyev)
+- [IDE Plugin] Wrap PsiElement.generatedVirtualFiles into read action (#2599 by @aperfilyev)
 - [IDE Plugin] Remove unnecessary nonnull cast (#2596)
 - [IDE Plugin] Properly handle nulls for find usages (#2595)
-- [IDE Plugin] Fix IDE autocomplete for generated files for Android (#2573 by [Martin Bonnin][martinbonnin])
-- [IDE Plugin] Fix npe in SqlDelightGotoDeclarationHandler (by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Mangle kotlin keywords in arguments inside insert stmt (#2433 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Fix npe in SqlDelightFoldingBuilder (#2382 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Catch ClassCastException in CopyPasteProcessor (#2369 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Fix update live template (by [Ilias Redissi][IliasRedissi])
-- [IDE Plugin] Adds descriptions to intention actions (#2489 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Fix exception in CreateTriggerMixin if table is not found (by [Alexander Perfilyev][aperfilyev])
+- [IDE Plugin] Fix IDE autocomplete for generated files for Android (#2573 by @martinbonnin)
+- [IDE Plugin] Fix npe in SqlDelightGotoDeclarationHandler (by @aperfilyev)
+- [IDE Plugin] Mangle kotlin keywords in arguments inside insert stmt (#2433 by @aperfilyev)
+- [IDE Plugin] Fix npe in SqlDelightFoldingBuilder (#2382 by @aperfilyev)
+- [IDE Plugin] Catch ClassCastException in CopyPasteProcessor (#2369 by @aperfilyev)
+- [IDE Plugin] Fix update live template (by @IliasRedissi)
+- [IDE Plugin] Adds descriptions to intention actions (#2489 by @aperfilyev)
+- [IDE Plugin] Fix exception in CreateTriggerMixin if table is not found (by @aperfilyev)
 - [Compiler] Topologically sort table creation statemenets
 - [Compiler] Stop invoking `forDatabaseFiles` callback on directories (#2532)
-- [Gradle Plugin] Propagate generateDatabaseInterface task dependency to potential consumers (#2518 by [Martin Bonnin][martinbonnin])
+- [Gradle Plugin] Propagate generateDatabaseInterface task dependency to potential consumers (#2518 by @martinbonnin)
 
 
 ## [1.5.1] - 2021-07-16
 [1.5.1]: https://github.com/sqldelight/sqldelight/releases/tag/1.5.1
 
 ### Added
-- [PostgreSQL Dialect] PostgreSQL JSONB and ON Conflict Do Nothing (by [Andrew Stewart][satook])
-- [PostgreSQL Dialect] Adds support for PostgreSQL ON CONFLICT (column, ...) DO UPDATE (by [Andrew Stewart][satook])
-- [MySQL Dialect] Support MySQL generated columns (by [Jeff Gulbronson][JeffG])
+- [PostgreSQL Dialect] PostgreSQL JSONB and ON Conflict Do Nothing (by @satook)
+- [PostgreSQL Dialect] Adds support for PostgreSQL ON CONFLICT (column, ...) DO UPDATE (by @satook)
+- [MySQL Dialect] Support MySQL generated columns (by @JGulbronson)
 - [Native Driver] Add watchosX64 support
-- [IDE Plugin] Add parameter types and annotations (by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Add action to generate 'select all' query (by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Show column types in autocomplete (by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Add icons to autocomplete (by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Add action to generate 'select by primary key' query (by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Add action to generate 'insert into' query (by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Add highlighting for column names, stmt identifiers, function names (by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Add remaining query generation actions (#489 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Show parameter hints from insert-stmt (by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Table alias intention action (by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Qualify column name intention (by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Go to declaration for kotlin property (by [Alexander Perfilyev][aperfilyev])
+- [IDE Plugin] Add parameter types and annotations (by @aperfilyev)
+- [IDE Plugin] Add action to generate 'select all' query (by @aperfilyev)
+- [IDE Plugin] Show column types in autocomplete (by @aperfilyev)
+- [IDE Plugin] Add icons to autocomplete (by @aperfilyev)
+- [IDE Plugin] Add action to generate 'select by primary key' query (by @aperfilyev)
+- [IDE Plugin] Add action to generate 'insert into' query (by @aperfilyev)
+- [IDE Plugin] Add highlighting for column names, stmt identifiers, function names (by @aperfilyev)
+- [IDE Plugin] Add remaining query generation actions (#489 by @aperfilyev)
+- [IDE Plugin] Show parameter hints from insert-stmt (by @aperfilyev)
+- [IDE Plugin] Table alias intention action (by @aperfilyev)
+- [IDE Plugin] Qualify column name intention (by @aperfilyev)
+- [IDE Plugin] Go to declaration for kotlin property (by @aperfilyev)
 
 ### Changed
-- [Native Driver] Improve native transaction performance by avoiding freezing and shareable data structures when possible (by [Anders Ha][andersio])
+- [Native Driver] Improve native transaction performance by avoiding freezing and shareable data structures when possible (by @andersio)
 - [Paging 3] Bump Paging3 version to 3.0.0 stable
 - [JS Driver] Upgrade sql.js to 1.5.0
 
 ### Fixed
-- [JDBC SQLite Driver] Call close() on connection before clearing the ThreadLocal (#2444 by [Hannes Struß][hannesstruss])
-- [RX extensions] Fix subscription / disposal race leak (#2403 by [Pierre Yves Ricau][pyricau])
+- [JDBC SQLite Driver] Call close() on connection before clearing the ThreadLocal (#2444 by @hannesstruss)
+- [RX extensions] Fix subscription / disposal race leak (#2403 by @pyricau)
 - [Coroutines extension] Ensure we register query listener before notifying
-- [Compiler] Sort notifyQueries to have consistent kotlin output file (by [Jiayu Chen][thomascjy])
-- [Compiler] Don't annotate select query class properties with @JvmField (by [Eliezer Graber][eygraber])
-- [IDE Plugin] Fix import optimizer (#2350 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Fix unused column inspection (by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Add nested classes support to import inspection and class annotator (by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Fix npe in CopyPasteProcessor (#2363 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Fix crash in InlayParameterHintsProvider (#2359 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Fix insertion of blank lines when copy-pasting any text into create table stmt (#2431 by [Alexander Perfilyev][aperfilyev])
+- [Compiler] Sort notifyQueries to have consistent kotlin output file (by @thomascjy)
+- [Compiler] Don't annotate select query class properties with @JvmField (by @eygraber)
+- [IDE Plugin] Fix import optimizer (#2350 by @aperfilyev)
+- [IDE Plugin] Fix unused column inspection (by @aperfilyev)
+- [IDE Plugin] Add nested classes support to import inspection and class annotator (by @aperfilyev)
+- [IDE Plugin] Fix npe in CopyPasteProcessor (#2363 by @aperfilyev)
+- [IDE Plugin] Fix crash in InlayParameterHintsProvider (#2359 by @aperfilyev)
+- [IDE Plugin] Fix insertion of blank lines when copy-pasting any text into create table stmt (#2431 by @aperfilyev)
 
 
 ## [1.5.0] - 2021-04-23
 [1.5.0]: https://github.com/sqldelight/sqldelight/releases/tag/1.5.0
 
 ### Added
-- [SQLite Javascript Driver] Enable sqljs-driver publication (#1667 by [Derek Ellis][dellisd])
-- [Paging3 Extension] Extension for Android Paging 3 Library (#1786 by [Kevin Cianfarini][kevincianfarini])
-- [MySQL Dialect] Adds support for mysql's ON DUPLICATE KEY UPDATE conflict resolution. (by [Ryan Harter][rharter])
-- [SQLite Dialect] Add compiler support for SQLite offsets() (by [Quinton Roberts][qjroberts])
-- [IDE Plugin] Add import quick fix for unknown type (#683 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Add unused import inspection (#1161 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Add unused query inspection (by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Add unused column inspection (#569 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Automatically bring imports on copy/paste (#684 by [Alexander Perfilyev][aperfilyev])
+- [SQLite Javascript Driver] Enable sqljs-driver publication (#1667 by @dellisd)
+- [Paging3 Extension] Extension for Android Paging 3 Library (#1786 by @kevincianfarini)
+- [MySQL Dialect] Adds support for mysql's ON DUPLICATE KEY UPDATE conflict resolution. (by @rharter)
+- [SQLite Dialect] Add compiler support for SQLite offsets() (by @qjroberts)
+- [IDE Plugin] Add import quick fix for unknown type (#683 by @aperfilyev)
+- [IDE Plugin] Add unused import inspection (#1161 by @aperfilyev)
+- [IDE Plugin] Add unused query inspection (by @aperfilyev)
+- [IDE Plugin] Add unused column inspection (#569 by @aperfilyev)
+- [IDE Plugin] Automatically bring imports on copy/paste (#684 by @aperfilyev)
 - [IDE Plugin] Pop a balloon when there are incompatibilities between gradle/intellij plugin versions
-- [IDE Plugin] Insert Into ... VALUES(?) parameter hints (#506 by [Alexander Perfilyev][aperfilyev])
-- [IDE Plugin] Inline parameter hints (by [Alexander Perfilyev][aperfilyev])
+- [IDE Plugin] Insert Into ... VALUES(?) parameter hints (#506 by @aperfilyev)
+- [IDE Plugin] Inline parameter hints (by @aperfilyev)
 - [Runtime] Include an API in the runtime for running migrations with callbacks (#1844)
 
 ### Changed
@@ -731,7 +731,7 @@ The currently supported dialects are `mysql-dialect`, `postgresql-dialect`, `hsq
 - [Native Driver] Native driver connection pool and performance updates
 
 ### Fixed
-- [Compiler] NBSP before lambdas (by [Benoît Quenaudon][oldergod])
+- [Compiler] NBSP before lambdas (by @oldergod)
 - [Compiler] Fix incompatible types in generated bind* and cursor.get* statements
 - [Compiler] SQL clause should persist adapted type (#2067)
 - [Compiler] Column with only NULL keyword should be nullable
@@ -743,32 +743,32 @@ The currently supported dialects are `mysql-dialect`, `postgresql-dialect`, `hsq
 - [Compiler] Correctly use query-imposed nullability for expressions
 - [MySQL Dialect] Support MySQL if statements
 - [PostgreSQL Dialect] Retrieve NUMERIC and DECIMAL as Double in PostgreSQL (#2118)
-- [SQLite Dialect] UPSERT notifications should account for BEFORE/AFTER UPDATE triggers. (#2198 by [Anders Ha][andersio])
+- [SQLite Dialect] UPSERT notifications should account for BEFORE/AFTER UPDATE triggers. (#2198 by @andersio)
 - [SQLite Driver] Use multiple connections for threads in the SqliteDriver unless we are in memory (#1832)
 - [JDBC Driver] JDBC Driver assumes autoCommit is true (#2041)
 - [JDBC Driver] Ensure that we close connections on exception (#2306)
-- [IDE Plugin] Fix GoToDeclaration/FindUsages being broken on Windows due to path separator bug (#2054 by [Angus Holder][AngusH])
+- [IDE Plugin] Fix GoToDeclaration/FindUsages being broken on Windows due to path separator bug (#2054 by @angusholder)
 - [IDE Plugin] Ignore gradle errors instead of crashing in the IDE.
 - [IDE Plugin] If a sqldelight file is moved to a non-sqldelight module, do not attempt codegen
 - [IDE Plugin] Ignore codegen errors in IDE
 - [IDE Plugin] Ensure that we dont try to negatively substring (#2068)
 - [IDE Plugin] Also ensure project is not disposed before running gradle action (#2155)
 - [IDE Plugin] Arithmetic on nullable types should also be nullable (#1853)
-- [IDE Plugin] Make 'expand * intention' work with additional projections (#2173 by [Alexander Perfilyev][aperfilyev])
+- [IDE Plugin] Make 'expand * intention' work with additional projections (#2173 by @aperfilyev)
 - [IDE Plugin] If kotlin resolution fails during GoTo, dont attempt to go to sqldelight files
 - [IDE Plugin] If IntelliJ encounters an exception while sqldelight is indexing, dont crash
 - [IDE Plugin] Handle exceptions that happen while detecting errors before codegen in the IDE
 - [IDE Plugin] Make the IDE plugin compatible with Dynamic Plugins (#1536)
-- [Gradle Plugin] Race condition generating a database using WorkerApi (#2062 by [Stéphane Nicolas][stephanenicolas])
-- [Gradle Plugin] classLoaderIsolation prevents custom jdbc usage (#2048 by [Ben Asher][BenA])
-- [Gradle Plugin] Improve missing packageName error message (by [Niklas Baudy][vanniktech])
+- [Gradle Plugin] Race condition generating a database using WorkerApi (#2062 by @stephanenicolas)
+- [Gradle Plugin] classLoaderIsolation prevents custom jdbc usage (#2048 by @benasher44)
+- [Gradle Plugin] Improve missing packageName error message (by @vanniktech)
 - [Gradle Plugin] SQLDelight bleeds IntelliJ dependencies onto buildscript class path (#1998)
 - [Gradle Plugin] Fix gradle build caching (#2075)
-- [Gradle Plugin] Do not depend on kotlin-native-utils in Gradle plugin (by [Ilya Matveev][ilmat192])
+- [Gradle Plugin] Do not depend on kotlin-native-utils in Gradle plugin (by @ilmat192)
 - [Gradle Plugin] Also write the database if there are only migration files (#2094)
 - [Gradle Plugin] Ensure diamond dependencies only get picked up once in the final compilation unit (#1455)
 
-Also just a general shoutout to [Matthew Haughton][3flex] who did a lot of work to improve the SQLDelight infrastructure this release.
+Also just a general shoutout to @3flex who did a lot of work to improve the SQLDelight infrastructure this release.
 
 ## [1.4.4] - 2020-10-08
 [1.4.4]: https://github.com/sqldelight/sqldelight/releases/tag/1.4.4
@@ -783,13 +783,13 @@ Also just a general shoutout to [Matthew Haughton][3flex] who did a lot of work 
 - [Gradle Plugin] Provide a warning when the sqldelight plugin is applied but no databases are configured (#1421)
 
 ### Fixed
-- [Compiler] Report an error when binding a column name in an ORDER BY clause (#1187 by [Eliezer Graber][eygraber])
+- [Compiler] Report an error when binding a column name in an ORDER BY clause (#1187 by @eygraber)
 - [Compiler] Registry warnings appear when generating the db interface (#1792)
 - [Compiler] Incorrect type inference for case statement (#1811)
 - [Compiler] Provide better errors for migration files with no version (#2006)
 - [Compiler] Required database type to marshal is incorrect for some database type ColumnAdapter's (#2012)
 - [Compiler] Nullability of CAST (#1261)
-- [Compiler] Lots of name shadowed warnings in query wrappers (#1946 by [Eliezer Graber][eygraber])
+- [Compiler] Lots of name shadowed warnings in query wrappers (#1946 by @eygraber)
 - [Compiler] Generated code is using full qualifier names (#1939)
 - [IDE Plugin] Trigger sqldelight code gen from gradle syncs
 - [IDE Plugin] Plugin not regenerating database interface when changing .sq files (#1945)
@@ -800,22 +800,22 @@ Also just a general shoutout to [Matthew Haughton][3flex] who did a lot of work 
 - [IDE Plugin] Throw a better error message when encountering an unknown expression (#1958)
 - [Gradle Plugin] SQLDelight bleeds IntelliJ dependencies onto buildscript class path (#1998)
 - [Gradle Plugin] "JavadocIntegrationKt not found" compilation error when adding method doc in *.sq file (#1982)
-- [Gradle Plugin] SqlDeslight gradle plugin doesn't support Configuration Caching (CoCa). (#1947 by [Stéphane Nicolas][stephanenicolas])
+- [Gradle Plugin] SqlDeslight gradle plugin doesn't support Configuration Caching (CoCa). (#1947 by @stephanenicolas)
 - [SQLite JDBC Driver] SQLException: database in auto-commit mode (#1832)
-- [Coroutines Extension] Fix IR backend for coroutines-extensions (#1918 by [Derek Ellis][dellisd])
+- [Coroutines Extension] Fix IR backend for coroutines-extensions (#1918 by @dellisd)
 
 ## [1.4.3] - 2020-09-04
 [1.4.3]: https://github.com/sqldelight/sqldelight/releases/tag/1.4.3
 
 ### Added
-- [MySQL Dialect] Add support for MySQL last_insert_id function (by [Kelvin Law][lawkai])
-- [PostgreSQL Dialect] Support SERIAL data type (by [Veyndan Stuart][VeyndanS] & [Felipe Lima][felipecsl])
-- [PostgreSQL Dialect] Support PostgreSQL RETURNING (by [Veyndan Stuart][VeyndanS])
+- [MySQL Dialect] Add support for MySQL last_insert_id function (by @lawkai)
+- [PostgreSQL Dialect] Support SERIAL data type (by @veyndan & @felipecsl)
+- [PostgreSQL Dialect] Support PostgreSQL RETURNING (by @veyndan)
 
 ### Fixed
 - [MySQL Dialect] Treat MySQL AUTO_INCREMENT as having a default value (#1823)
-- [Compiler] Fix Upsert statement compiler error (#1809 by [Eliezer Graber][eygraber])
-- [Compiler] Fix issue with invalid Kotlin being generated (#1925 by [Eliezer Graber][eygraber])
+- [Compiler] Fix Upsert statement compiler error (#1809 by @eygraber)
+- [Compiler] Fix issue with invalid Kotlin being generated (#1925 by @eygraber)
 - [Compiler] Have a better error message for unknown functions (#1843)
 - [Compiler] Expose string as the type for the second parameter of instr
 - [IDE Plugin] Fix daemon bloat and UI thread stalling for IDE plugin (#1916)
@@ -831,14 +831,14 @@ Also just a general shoutout to [Matthew Haughton][3flex] who did a lot of work 
 
 ### Added
 - [Runtime] Support new JS IR backend
-- [Gradle Plugin] Add generateSqlDelightInterface Gradle task. (by [Niklas Baudy][vanniktech])
-- [Gradle Plugin] Add verifySqlDelightMigration Gradle task. (by [Niklas Baudy][vanniktech])
+- [Gradle Plugin] Add generateSqlDelightInterface Gradle task. (by @vanniktech)
+- [Gradle Plugin] Add verifySqlDelightMigration Gradle task. (by @vanniktech)
 
 ### Fixed
 - [IDE Plugin] Use the gradle tooling API to facilitate data sharing between the IDE and gradle
 - [IDE Plugin] Default to false for schema derivation
 - [IDE Plugin] Properly retrieve the commonMain source set
-- [MySQL Dialect] Added minute to mySqlFunctionType() (by [MaaxGr][maaxgr])
+- [MySQL Dialect] Added minute to mySqlFunctionType() (by @maaxgr)
 
 ## [1.4.1] - 2020-08-21
 [1.4.1]: https://github.com/sqldelight/sqldelight/releases/tag/1.4.1
@@ -850,49 +850,49 @@ Also just a general shoutout to [Matthew Haughton][3flex] who did a lot of work 
 - [Gradle Plugin] Make AGP dependency compileOnly (#1362)
 
 ### Fixed
-- [Compiler] Add optional javadoc to column defintion rule and to table interface generator (#1224 by [Daniel Eke][endanke])
-- [SQLite Dialect] Add support for sqlite fts5 auxiliary functions highlight, snippet, and bm25 (by [Daniel Rampelt][drampelt])
+- [Compiler] Add optional javadoc to column defintion rule and to table interface generator (#1224 by @endanke)
+- [SQLite Dialect] Add support for sqlite fts5 auxiliary functions highlight, snippet, and bm25 (by @drampelt)
 - [MySQL Dialect] Support MySQL bit data type
 - [MySQL Dialect] Support MySQL binary literals
-- [PostgreSQL Dialect] Expose SERIAL from sql-psi (by [Veyndan Stuart][VeyndanS])
-- [PostgreSQL Dialect] Add BOOLEAN data type (by [Veyndan Stuart][VeyndanS])
-- [PostgreSQL Dialect] Add NULL column constraint (by [Veyndan Stuart][VeyndanS])
-- [HSQL Dialect] Adds `AUTO_INCREMENT` support to HSQL (by [Ryan Harter][rharter])
+- [PostgreSQL Dialect] Expose SERIAL from sql-psi (by @veyndan)
+- [PostgreSQL Dialect] Add BOOLEAN data type (by @veyndan)
+- [PostgreSQL Dialect] Add NULL column constraint (by @veyndan)
+- [HSQL Dialect] Adds `AUTO_INCREMENT` support to HSQL (by @rharter)
 
 ## [1.4.0] - 2020-06-22
 [1.4.0]: https://github.com/sqldelight/sqldelight/releases/tag/1.4.0
 
 ### Added
-- [MySQL Dialect] MySQL support (by [Jeff Gulbronson][JeffG] & [Veyndan Stuart][VeyndanS])
-- [PostgreSQL Dialect] Experimental PostgreSQL support (by [Veyndan Stuart][VeyndanS])
-- [HSQL Dialect] Experimental H2 support (by [Marius Volkhart][MariusV])
-- [SQLite Dialect] SQLite FTS5 support (by [Ben Asher][BenA] & [James Palawaga][JamesP])
-- [SQLite Dialect] Support alter table rename column (#1505 by [Angus Holder][AngusH])
+- [MySQL Dialect] MySQL support (by @JGulbronson & @veyndan)
+- [PostgreSQL Dialect] Experimental PostgreSQL support (by @veyndan)
+- [HSQL Dialect] Experimental H2 support (by @MariusVolkhart)
+- [SQLite Dialect] SQLite FTS5 support (by @benasher44 & @jpalawaga)
+- [SQLite Dialect] Support alter table rename column (#1505 by @angusholder)
 - [IDE] IDE support for migration (.sqm) files
-- [IDE] Add SQLDelight Live Templates that mimic built-in SQL Live Templates (#1154 by [Veyndan Stuart][VeyndanS])
-- [IDE] Add new SqlDelight file action (#42 by [Roman Zavarnitsyn][RomanZ])
+- [IDE] Add SQLDelight Live Templates that mimic built-in SQL Live Templates (#1154 by @veyndan)
+- [IDE] Add new SqlDelight file action (#42 by @romtsn)
 - [Runtime] transactionWithReturn API for transactions that return results
 - [Compiler] Syntax for grouping multiple SQL statements together in a .sq file
 - [Compiler] Support generating schemas from migration files
 - [Gradle Plugin] Add a task for outputting migration files as valid sql
 
 ### Changed
-- [Documentation] Overhaul of the documentation website (by [Saket Narayan][SaketN])
-- [Gradle Plugin] Improve unsupported dialect error message (by [Veyndan Stuart][VeyndanS])
-- [IDE] Dynamically change file icon based on dialect (by [Veyndan Stuart][VeyndanS])
+- [Documentation] Overhaul of the documentation website (by @saket)
+- [Gradle Plugin] Improve unsupported dialect error message (by @veyndan)
+- [IDE] Dynamically change file icon based on dialect (by @veyndan)
 - [JDBC Driver] Expose a JdbcDriver constructor off of javax.sql.DataSource (#1614)
 
 ### Fixed
 - [Compiler]Support Javadoc on tables and fix multiple javadoc in one file (#1224)
 - [Compiler] Enable inserting a value for synthesized columns (#1351)
-- [Compiler] Fix inconsistency in directory name sanitizing (by [Zac Sweers][ZacSweers])
+- [Compiler] Fix inconsistency in directory name sanitizing (by @ZacSweers)
 - [Compiler] Synthesized columns should retain nullability across joins (#1656)
 - [Compiler] Pin the delete statement on the delete keyword (#1643)
-- [Compiler] Fix quoting (#1525 by [Angus Holder][AngusH])
+- [Compiler] Fix quoting (#1525 by @angusholder)
 - [Compiler] Fix the between operator to properly recurse into expressions (#1279)
 - [Compiler] Give better error for missing table/column when creating an index (#1372)
 - [Compiler] Enable using the outer querys projection in join constraints (#1346)
-- [Native Driver] Make execute use transationPool (by [Ben Asher][BenA])
+- [Native Driver] Make execute use transationPool (by @benasher44)
 - [JDBC Driver] Use the jdbc transaction APIs instead of sqlite (#1693)
 - [IDE] Fix virtualFile references to always be the original file (#1782)
 - [IDE] Use the correct throwable when reporting errors to bugsnag (#1262)
@@ -1178,79 +1178,3 @@ Also just a general shoutout to [Matthew Haughton][3flex] who did a lot of work 
 [0.1.0]: https://github.com/sqldelight/sqldelight/releases/tag/0.1.0
 
 Initial release.
-
-  [JeffG]: https://github.com/JGulbronson
-  [VeyndanS]: https://github.com/veyndan
-  [BenA]: https://github.com/benasher44
-  [JamesP]: https://github.com/jpalawaga
-  [MariusV]: https://github.com/MariusVolkhart
-  [SaketN]: https://github.com/saket
-  [RomanZ]: https://github.com/romtsn
-  [ZacSweers]: https://github.com/ZacSweers
-  [AngusH]: https://github.com/angusholder
-  [drampelt]: https://github.com/drampelt
-  [endanke]: https://github.com/endanke
-  [rharter]: https://github.com/rharter
-  [vanniktech]: https://github.com/vanniktech
-  [maaxgr]: https://github.com/maaxgr
-  [eygraber]: https://github.com/eygraber
-  [lawkai]: https://github.com/lawkai
-  [felipecsl]: https://github.com/felipecsl
-  [dellisd]: https://github.com/dellisd
-  [stephanenicolas]: https://github.com/stephanenicolas
-  [oldergod]: https://github.com/oldergod
-  [qjroberts]: https://github.com/qjroberts
-  [kevincianfarini]: https://github.com/kevincianfarini
-  [andersio]: https://github.com/andersio
-  [ilmat192]: https://github.com/ilmat192
-  [3flex]: https://github.com/3flex
-  [aperfilyev]: https://github.com/aperfilyev
-  [satook]: https://github.com/Satook
-  [thomascjy]: https://github.com/ThomasCJY
-  [pyricau]: https://github.com/pyricau
-  [hannesstruss]: https://github.com/hannesstruss
-  [martinbonnin]: https://github.com/martinbonnin
-  [enginegl]: https://github.com/enginegl
-  [pchmielowski]: https://github.com/pchmielowski
-  [chippmann]: https://github.com/chippmann
-  [IliasRedissi]: https://github.com/IliasRedissi
-  [ahmedre]: https://github.com/ahmedre
-  [pabl0rg]: https://github.com/pabl0rg
-  [hfhbd]: https://github.com/hfhbd
-  [sdoward]: https://github.com/sdoward
-  [PhilipDukhov]: https://github.com/PhilipDukhov
-  [julioromano]: https://github.com/julioromano
-  [PaulWoitaschek]: https://github.com/PaulWoitaschek
-  [kpgalligan]: https://github.com/kpgalligan
-  [robx]: https://github.com/robxyy
-  [madisp]: https://github.com/madisp
-  [svenjacobs]: https://github.com/svenjacobs
-  [jeffdgr8]: https://github.com/jeffdgr8
-  [bellatoris]: https://github.com/bellatoris
-  [sachera]: https://github.com/sachera
-  [sproctor]: https://github.com/sproctor
-  [davidwheeler123]: https://github.com/davidwheeler123
-  [C2H6O]: https://github.com/C2H6O
-  [griffio]: https://github.com/griffio
-  [shellderp]: https://github.com/shellderp
-  [joshfriend]: https://github.com/joshfriend
-  [daio]: https://github.com/daio
-  [morki]: https://github.com/morki
-  [Adriel-M]: https://github.com/Adriel-M
-  [05nelsonm]: https://github.com/05nelsonm
-  [jingwei99]: https://github.com/jingwei99
-  [anddani]: https://github.com/anddani
-  [BoD]: https://github.com/BoD
-  [de-luca]: https://github.com/de-luca
-  [MohamadJaara]: https://github.com/MohamadJaara
-  [nwagu]: https://github.com/nwagu
-  [IlyaGulya]: https://github.com/IlyaGulya
-  [edenman]: https://github.com/edenman
-  [vitorhugods]: https://github.com/vitorhugods
-  [evant]: https://github.com/evant
-  [TheMrMilchmann]: https://github.com/TheMrMilchmann
-  [drewd]: https://github.com/drewd
-  [orenkislev-faire]: https://github.com/orenkislev-faire
-  [janbina]: https://github.com/janbina
-  [DRSchlaubi]: https://github.com/DRSchlaubi
-  [jonapoul]: https://github.com/jonapoul


### PR DESCRIPTION
These render correctly in the release notes, and also attribute the actual account in GitHub's UI.

If we ever migrate from GitHub, we can trivially back-fill these as full links or something.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
