### PR TITLE
Add extendedConfig param to inMemoryDriver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- [Native Driver] Add `extendedConfig` parameter to `inMemoryDriver` (#5539 by @GuilhE)
 - [PostgreSQL Dialect] Add query support for implicitly defined System Columns (#5834 by @griffio)
 - [PostgreSQL Dialect] Add basic Array literal support (#5997 by @griffio)
 - [PostgreSQL Dialect] Add basic LTREE support (#5880 by @yesitskev @griffio)

--- a/drivers/native-driver/src/nativeMain/kotlin/app/cash/sqldelight/driver/native/NativeSqlDatabase.kt
+++ b/drivers/native-driver/src/nativeMain/kotlin/app/cash/sqldelight/driver/native/NativeSqlDatabase.kt
@@ -288,7 +288,7 @@ fun inMemoryDriver(schema: SqlSchema<QueryResult.Value<Unit>>): NativeSqliteDriv
  * Helper function to create an in-memory driver. In-memory drivers have a single connection, so
  * concurrent access will be block
  */
-fun inMemoryDriver(schema: SqlSchema<QueryResult.Value<Unit>>, extendedConfig: Extended = Extended()): NativeSqliteDriver = NativeSqliteDriver(
+fun inMemoryDriver(schema: SqlSchema<QueryResult.Value<Unit>>, extendedConfig: DatabaseConfiguration.Extended = DatabaseConfiguration.Extended()): NativeSqliteDriver = NativeSqliteDriver(
   DatabaseConfiguration(
     name = null,
     inMemory = true,
@@ -299,8 +299,8 @@ fun inMemoryDriver(schema: SqlSchema<QueryResult.Value<Unit>>, extendedConfig: E
     upgrade = { connection, oldVersion, newVersion ->
       wrapConnection(connection) { schema.migrate(it, oldVersion.toLong(), newVersion.toLong()) }
     },
-    extendedConfig = extendedConfig
-  )
+    extendedConfig = extendedConfig,
+  ),
 )
 
 /**


### PR DESCRIPTION
## Summary
- Cherry-picks #5539 by @GuilhE: adds an `extendedConfig` parameter to `inMemoryDriver` so callers can configure things like `foreignKeyConstraints` without manually constructing the full `DatabaseConfiguration`
- Fixes unqualified `Extended` type reference to `DatabaseConfiguration.Extended`
- Adds changelog entry

## Test plan
- [x] Build compiles (`compileKotlinIosArm64`)
- [x] `spotlessApply` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)