### PR TITLE
Docs: use register() for SQLDelight databases

### DIFF
--- a/docs/common/index_gradle_database.md
+++ b/docs/common/index_gradle_database.md
@@ -1,5 +1,5 @@
 First apply the gradle plugin in your project{% if dialect %} and set your database's dialect accordingly{% endif %}. {% if async %}Make sure to set `generateAsync` to 
-`true` when creating your database.{% endif %} 
+`true` when creating your database.{% endif %}
 
 === "Kotlin"
     ```kotlin
@@ -14,7 +14,7 @@ First apply the gradle plugin in your project{% if dialect %} and set your datab
     
     sqldelight {
       databases {
-        create("Database") {
+        register("Database") {
           packageName.set("com.example"){% if dialect %}
           dialect("{{ dialect }}:{{ versions.sqldelight }}"){% endif %}{% if async %}
           generateAsync.set(true){% endif %}
@@ -35,7 +35,7 @@ First apply the gradle plugin in your project{% if dialect %} and set your datab
 
     sqldelight {
       databases {
-        Database { // This will be the name of the generated database class.
+        register("Database") { // This will be the name of the generated database class.
           packageName = "com.example"{% if dialect %}
           dialect "{{ dialect }}:{{ versions.sqldelight }}"{% endif %}{% if async %}
           generateAsync = true{% endif %}


### PR DESCRIPTION
## TL;DR
Use `register()` in the install guide so Gradle stays lazy and configuration cache-friendly.

## Summary
- Update Gradle docs to use `register()` for database configuration.
- Align with Gradle 9.x lazy configuration and configuration cache behavior.

## Why
- The installation guide currently shows `create()`, which eagerly configures container items.
- With configuration cache enabled, eager configuration can cause configuration-time work and lead to cache misses or configuration errors in some Gradle setups.
- `register()` defers container realization, improving cacheability and keeping configuration work lazy.
- Reference: https://docs.gradle.org/current/dsl/org.gradle.api.NamedDomainObjectContainer.html

## Test plan
- Not run (docs-only change; avoid build).

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable. (Not applicable: docs only)