### PR TITLE
Postgres allow SET with dots in setting name

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -771,7 +771,8 @@ array_agg_stmt ::= 'array_agg' LP [ ALL | DISTINCT ] <<expr '-1'>> [ ORDER BY {o
 
 set_stmt ::= 'SET' [ ('SESSION' | 'LOCAL') ] ( set_config | set_timezone | set_schema | set_names | set_seed )
 set_value ::= literal_value | {identifier} | DEFAULT
-set_config ::= {identifier} ( TO | EQ ) set_value
+set_config ::= set_config_name ( TO | EQ ) set_value
+set_config_name ::= {identifier} ( DOT {identifier} )*
 set_schema ::= 'SCHEMA' string_literal
 set_names ::= 'NAMES' set_value
 set_seed ::= 'SEED' TO ( set_value | [PLUS | MINUS]{numeric_literal} )

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/set/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/set/Test.s
@@ -7,6 +7,7 @@ SET test TO DEFAULT;
 
 SET SESSION test = yes;
 SET LOCAL test = yes;
+SET LOCAL test.test = 'test';
 
 SET TIME ZONE 'PST8PDT';
 SET TIME ZONE 'Europe/Paris';


### PR DESCRIPTION
minor fix to support https://www.postgresql.org/docs/current/runtime-config-custom.html

lmk if its worth a changelog entry.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
