### PR TITLE
Rework the addition of runtime dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [SQLite Dialect] Use String type for group_concat function when using custom column type (#6082 by @griffio)
 - [Gradle Plugin] Improve performance of `VerifyMigrationTask` to stop it from hanging on complex schemas (#6073 by @Lightwood13)
 - [Intellij Plugin] Fix Plugin initialization exceptions and update deprecated methods (#6040 by @griffio)
+- [Gradle Plugin] Fix compatibility with Android Gradle Plugin's built-in Kotlin (#6139)
 
 ## [2.2.1] - 2025-11-13
 [2.2.1]: https://github.com/sqldelight/sqldelight/releases/tag/2.2.1


### PR DESCRIPTION
It's going to be harder to get the "main" configuration as opposed to just using a project's top-level dependencies manager for non-multiplatform projects.

Closes #6078

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
