### PR TITLE
Backwards compatibility fix for `expandSelectStar` in IDE plugin

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/GradleCompatibility.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/GradleCompatibility.kt
@@ -32,6 +32,17 @@ object GradleCompatibility {
     return CompatibilityReport.Compatible
   }
 
+  // Fallback on default value of `expandSelectStar` when gradle version is older than 2.3.0
+  fun readExpandSelectStar(propertiesFile: SqlDelightPropertiesFile, databaseProperties: SqlDelightDatabaseProperties): Boolean {
+    val currentGradleVersion = SemVer(propertiesFile.currentVersion)
+
+    if (currentGradleVersion < SemVer("2.3.0")) {
+      return true
+    }
+
+    return databaseProperties.expandSelectStar
+  }
+
   private data class SemVer(
     val major: Int,
     val minor: Int,

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/resolvers/SqlDelightProjectResolverExtension.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/resolvers/SqlDelightProjectResolverExtension.kt
@@ -1,5 +1,6 @@
 package app.cash.sqldelight.intellij.resolvers
 
+import app.cash.sqldelight.core.GradleCompatibility
 import app.cash.sqldelight.core.SqlDelightCompilationUnit
 import app.cash.sqldelight.core.SqlDelightDatabaseName
 import app.cash.sqldelight.core.SqlDelightDatabaseProperties
@@ -39,7 +40,7 @@ class SqlDelightProjectResolverExtension : AbstractProjectResolverExtension() {
             databaseProperties.treatNullAsUnknownForEquality,
             databaseProperties.generateAsync,
             databaseProperties.rootDirectory,
-            databaseProperties.expandSelectStar,
+            GradleCompatibility.readExpandSelectStar(sqlDelightModel, databaseProperties),
           )
         },
         sqlDelightModel.dialectJars.toMutableList(),


### PR DESCRIPTION
https://github.com/sqldelight/sqldelight/pull/5813#issuecomment-4043040344

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
