### PR TITLE
Fix handling of directory paths with spaces

### DIFF
--- a/sqldelight-gradle-plugin/src/test/build-logic-tests/src/main/kotlin/sqldelightTests.settings.gradle.kts
+++ b/sqldelight-gradle-plugin/src/test/build-logic-tests/src/main/kotlin/sqldelightTests.settings.gradle.kts
@@ -1,6 +1,6 @@
 pluginManagement {
     repositories {
-        maven(url = "file://${settingsDir.absolutePath}/../../../../build/localMaven")
+        maven(url = "${settingsDir.toURI()}/../../../../build/localMaven")
         mavenCentral()
         google()
         gradlePluginPortal()
@@ -28,7 +28,7 @@ dependencyResolutionManagement {
   }
 
   repositories {
-    maven(url = "file://${rootDir}/../../../../build/localMaven")
+    maven(url = "${rootDir.toURI()}/../../../../build/localMaven")
     mavenCentral()
     google()
   }


### PR DESCRIPTION
---
The Gradle settings for the Gradle Plugin tests uses the raw absolute path to build a file URL for a local maven repo, if any illegal characters are present in that path it will error. Replaced with a call to `File.toURI`. 
- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
