### PR TITLE
Removed forkOptions inputs as gradle build cache inputs

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightWorkerTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightWorkerTask.kt
@@ -2,13 +2,10 @@ package app.cash.sqldelight.gradle
 
 import javax.inject.Inject
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.provider.ListProperty
-import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.SourceTask
 import org.gradle.process.JavaForkOptions
 import org.gradle.workers.ClassLoaderWorkerSpec
@@ -28,97 +25,27 @@ abstract class SqlDelightWorkerTask : SourceTask() {
   @get:Classpath
   abstract val classpath: ConfigurableFileCollection
 
-  /** @see JavaForkOptions.getEnvironment */
-  @get:Input
-  @get:Optional
-  val environment: MapProperty<String, Any> =
-    project.objects.mapProperty(String::class.java, Any::class.java)
-      .convention(getInheritableEnvironmentVariables(System.getenv()))
-
-  fun environment(name: String, value: Any): SqlDelightWorkerTask {
-    environment.put(name, value)
-    return this
-  }
-
-  fun environment(environmentVariables: Map<String, Any>): SqlDelightWorkerTask {
-    environment.putAll(environmentVariables)
-    return this
-  }
-
-  /** @see JavaForkOptions.getSystemProperties */
-  @get:Input
-  @get:Optional
-  val systemProperties: MapProperty<String, Any> =
-    project.objects.mapProperty(String::class.java, Any::class.java)
-
-  fun systemProperty(name: String, value: Any): SqlDelightWorkerTask {
-    systemProperties.put(name, value)
-    return this
-  }
-
-  fun systemProperties(properties: Map<String, Any>): SqlDelightWorkerTask {
-    systemProperties.putAll(properties)
-    return this
-  }
-
   /** @see JavaForkOptions.getMinHeapSize */
-  @get:Input
-  @get:Optional
+  @get:Internal
   val minHeapSize: Property<String> =
     project.objects.property(String::class.java)
 
   /** @see JavaForkOptions.getMaxHeapSize */
-  @get:Input
-  @get:Optional
+  @get:Internal
   val maxHeapSize: Property<String> =
     project.objects.property(String::class.java).convention("512M")
-
-  /** @see JavaForkOptions.jvmArgs */
-  @get:Input
-  @get:Optional
-  val jvmArgs: ListProperty<String> =
-    project.objects.listProperty(String::class.java)
-
-  fun jvmArgs(arguments: Iterable<*>): SqlDelightWorkerTask {
-    jvmArgs.addAll(arguments.map { it.toString() })
-    return this
-  }
-
-  fun jvmArgs(vararg arguments: Any): SqlDelightWorkerTask {
-    this.jvmArgs(listOf(*arguments))
-    return this
-  }
 
   internal fun workQueue(): WorkQueue = workerExecutor.processIsolation { workerSpec ->
     workerSpec.classpath.from(classpath)
 
     workerSpec.forkOptions { forkOptions ->
       forkOptions.defaultCharacterEncoding = "UTF-8"
-      forkOptions.environment(environment.orNull)
-      forkOptions.systemProperties(systemProperties.orNull)
+      // Necessary for SQLiteJDBCLoader and SQLiteConnection, otherwise Windows will default to the system root.
+      val tmpdir = System.getProperty("java.io.tmpdir")
+      forkOptions.environment("TMP", tmpdir)
+      forkOptions.environment("TMPDIR", tmpdir)
       forkOptions.minHeapSize = minHeapSize.orNull
-      forkOptions.maxHeapSize = maxHeapSize.orNull
-      forkOptions.jvmArgs = jvmArgs.orNull
+      forkOptions.maxHeapSize = maxHeapSize.get()
     }
-  }
-
-  /** Copied from Gradle's internal org.gradle.internal.jvm.Jvm.getInheritableEnvironmentVariables() */
-  private fun getInheritableEnvironmentVariables(envVars: Map<String, Any>): Map<String, Any> {
-    val appNameRegex = "APP_NAME_\\d+".toRegex()
-    val javaMainClassRegex = "JAVA_MAIN_CLASS_\\d+".toRegex()
-
-    val vars: MutableMap<String, Any> = HashMap()
-    for ((key, value) in envVars) {
-      // The following are known variables that can change between builds and should not be inherited
-      if (appNameRegex.matches(key) ||
-        javaMainClassRegex.matches(key) ||
-        key == "TERM_SESSION_ID" ||
-        key == "ITERM_SESSION_ID"
-      ) {
-        continue
-      }
-      vars[key] = value
-    }
-    return vars
   }
 }


### PR DESCRIPTION
Fixes issue #6085 

I changed `minHeapSize` and `maxHeapSize` from `@get:Input` to `@get:Internal` as they affect how the tasks run, but they don't affect the output of a successful task, so they shouldn't be annotated as task inputs. 

I also removed `environment`, `jvmArgs` and `systemProperties` as these polluted the cache but could also create unpredictable build environments. The [Windows issue](https://github.com/sqldelight/sqldelight/issues/5129) is likely related to the `java.io.tmpdir` not being copied into `processIsolation`. This property is needed for the [SQLiteJDBCLoader](https://github.com/xerial/sqlite-jdbc/blob/master/src/main/java/org/sqlite/SQLiteJDBCLoader.java#L330-L333), and `processIsolation` workers don't inherit these environments. Windows defaults to the [system root](https://github.com/openjdk/jdk/blob/pr/29386/src/hotspot/os/windows/os_windows.cpp#L1588-L1598) if it doesn't find this directory.

Windows first looks for the [TMP environment variable](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppatha#remarks), so my proposed fix is limiting the changes to this (and I also added `TMPDIR` for unix/linux/macOS for consistency). The previous fix did work in that it would add this variable, but adding every variable seems like a sledgehammer approach that could result in inconsistent builds across different environments. Exposing it as public API could also lead to users overriding the necessary `TMP` fix. 

Here's a screenshot of the configuration cache report in the current build:

<img width="400" src="https://github.com/user-attachments/assets/0411b3dc-6d02-4f76-b943-d63f2d9900a6" />

And here's one with these changes:

<img width="400" src="https://github.com/user-attachments/assets/ee019a29-62f9-45be-be78-62dd8ba4c667" />

</p>

I wasn't able to replicate the Windows bug in CI, I think maybe it's because the CI runner has admin privileges. I was able to verify this behavior by adding logs for `System.getProperty("java.io.tmpdir")` and `System.getenv("TMP")`in the `workQueue().submit` block and then the same logs in the WorkAction `execute()` method. 

When only classpath was set for processIsolation, the logs produced this:
```console
submit java.io.tmpdir: C:\Users\RUNNER~1\AppData\Local\Temp\
submit TMP env: C:\Users\RUNNER~1\AppData\Local\Temp
execute java.io.tmpdir: C:\Windows\ // ⚠️ Likely AccessDeniedException culprit
execute TMP env: null
```
And when you add the `System.getProperty("java.io.tmpdir")` to the forkOptions environment, the logs produce this:
```console
submit java.io.tmpdir: C:\Users\RUNNER~1\AppData\Local\Temp\
submit TMP env: C:\Users\RUNNER~1\AppData\Local\Temp
execute java.io.tmpdir: C:\Users\RUNNER~1\AppData\Local\Temp\ // ✅
execute TMP env: C:\Users\RUNNER~1\AppData\Local\Temp\
```
I don't have any Windows machines and a Windows CI runner may have resulted in false positives since they have admin privileges. So you'll want to verify this works for a Windows device before merging.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
