### PR TITLE
docs: Replace sqljs-driver with web-worker-driver

### DIFF
--- a/docs/js_sqlite/multiplatform.md
+++ b/docs/js_sqlite/multiplatform.md
@@ -25,7 +25,7 @@ kotlin {
   }
 
   sourceSets.jsMain.dependencies {
-    implementation "app.cash.sqldelight:sqljs-driver:{{ versions.sqldelight }}"
+    implementation "app.cash.sqldelight:web-worker-driver:{{ versions.sqldelight }}"
     implementation npm("sql.js", "1.6.2")
     implementation devNpm("copy-webpack-plugin", "9.1.0")
   }


### PR DESCRIPTION
Closed #5969

https://github.com/sqldelight/sqldelight/pull/4670 removed sqljs-driver and web-worker-driver has replaced it
