### PR TITLE
Remove the restriction on Sqlite for completions in Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [PostgreSQL Dialect] Resolve nullability correctly for coalesce and ifnull
 - [PostgreSQL Dialect] Fixed IDE integration of the PostgreSQL dialect
 - [PostgreSQL Dialect] Improve IDE plugin for PostgreSQL dialect (#6209 by @griffio)
+- [PostgreSQL Dialect] IDE plugin can perform code completions for PostgreSQL dialect (#6210 by @griffio) 
 
 ## [2.3.2] - 2026-03-16
 [2.3.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - [PostgreSQL Dialect] Resolve nullability correctly for coalesce and ifnull
 - [PostgreSQL Dialect] Fixed IDE integration of the PostgreSQL dialect
 - [PostgreSQL Dialect] Improve IDE plugin for PostgreSQL dialect (#6209 by @griffio)
-- [PostgreSQL Dialect] IDE plugin can perform code completions for PostgreSQL dialect (#6210 by @griffio) 
+- [Intellij Plugin] IDE plugin can perform code completions for all dialects (#6210 by @griffio)
 
 ## [2.3.2] - 2026-03-16
 [2.3.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.3.2

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/lang/completion/SqlDelightKeywordCompletionContributor.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/lang/completion/SqlDelightKeywordCompletionContributor.kt
@@ -87,7 +87,7 @@ class SqlDelightKeywordCompletionContributor : CompletionContributor() {
     ) {
       val originalFile = parameters.originalFile
       val project = originalFile.project
-      val dialect = context.get(dialectKey) ?: run {
+      context.get(dialectKey) ?: run {
         SqlDelightProjectService.getInstance(project).dialect
           .also {
             context.put(dialectKey, it)

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/lang/completion/SqlDelightKeywordCompletionContributor.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/lang/completion/SqlDelightKeywordCompletionContributor.kt
@@ -93,9 +93,7 @@ class SqlDelightKeywordCompletionContributor : CompletionContributor() {
             context.put(dialectKey, it)
           }
       }
-      if (!dialect.isSqlite) {
-        return
-      }
+
       val position = parameters.position
       if (position.node.elementType == SqlTypes.COMMENT) {
         return


### PR DESCRIPTION
fixes #6207

It doesn't appear that the plugin can set more than one completion extension per language.
 
A simpler approach for now is to remove the restriction on Sqlite for completions as it will use the project dialect setting, this works well for PostgreSql as the correct dialect code completions are activated on CTRL-SPACE.

NOTE:
The plugin doesn't support switching between multiple dialects in the same IDEA project, I don't think it was designed to do that.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
