### PR TITLE
Modify Maven Central publish command for rate limiting

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -31,8 +31,8 @@ jobs:
       # Build all artifacts with full parallelism.
       - run: ./gradlew publishToMavenLocal
 
-      # Publish to Maven Central without parallelism to try and avoid rate limiting.
-      - run: ./gradlew publishToMavenCentral --no-parallel
+      # Publish to Maven Central with parallelism limited by max-workers to try and avoid rate limiting.
+      - run: ./gradlew publishToMavenCentral --parallel --max-workers=2
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_CENTRAL_PASSWORD }}


### PR DESCRIPTION
🐌 Previous PR https://github.com/sqldelight/sqldelight/pull/6044 used `--no-parallelism` to avoid rate limits but the job is 1hr (same as previous working jobs). 

🚀 Can We speed it up without upsetting the cumulative rate limits ?

Updated the Maven Central publish command to use limited parallelism to mitigate rate limiting issues.

Runner has 3 max-workers (3 CPU instance) - reduce workers to keep within rate limits but speed up tasks - try 2 or reduce to 1 if that doesn't work

`--parallel --max-workers=2`

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
