### PR TITLE
Fix IDE freeze caused by file type detection in VFS listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [Paging Extension] Switch to AndroidX Paging (#5910 by @jeffdgr8)
 
 ### Fixed
+- [IntelliJ Plugin] Fix IDE freeze caused by blocking file type detection on the EDT during VFS refresh events.
 - [SQLite Dialect] Fix Sqlite 3.38 compilation error when using Json path operators (#6070 by @griffio)
 - [SQLite Dialect] Use String type for group_concat function when using custom column type (#6082 by @griffio)
 - [Gradle Plugin] Improve performance of `VerifyMigrationTask` to stop it from hanging on complex schemas (#6073 by @Lightwood13)


### PR DESCRIPTION
Calling `VirtualFile.fileType` in a `BulkFileListener.after()` callback triggers `FileTypeDetectionService` to read bytes from disk synchronously on the EDT, causing multi-second IDE freezes on every file system refresh. Switched to checking the path extension.

```
File: threadDump-20260218-114625.txt
"AWT-EventQueue-0" prio=0 tid=0x0 nid=0x0 runnable
     java.lang.Thread.State: RUNNABLE
 (in native)
	at java.base@21.0.8/sun.nio.fs.UnixNativeDispatcher.open0(Native Method)
	at java.base@21.0.8/sun.nio.fs.UnixNativeDispatcher.open(Unknown Source)
	at java.base@21.0.8/sun.nio.fs.UnixChannelFactory.open(Unknown Source)
	at java.base@21.0.8/sun.nio.fs.UnixChannelFactory.newFileChannel(Unknown Source)
	at java.base@21.0.8/sun.nio.fs.UnixChannelFactory.newFileChannel(Unknown Source)
	at java.base@21.0.8/sun.nio.fs.UnixFileSystemProvider.newByteChannel(Unknown Source)
	at java.base@21.0.8/java.nio.file.Files.newByteChannel(Unknown Source)
	at java.base@21.0.8/java.nio.file.Files.newByteChannel(Unknown Source)
	at java.base@21.0.8/java.nio.file.spi.FileSystemProvider.newInputStream(Unknown Source)
	at com.intellij.platform.core.nio.fs.DelegatingFileSystemProvider.newInputStream(DelegatingFileSystemProvider.java:80)
	at java.base@21.0.8/java.nio.file.Files.newInputStream(Unknown Source)
	at com.intellij.openapi.vfs.impl.local.LocalFileSystemBase.getInputStream(LocalFileSystemBase.java:348)
	at com.intellij.openapi.fileTypes.impl.FileTypeDetectionService.readFirstBytesFromFile(FileTypeDetectionService.java:621)
	at com.intellij.openapi.fileTypes.impl.FileTypeDetectionService.getFirstBytes(FileTypeDetectionService.java:640)
	at com.intellij.openapi.fileTypes.impl.FileTypeDetectionService.getOrDetectFromContent(FileTypeDetectionService.java:210)
	at com.intellij.openapi.fileTypes.impl.FileTypeManagerImpl.internalContinueToDetectFileTypeByFile(FileTypeManagerImpl.java:899)
	at com.intellij.openapi.fileTypes.impl.FileTypeManagerImpl.getFileTypeByFile(FileTypeManagerImpl.java:885)
	at com.intellij.openapi.fileTypes.impl.FileTypeManagerImpl.getFileTypeByFile(FileTypeManagerImpl.java:787)
	at com.intellij.openapi.vfs.VirtualFile.getFileType(VirtualFile.java:358)
	at com.intellij.openapi.vfs.newvfs.impl.VirtualFileSystemEntry.getFileType(VirtualFileSystemEntry.java:653)
	at app.cash.sqldelight.intellij.ProjectService$1.after(ProjectService.kt:85)
	...
```

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
