### PR TITLE
Increase timeout in MappingJvmTest to allow for Jvm warmup

### DIFF
--- a/extensions/coroutines-extensions/src/jvmTest/kotlin/app/cash/sqldelight/coroutines/MappingJvmTest.kt
+++ b/extensions/coroutines-extensions/src/jvmTest/kotlin/app/cash/sqldelight/coroutines/MappingJvmTest.kt
@@ -30,7 +30,7 @@ import org.junit.Test
 import org.junit.rules.Timeout
 
 class MappingJvmTest : DbTest {
-  @get:Rule val timeout = Timeout(2, SECONDS)
+  @get:Rule val timeout = Timeout(10, SECONDS)
 
   override suspend fun setupDb(): TestDb = TestDb(testDriver())
 


### PR DESCRIPTION
⌛ ♨️  Likely due to JVM warmup time and compilation on lambda - timeout needs increasing - the test that is first takes the compilation hit

For a few weeks - seeing this timeout exception most of the time a build is run on GitHub - happening in the same test.

```
Test 						Outcome Total time
mapToOneNonNullUsesContext   FAILED	1.050s		
mapToOneOrDefaultUsesContext PASSED	0.209s		
mapToListUsesContext         PASSED	0.058s		
mapToOneOrNullUsesContext    PASSED	0.046s		
mapToOneUsesContext          PASSED	0.032s		
```

It doesn't seem to matter what the test performs and there doesn't appear to be a deadlock

Locally, even reducing the timeout - one test always fails

```
org.junit.runners.model.TestTimedOutException: test timed out after 1 seconds at app.cash.sqldelight.coroutines.FlowQuery.toFlow(FlowExtensions.kt:37) at app.cash.sqldelight.coroutines.MappingJvmTest$mapToOneNonNullUsesContext$1.invokeSuspend(MappingJvmTest.kt:60) •••
at app.cash.sqldelight.coroutines.RunTestKt$runTest$1.invokeSuspend(RunTest.kt:24) •••
at app.cash.sqldelight.coroutines.RunTestKt.runTest(RunTest.kt:21) at app.cash.sqldelight.coroutines.MappingJvmTest.mapToOneNonNullUsesContext(MappingJvmTest.kt:58)
```

See if this cures the problem - I will check the buildscan to see the test time again

Buildscan results with 2 second timeout
```
Test 						 Outcome Total time
mapToOneNonNullUsesContext 	 PASSED		1.096s	<---	
mapToOneOrDefaultUsesContext PASSED		0.032s		
mapToListUsesContext 		 PASSED		0.027s		
mapToOneOrNullUsesContext 	 PASSED		0.021s		
mapToOneUsesContext 		 PASSED		0.020s		
```
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
