### PR TITLE
Extend Postgres FOR UPDATE support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [Gradle Plugin] Make `SqlDelightWorkerTask` more configurable, and update default configuration to support developing on Windows (#5215 by @MSDarwish2000)
 - [SQLite Dialect] Add support for synthesized columns in FTS5 virtual tables (#5986 by @watbe)
 - [PostgreSQL Dialect] Add support for Postgres row level security (#6087 by @shellderp)
+- [PostgreSQL Dialect] Extended FOR UPDATE to support OF table, NO KEY UPDATE, NO WAIT (#6104 by @shellderp)
 - [PostgreSQL Dialect] Support Postgis Point type and related functions (#5602 by @vanniktech)
 
 ### Changed

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -531,7 +531,21 @@ join_clause ::= {table_or_subquery} ( {join_operator} {table_or_subquery} [ {joi
   override = true
 }
 
-compound_select_stmt ::= [ {with_clause} ] {select_stmt}  ( {compound_operator} {select_stmt} ) * [ ORDER BY {ordering_term} ( COMMA {ordering_term} ) * ] [ LIMIT {limiting_term} ] [ ( OFFSET | COMMA ) {limiting_term} ] [ FOR UPDATE [ 'SKIP' 'LOCKED' ] ] {
+for_locking_clause ::= FOR for_locking_strength [ OF for_locking_reference ( COMMA for_locking_reference ) * ] [ 'NOWAIT' | 'SKIP' 'LOCKED' ]
+
+for_locking_strength ::= UPDATE | NO KEY UPDATE | 'SHARE' | KEY 'SHARE'
+
+for_locking_reference ::= [ {database_name} DOT ] for_locking_reference_name
+
+for_locking_reference_name ::= id | string {
+  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.ForLockingReferenceMixin"
+  implements = [
+    "com.alecstrong.sql.psi.core.psi.NamedElement";
+    "com.alecstrong.sql.psi.core.psi.SqlCompositeElement"
+  ]
+}
+
+compound_select_stmt ::= [ {with_clause} ] {select_stmt}  ( {compound_operator} {select_stmt} ) * [ ORDER BY {ordering_term} ( COMMA {ordering_term} ) * ] [ LIMIT {limiting_term} ] [ ( OFFSET | COMMA ) {limiting_term} ] ( for_locking_clause ) * {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlCompoundSelectStmtImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlCompoundSelectStmt"
   override = true

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/ForLockingReferenceMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/ForLockingReferenceMixin.kt
@@ -1,0 +1,38 @@
+package app.cash.sqldelight.dialects.postgresql.grammar.mixins
+
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlForLockingReferenceName
+import com.alecstrong.sql.psi.core.SqlAnnotationHolder
+import com.alecstrong.sql.psi.core.SqlParser
+import com.alecstrong.sql.psi.core.psi.FromQuery
+import com.alecstrong.sql.psi.core.psi.SqlCompoundSelectStmt
+import com.alecstrong.sql.psi.core.psi.SqlNamedElementImpl
+import com.intellij.lang.ASTNode
+import com.intellij.lang.PsiBuilder
+import com.intellij.psi.util.parentOfType
+
+internal abstract class ForLockingReferenceMixin(
+  node: ASTNode,
+) : SqlNamedElementImpl(node),
+  PostgreSqlForLockingReferenceName {
+
+  override val parseRule: (PsiBuilder, Int) -> Boolean = SqlParser::table_name_real
+
+  override fun annotate(annotationHolder: SqlAnnotationHolder) {
+    val targetName = name
+
+    val compoundSelect = parentOfType<SqlCompoundSelectStmt>(withSelf = false) ?: return
+    val availableTables = compoundSelect.selectStmtList
+      .flatMap { (it as? FromQuery)?.fromQuery().orEmpty() }
+      .mapNotNull { it.table?.name }
+      .toSet()
+
+    if (targetName !in availableTables) {
+      annotationHolder.createErrorAnnotation(
+        this,
+        "No table found in the FROM clause with name $targetName",
+      )
+    }
+
+    super.annotate(annotationHolder)
+  }
+}

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/for-update-invalid-of/Sample.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/for-update-invalid-of/Sample.s
@@ -1,0 +1,15 @@
+CREATE TABLE run(
+  status TEXT NOT NULL
+);
+
+CREATE TABLE example_table(
+  id INTEGER NOT NULL
+);
+
+SELECT * FROM run WHERE status = 'WAITING' LIMIT 1 FOR UPDATE OF example_table;
+
+SELECT * FROM run
+  JOIN example_table ex ON ex.id = 1
+  WHERE status = 'WAITING'
+  LIMIT 1
+  FOR UPDATE OF example_table;

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/for-update-invalid-of/failure.txt
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/for-update-invalid-of/failure.txt
@@ -1,0 +1,2 @@
+Sample.s line 9:65 - No table found in the FROM clause with name example_table
+Sample.s line 15:16 - No table found in the FROM clause with name example_table

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/for-update/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/for-update/Test.s
@@ -2,5 +2,33 @@ CREATE TABLE run(
   status TEXT NOT NULL
 );
 
+CREATE TABLE example_table(
+  id INTEGER NOT NULL
+);
+
 SELECT * FROM run WHERE status = 'WAITING' LIMIT 1 FOR UPDATE;
+
 SELECT * FROM run WHERE status = 'WAITING' LIMIT 1 FOR UPDATE SKIP LOCKED;
+
+SELECT * FROM run WHERE status = 'WAITING' LIMIT 1 FOR SHARE NOWAIT;
+
+SELECT * FROM run
+  JOIN example_table ex ON ex.id = 1
+  WHERE status = 'WAITING'
+  LIMIT 1
+  FOR NO KEY UPDATE OF ex SKIP LOCKED;
+
+SELECT * FROM run
+  JOIN example_table ON example_table.id = 1
+  WHERE status = 'WAITING'
+  LIMIT 1
+  FOR KEY SHARE OF example_table NOWAIT
+  FOR UPDATE OF run SKIP LOCKED;
+
+SELECT * FROM run
+  JOIN example_table ON example_table.id = 1
+  WHERE status = 'WAITING'
+  LIMIT 1
+  FOR UPDATE OF run, example_table NOWAIT;
+
+SELECT * FROM (SELECT * FROM example_table FOR UPDATE) e WHERE id = 5;


### PR DESCRIPTION
As per: https://www.postgresql.org/docs/current/sql-select.html

Support the full syntax:
```
    [ FOR { UPDATE | NO KEY UPDATE | SHARE | KEY SHARE } [ OF from_reference [, ...] ] [ NOWAIT | SKIP LOCKED ] [...] ]
```

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
