### PR TITLE
Update FileIndexMap.kt

### DIFF
--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/gradle/FileIndexMap.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/gradle/FileIndexMap.kt
@@ -47,8 +47,9 @@ internal class FileIndexMap {
       }
 
       val pluginDescriptor = PluginManagerCore.getPlugin(PluginId.getId("com.squareup.sqldelight"))!!
+
       val shouldInvalidate = pluginDescriptor.addDialect(
-        propertiesFile.dialectJars.map { it.toURI() },
+        propertiesFile.dialectJars.filterNot { it.path.contains("org.jetbrains.kotlin") }.map { it.toURI() },
       )
 
       val database = propertiesFile.databases.first()


### PR DESCRIPTION
Filter out Kotlin standard libs for the idea plugin used for compatibility with previous releases before 2.3.0. This prevents classloader crashes in some environments.

The change filters out these Kotlin stdlib from the given cache paths provided by the gradle plugin.

e.g.
```
/Users/abc/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/2.1.21/49293/kotlin-reflect-2.1.21.jar
/Users/abc/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/2.2.21/54544/kotlin-stdlib-2.2.21.jar
```

This is equivalent to the fix in the gradle plugin if the user is on the latest version

https://github.com/sqldelight/sqldelight/blob/9c23cad229bcbae2a63056bb004881f35c2466c2/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt#L44-L49

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
