### PR TITLE
Replace src/main with src/commonMain on KMP docs.

### DIFF
--- a/docs/common/index_queries.md
+++ b/docs/common/index_queries.md
@@ -2,7 +2,7 @@
 
 SQLDelight will generate a typesafe function for any labeled SQL statement in a `.sq` file.
 
-```sql title="src/main/sqldelight/com/example/sqldelight/hockey/data/Player.sq"
+```sql title="src/commonMain/sqldelight/com/example/sqldelight/hockey/data/Player.sq"
 selectAll:
 SELECT *
 FROM hockeyPlayer;

--- a/docs/common/index_schema_sq.md
+++ b/docs/common/index_schema_sq.md
@@ -1,10 +1,10 @@
 {% if not server %}## Defining the Schema{% endif %}
 
-Write your SQL statements in a `.sq` file under `src/main/sqldelight`. 
+Write your SQL statements in a `.sq` file under `src/commonMain/sqldelight`. 
 Typically the first statement in the `.sq` file creates a table, but you can also create indexes
 or set up default content.
 
-```sql title="src/main/sqldelight/com/example/sqldelight/hockey/data/Player.sq"
+```sql title="src/commonMain/sqldelight/com/example/sqldelight/hockey/data/Player.sq"
 CREATE TABLE hockeyPlayer (
   player_number INTEGER PRIMARY KEY NOT NULL,
   full_name TEXT NOT NULL


### PR DESCRIPTION
---

Kotlin Multiplatform projects do not use the src/main convention but rather src/commonMain.
Attempting to use sqlDelight in src/main on a new KMP project (for example, with mobile, web, etc) causes build errors.
This PR fix such errors and updates the docs to match the new standards.

Note: There are other references to "src/main" on the project, but they seem to not be related to other flows and not to these specific docs.