### PR TITLE
Try better heap settings on mac runners

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -236,6 +236,6 @@ jobs:
 
 env:
   GRADLE_OPTS: -Dkotlin.incremental=false -Dorg.gradle.daemon=false -Dorg.gradle.vfs.watch=false -Dorg.gradle.logging.stacktrace=full
-  JAVA_OPTS_macOS-14: -Xmx5g -Xms2g -XX:MaxMetaspaceSize=4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+  JAVA_OPTS_macOS-14: -Xmx4g -Xms2g -XX:MaxMetaspaceSize=4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
   JAVA_OPTS_windows-latest: -Xmx12g -Xms4g -XX:MaxMetaspaceSize=4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
   JAVA_OPTS_ubuntu-latest: -Xmx12g -Xms4g -XX:MaxMetaspaceSize=4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8


### PR DESCRIPTION
Mac runners only have [7GB of memory](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories) available and if we're letting the JVM use more memory than that we'll be using swap which is slower than forcing more GC (in theory).

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
