### PR TITLE
Enable lazy configuration of SQLDelight tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [PostgreSQL Dialect] Extended FOR UPDATE to support OF table, NO KEY UPDATE, NO WAIT (#6104 by @shellderp)
 - [PostgreSQL Dialect] Support Postgis Point type and related functions (#5602 by @vanniktech)
 - [Runtime] Added `SuspendingTransacter.TransactionDispatcher` that provides a mechanism for controlling the `CoroutineContext` of the transaction (#5967 by @eygraber)
+- [Gradle Plugin] Full compatibility with Android Gradle Plugin 9.0's new DSL. (#6140)
 
 ### Changed
 - [Compiler] Change compiler output type from java.lang.Void to kotlin.Nothing (#6099 by @griffio)

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
@@ -21,6 +21,7 @@ import app.cash.sqldelight.core.SqlDelightPropertiesFile
 import app.cash.sqldelight.gradle.android.packageName
 import app.cash.sqldelight.gradle.android.sqliteVersion
 import app.cash.sqldelight.gradle.kotlin.linkSqlite
+import com.android.build.api.variant.AndroidComponentsExtension
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import org.gradle.api.Plugin
@@ -52,7 +53,7 @@ abstract class SqlDelightPlugin : Plugin<Project> {
 
     project.plugins.withId("com.android.base") {
       android.set(true)
-      project.afterEvaluate {
+      project.extensions.getByType(AndroidComponentsExtension::class.java).finalizeDsl {
         project.setupSqlDelightTasks(afterAndroid = true, extension)
       }
     }
@@ -73,6 +74,9 @@ abstract class SqlDelightPlugin : Plugin<Project> {
 
     project.afterEvaluate {
       project.setupSqlDelightTasks(afterAndroid = false, extension)
+
+      // Always do this last so that the lazy properties are definitely populated
+      registry.register(PropertiesModelBuilder(extension.databases))
     }
   }
 
@@ -120,8 +124,6 @@ abstract class SqlDelightPlugin : Plugin<Project> {
         }
         database.registerTasks()
       }
-
-      registry.register(PropertiesModelBuilder(databases))
     }
   }
 

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/WithCommonConfiguration.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/WithCommonConfiguration.kt
@@ -9,7 +9,7 @@ internal fun GradleRunner.withCommonConfiguration(projectRoot: File): GradleRunn
     """
       |org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
       |android.useAndroidX=true
-      |android.newDsl=false
+      |android.newDsl=true
       |
     """.trimMargin(),
   )


### PR DESCRIPTION
Make AGP configuration lazy using `onVariants`, and enable newDsl flag in tests

This is blocked on https://github.com/sqldelight/sqldelight/pull/6139 being merged and stacked on https://github.com/sqldelight/sqldelight/pull/6138

Closes #5989

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
