### PR TITLE
Improve PostgreSql dialect plugin use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [Compiler] Other columns in a non-grouped aggregate result set are always nullable
 - [PostgreSQL Dialect] Resolve nullability correctly for coalesce and ifnull
 - [PostgreSQL Dialect] Fixed IDE integration of the PostgreSQL dialect
+- [PostgreSQL Dialect] Improve IDE plugin for PostgreSQL dialect (#6209 by @griffio)
 
 ## [2.3.2] - 2026-03-16
 [2.3.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.3.2

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/CreateIndexMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/CreateIndexMixin.kt
@@ -3,15 +3,14 @@ package app.cash.sqldelight.dialects.postgresql.grammar.mixins
 import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlCreateIndexStmt
 import app.cash.sqldelight.dialects.postgresql.grammar.psi.impl.PostgreSqlCreateIndexStmtImpl
 import com.alecstrong.sql.psi.core.SqlAnnotationHolder
-import com.alecstrong.sql.psi.core.SqlSchemaContributorElementType
 import com.alecstrong.sql.psi.core.psi.SchemaContributorStub
-import com.alecstrong.sql.psi.core.psi.SqlCreateIndexStmt
-import com.alecstrong.sql.psi.core.psi.SqlTypes
+import com.alecstrong.sql.psi.core.psi.SqlIndexName
 import com.alecstrong.sql.psi.core.psi.impl.SqlCreateIndexStmtImpl
 import com.alecstrong.sql.psi.core.psi.mixins.CreateIndexElementType
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import com.intellij.psi.stubs.IStubElementType
+import com.intellij.psi.util.PsiTreeUtil
 
 /**
  * Storage parameter list 'autosummarize' | 'buffering' | 'deduplicate_items' | 'fastupdate' | 'fillfactor' | 'gin_pending_list_limit' | 'pages_per_range'
@@ -60,7 +59,10 @@ internal abstract class CreateIndexMixin :
         }
       }
     }
-    super.annotate(annotationHolder)
+
+    PsiTreeUtil.getChildOfType(this, SqlIndexName::class.java)?.let {
+      super.annotate(annotationHolder)
+    }
   }
 
   companion object {


### PR DESCRIPTION
The IDEA plugin with PostgreSql dialect is quite usable now, there are some common exceptions that should be fixed.

* Fix error thrown by plugin when using PostgreSql, inherited annotation checks the indexName for duplicate.
  * Guard against calling the inherited annotate when there is no index name element present when editing query file.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
