### PR TITLE
Ignore an AGP 8 test in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,7 +34,8 @@
   ],
   "ignorePaths": [
     ".github/workflows/requirements.txt",
-    "libs/linux/"
+    "libs/linux/",
+    "sqldelight-gradle-plugin/src/test/library-project-agp8/"
   ],
   "pip-compile": {
     "fileMatch": [


### PR DESCRIPTION
---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
