### PR TITLE
Update PR.yml - reclaim disk space on ubuntu-latest 

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -52,7 +52,6 @@ jobs:
         if: matrix.os == 'macOS-14'
       - name: Reclaim disk-space on ubuntu
         run: |
-          df -h
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /usr/share/swift
           df -h


### PR DESCRIPTION
💾 Currently the Android emulator integration tests are failing with out of disk space

Add disk space use printout to see what is going on

```
Showing disk space use
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   60G   13G  83% / <--- Running out
tmpfs           7.9G   84K  7.9G   1% /dev/shm
tmpfs           3.2G  1.1M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb16      881M   62M  758M   8% /boot
/dev/sdb15      105M  6.2M   99M   6% /boot/efi
/dev/sda1        74G  4.1G   66G   6% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
```

Maybe caused by increased cache use or increased sdk size ?

🟢 Reclaiming about 5G of disk-space by deleting 👾 an unwanted sdk e.g `.dotnet` runtime `sudo rm -rf /usr/share/dotnet` was enough to clear space for job completion.

Swift should go as well 😈 

```
Showing top /usr/share uses
3.2G	/usr/share/swift
```

Reclaimed nearly 15G

```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   46G   26G  65% /
```

Fix added in this PR

```
 - name: Reclaim disk-space on ubuntu
        run: |
          sudo rm -rf /usr/share/dotnet
          sudo rm -rf /usr/share/swift
          df -h
        if: matrix.os == 'ubuntu-latest'
```

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
